### PR TITLE
api: backend steps 1–2 — schema, ingest primitives, public read API + hardening

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/AppConfig.kt
+++ b/api/src/main/kotlin/dev/androidskills/AppConfig.kt
@@ -16,6 +16,8 @@ data class AppConfig(
     val llmBaseUrl: String?,
     val llmApiKey: String?,
     val llmModel: String?,
+    /** When true, a small demo dataset is seeded into an empty DB (local/dev only). */
+    val seedDemo: Boolean = false,
 ) {
     companion object {
         fun fromEnv(): AppConfig {
@@ -28,6 +30,7 @@ data class AppConfig(
                 llmBaseUrl = env("LLM_BASE_URL"),
                 llmApiKey = env("LLM_API_KEY"),
                 llmModel = env("LLM_MODEL"),
+                seedDemo = env("SEED_DEMO")?.equals("1", ignoreCase = true) == true,
             )
         }
     }

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -1,5 +1,8 @@
 package dev.androidskills
 
+import dev.androidskills.api.installApiErrorMapping
+import dev.androidskills.api.publicRoutes
+import dev.androidskills.db.Skills
 import dev.androidskills.llm.LlmClient
 import dev.androidskills.llm.StubLlmClient
 import dev.androidskills.storage.FileStore
@@ -13,6 +16,8 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
 
 /**
  * Ktor application module (referenced from application.conf). The entrypoint is
@@ -23,9 +28,14 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv()) {
 
     install(ContentNegotiation) { json() }
     install(CallLogging)
+    installApiErrorMapping()
 
     val fileStore: FileStore = LocalFsStore(config.fileStoreDir)
     val llm: LlmClient = StubLlmClient()
+
+    if (config.seedDemo && transaction { Skills.selectAll().count() == 0L }) {
+        dev.androidskills.api.DemoData.seed(fileStore)
+    }
 
     routing {
         get("/api/health") {
@@ -39,6 +49,7 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv()) {
                 ),
             )
         }
+        publicRoutes(fileStore)
     }
 }
 

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -18,8 +18,7 @@ import kotlinx.serialization.Serializable
  * Ktor application module (referenced from application.conf). The entrypoint is
  * io.ktor.server.netty.EngineMain (see main.kt).
  */
-fun Application.module() {
-    val config = AppConfig.fromEnv()
+fun Application.module(config: AppConfig = AppConfig.fromEnv()) {
     Database.init(config)
 
     install(ContentNegotiation) { json() }

--- a/api/src/main/kotlin/dev/androidskills/Database.kt
+++ b/api/src/main/kotlin/dev/androidskills/Database.kt
@@ -1,5 +1,7 @@
 package dev.androidskills
 
+import dev.androidskills.db.Migrations
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.sqlite.SQLiteConfig
 import org.sqlite.SQLiteDataSource
@@ -13,6 +15,10 @@ import org.jetbrains.exposed.sql.Database as ExposedDatabase
  * These PRAGMAs are applied via [SQLiteConfig] at connect time — SQLite refuses
  * to switch journal modes from inside a transaction, so they cannot be run through
  * an Exposed `transaction { }` block.
+ *
+ * The latest connected database is also installed as Exposed's
+ * `TransactionManager.defaultDatabase` so handlers can call `transaction { }`
+ * without a handle (and tests can re-point it at an isolated temp DB per run).
  */
 object Database {
     private lateinit var db: ExposedDatabase
@@ -29,12 +35,9 @@ object Database {
         ).apply { url = "jdbc:sqlite:${config.dbPath}" }
 
         db = ExposedDatabase.connect(dataSource)
+        TransactionManager.defaultDatabase = db
 
-        transaction(db) {
-            // Walking-skeleton marker; the real schema/migrations land with the read path.
-            exec("CREATE TABLE IF NOT EXISTS schema_meta (key TEXT PRIMARY KEY, value TEXT);")
-            exec("INSERT OR IGNORE INTO schema_meta(key, value) VALUES ('version', '0');")
-        }
+        Migrations.run(db)
     }
 
     fun journalMode(): String = transaction(db) {

--- a/api/src/main/kotlin/dev/androidskills/api/DemoData.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/DemoData.kt
@@ -1,10 +1,16 @@
 package dev.androidskills.api
 
 import dev.androidskills.db.Bundles
+import dev.androidskills.db.BundleKind
 import dev.androidskills.db.Categories
+import dev.androidskills.db.Role
 import dev.androidskills.db.SkillFiles
+import dev.androidskills.db.SkillStatus
 import dev.androidskills.db.Skills
+import dev.androidskills.db.TokenBand
+import dev.androidskills.db.UserStatus
 import dev.androidskills.db.Users
+import dev.androidskills.db.VersionSource
 import dev.androidskills.db.Versions
 import dev.androidskills.ingest.Tokens
 import dev.androidskills.storage.FileStore
@@ -167,15 +173,15 @@ object DemoData {
         fun isoDaysAgo(days: Int, hour: Int) = base.minus(days.toLong(), ChronoUnit.DAYS)
             .truncatedTo(ChronoUnit.DAYS).plus(hour.toLong(), ChronoUnit.HOURS).toString()
 
-        val aliceId = insertUser("alice", githubId = 10_001, name = "Alice Tan", role = "contributor")
-        val bobId = insertUser("bob", githubId = 10_002, name = "Bob Lee", role = "member")
+        val aliceId = insertUser("alice", githubId = 10_001, name = "Alice Tan", role = Role.contributor)
+        val bobId = insertUser("bob", githubId = 10_002, name = "Bob Lee", role = Role.member)
 
         val repoBundle = insertBundle(
-            kind = "repo", provenance = "alice/jetpack-toolkit", ownerUserId = aliceId,
+            kind = BundleKind.repo, provenance = "alice/jetpack-toolkit", ownerUserId = aliceId,
             sourceRef = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", createdAt = isoDaysAgo(30, 9),
         )
         val zipBundle = insertBundle(
-            kind = "zip", provenance = "upload-bob-1", ownerUserId = bobId,
+            kind = BundleKind.zip, provenance = "upload-bob-1", ownerUserId = bobId,
             sourceRef = "sha-256:upload-bob-1", createdAt = isoDaysAgo(18, 11),
         )
 
@@ -187,7 +193,7 @@ object DemoData {
         }
     }
 
-    private fun insertUser(handle: String, githubId: Long, name: String, role: String): String {
+    private fun insertUser(handle: String, githubId: Long, name: String, role: Role): String {
         val id = newId()
         val now = nowIso()
         Users.insert {
@@ -196,8 +202,8 @@ object DemoData {
             it[Users.handle] = handle
             it[Users.name] = name
             it[Users.avatarUrl] = "https://avatars.example.com/$handle.png"
-            it[Users.role] = role
-            it[Users.status] = "active"
+            it[Users.role] = role.name // validated enum (fix: typed invariants)
+            it[Users.status] = UserStatus.active.name
             it[Users.createdAt] = now
             it[Users.updatedAt] = now
         }
@@ -205,12 +211,12 @@ object DemoData {
     }
 
     private fun insertBundle(
-        kind: String, provenance: String, ownerUserId: String, sourceRef: String?, createdAt: String,
+        kind: BundleKind, provenance: String, ownerUserId: String, sourceRef: String?, createdAt: String,
     ): String {
         val id = newId()
         Bundles.insert {
             it[Bundles.id] = id
-            it[Bundles.kind] = kind
+            it[Bundles.kind] = kind.name
             it[Bundles.provenance] = provenance
             it[Bundles.ownerUserId] = ownerUserId
             it[Bundles.sourceRef] = sourceRef
@@ -247,12 +253,12 @@ object DemoData {
             it[Skills.tags] = tagsJson
             it[Skills.categoryId] = categoryId
             it[Skills.version] = s.version
-            it[Skills.versionSource] = "manifest"
+            it[Skills.versionSource] = VersionSource.manifest.name
             it[Skills.tokenUpfront] = tokenUpfront
             it[Skills.tokenOndemand] = tokenOndemand
-            it[Skills.tokenBand] = band
+            it[Skills.tokenBand] = TokenBand.parse(band).name // validate band is a real bucket
             it[Skills.verified] = s.verified
-            it[Skills.status] = "published"
+            it[Skills.status] = SkillStatus.published.name
             it[Skills.featured] = s.featured
             it[Skills.installs] = s.installs
             it[Skills.readmeMd] = s.body

--- a/api/src/main/kotlin/dev/androidskills/api/DemoData.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/DemoData.kt
@@ -1,0 +1,303 @@
+package dev.androidskills.api
+
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Categories
+import dev.androidskills.db.SkillFiles
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Users
+import dev.androidskills.db.Versions
+import dev.androidskills.ingest.Tokens
+import dev.androidskills.storage.FileStore
+import dev.androidskills.util.appJson
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.encodeToString
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.io.ByteArrayOutputStream
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * A small, deterministic dataset that exercises the whole public read surface
+ * (search facets, detail, files, versions, download, bundles, authors, timeline)
+ * so the frontend and tests have something to render. Seeded only when the DB is
+ * empty and `SEED_DEMO=1` (opt-in) — prod stays clean (spec §13).
+ *
+ * Manifest fields (name/description/tags/license) are written as if parsed from
+ * a real `SKILL.md`; the token estimate is computed with the real [Tokens]
+ * heuristic so seed data is consistent with ingest (§5).
+ */
+object DemoData {
+
+    private data class SeedFile(val path: String, val content: String, val isBinary: Boolean = false)
+
+    private data class SeedSkill(
+        val slug: String,
+        val name: String,
+        val description: String,
+        val license: String,
+        val tags: List<String>,
+        val category: String,
+        val version: String,
+        val verified: Boolean,
+        val featured: Boolean = false,
+        val body: String,
+        val files: List<SeedFile>,
+        val daysAgo: Int,
+        val installs: Int,
+    )
+
+    private val skills = listOf(
+        SeedSkill(
+            slug = "jetpack-compose-mvi",
+            name = "Jetpack Compose MVI Scaffold",
+            description = "A predictable Model-View-Intent baseline for Compose apps with unidirectional data flow and side-effect handling.",
+            license = "Apache-2.0",
+            tags = listOf("android", "compose", "mvi", "architecture"),
+            category = "jetpack-compose",
+            version = "1.4.2",
+            verified = true,
+            featured = true,
+            body = """
+                # Jetpack Compose MVI Scaffold
+
+                Renders state through a single `UiState` and routes user intents through one
+                `ViewModel`. Keeps Compose code side-effect free.
+
+                ## Usage
+                Drop the folder into your `skills/` directory and point your feature at the
+                `MviScreen` composable.
+
+                ## State
+                All UI state is a sealed hierarchy; events are intents reduced in the VM.
+            """.trimIndent(),
+            files = listOf(
+                SeedFile("references/intent.md", "Intents are sealed classes reduced by the ViewModel.\n"),
+                SeedFile("examples/CounterScreen.kt", "package example\n\n@Composable\nfun CounterScreen(vm: CounterViewModel) { /* ... */ }\n"),
+            ),
+            daysAgo = 2,
+            installs = 1280,
+        ),
+        SeedSkill(
+            slug = "coroutine-test-patterns",
+            name = "Kotlin Coroutine Test Patterns",
+            description = "Idiomatic patterns for testing suspend functions, Flows, and Dispatchers with Turbine and runTest.",
+            license = "MIT",
+            tags = listOf("kotlin", "coroutines", "testing"),
+            category = "kotlin-language",
+            version = "0.9.0",
+            verified = true,
+            body = """
+                # Kotlin Coroutine Test Patterns
+
+                Covers `runTest`, virtual time, `Turbine` collectors, and replacing Dispatchers
+                with a TestDispatcher.
+            """.trimIndent(),
+            files = listOf(SeedFile("references/runtest.md", "Use runTest to control virtual time.\n")),
+            daysAgo = 6,
+            installs = 640,
+        ),
+        SeedSkill(
+            slug = "room-migration-helper",
+            name = "Room Migration Helper",
+            description = "Safe incremental Room schema migrations with validated fallbacks and export checks.",
+            license = "Apache-2.0",
+            tags = listOf("android", "room", "database", "persistence"),
+            category = "data-persistence",
+            version = "2.1.0",
+            verified = true,
+            body = "# Room Migration Helper\n\nGenerate and validate fallback migrations.\n",
+            files = listOf(SeedFile("references/migrations.md", "Always export schemas to /schemas.\n")),
+            daysAgo = 11,
+            installs = 410,
+        ),
+        SeedSkill(
+            slug = "retrofit-okhttp-config",
+            name = "Retrofit + OkHttp Baseline",
+            description = "A hardened networking baseline: timeouts, retry, auth interceptor, and structured logging.",
+            license = "Apache-2.0",
+            tags = listOf("android", "networking", "retrofit", "okhttp"),
+            category = "networking",
+            version = "1.0.3",
+            verified = false,
+            body = "# Retrofit + OkHttp Baseline\n\nSensible defaults for HTTP clients.\n",
+            files = emptyList(),
+            daysAgo = 14,
+            installs = 95,
+        ),
+        SeedSkill(
+            slug = "baseline-profile-gradle",
+            name = "Baseline Profile Gradle Setup",
+            description = "Generate and ship Android Baseline Profiles from your Gradle build for faster cold start.",
+            license = "Apache-2.0",
+            tags = listOf("android", "performance", "gradle", "macrobench"),
+            category = "performance",
+            version = "0.3.1",
+            verified = true,
+            body = "# Baseline Profile Gradle Setup\n\nWires the baselineprofile plugin and CI.\n",
+            files = listOf(SeedFile("references/ci.md", "Run Macrobenchmark on CI to refresh profiles.\n")),
+            daysAgo = 20,
+            installs = 210,
+        ),
+        SeedSkill(
+            slug = "compose-accessibility-audit",
+            name = "Compose Accessibility Audit",
+            description = "Audit Compose UIs for content descriptions, touch targets, and contrast; surface findings as TODOs.",
+            license = "Apache-2.0",
+            tags = listOf("android", "compose", "accessibility", "a11y"),
+            category = "accessibility",
+            version = "0.5.0",
+            verified = true,
+            body = "# Compose Accessibility Audit\n\nChecks semantics, target sizes, and contrast.\n",
+            files = emptyList(),
+            daysAgo = 27,
+            installs = 150,
+        ),
+    )
+
+    fun seed(store: FileStore) = transaction {
+        if (Skills.selectAll().count() > 0) return@transaction
+
+        val base = Instant.now()
+        fun isoDaysAgo(days: Int, hour: Int) = base.minus(days.toLong(), ChronoUnit.DAYS)
+            .truncatedTo(ChronoUnit.DAYS).plus(hour.toLong(), ChronoUnit.HOURS).toString()
+
+        val aliceId = insertUser("alice", githubId = 10_001, name = "Alice Tan", role = "contributor")
+        val bobId = insertUser("bob", githubId = 10_002, name = "Bob Lee", role = "member")
+
+        val repoBundle = insertBundle(
+            kind = "repo", provenance = "alice/jetpack-toolkit", ownerUserId = aliceId,
+            sourceRef = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", createdAt = isoDaysAgo(30, 9),
+        )
+        val zipBundle = insertBundle(
+            kind = "zip", provenance = "upload-bob-1", ownerUserId = bobId,
+            sourceRef = "sha-256:upload-bob-1", createdAt = isoDaysAgo(18, 11),
+        )
+
+        // Bundle assignment by author for realism.
+        skills.forEachIndexed { idx, s ->
+            val bundleId = if (s.category == "networking" || s.category == "performance") zipBundle else repoBundle
+            val authorId = if (bundleId == zipBundle) bobId else aliceId
+            insertSkill(s, bundleId, authorId, store, createdOffsetHours = idx)
+        }
+    }
+
+    private fun insertUser(handle: String, githubId: Long, name: String, role: String): String {
+        val id = newId()
+        val now = nowIso()
+        Users.insert {
+            it[Users.id] = id
+            it[Users.githubId] = githubId
+            it[Users.handle] = handle
+            it[Users.name] = name
+            it[Users.avatarUrl] = "https://avatars.example.com/$handle.png"
+            it[Users.role] = role
+            it[Users.status] = "active"
+            it[Users.createdAt] = now
+            it[Users.updatedAt] = now
+        }
+        return id
+    }
+
+    private fun insertBundle(
+        kind: String, provenance: String, ownerUserId: String, sourceRef: String?, createdAt: String,
+    ): String {
+        val id = newId()
+        Bundles.insert {
+            it[Bundles.id] = id
+            it[Bundles.kind] = kind
+            it[Bundles.provenance] = provenance
+            it[Bundles.ownerUserId] = ownerUserId
+            it[Bundles.sourceRef] = sourceRef
+            it[Bundles.createdAt] = createdAt
+            it[Bundles.syncedAt] = createdAt
+        }
+        return id
+    }
+
+    private fun insertSkill(
+        s: SeedSkill, bundleId: String, authorId: String, store: FileStore, createdOffsetHours: Int,
+    ) {
+        val skillId = newId()
+        val categoryId = transaction {
+            Categories.selectAll().where { Categories.slug eq s.category }.singleOrNull()?.get(Categories.id)
+        }
+        val created = nowIso() // stable enough; ordering tested via timeline aggregation
+        val tagsJson = appJson.encodeToString(s.tags)
+        val onDemandText = buildString {
+            append(s.body)
+            s.files.forEach { append("\n").append(it.content) }
+        }
+        val tokenUpfront = Tokens.estimate("${s.name} ${s.description}")
+        val tokenOndemand = Tokens.estimate(onDemandText)
+        val band = Tokens.band(tokenUpfront + tokenOndemand)
+
+        Skills.insert {
+            it[Skills.id] = skillId
+            it[Skills.bundleId] = bundleId
+            it[Skills.slug] = s.slug
+            it[Skills.name] = s.name
+            it[Skills.description] = s.description
+            it[Skills.license] = s.license
+            it[Skills.tags] = tagsJson
+            it[Skills.categoryId] = categoryId
+            it[Skills.version] = s.version
+            it[Skills.versionSource] = "manifest"
+            it[Skills.tokenUpfront] = tokenUpfront
+            it[Skills.tokenOndemand] = tokenOndemand
+            it[Skills.tokenBand] = band
+            it[Skills.verified] = s.verified
+            it[Skills.status] = "published"
+            it[Skills.featured] = s.featured
+            it[Skills.installs] = s.installs
+            it[Skills.readmeMd] = s.body
+            it[Skills.createdAt] = created
+            it[Skills.updatedAt] = created
+        }
+
+        s.files.forEach { f ->
+            val bytes = f.content.toByteArray(Charsets.UTF_8)
+            val key = "skills/$skillId/files/${f.path}"
+            store.put(key, bytes)
+            SkillFiles.insert {
+                it[SkillFiles.id] = newId()
+                it[SkillFiles.skillId] = skillId
+                it[SkillFiles.path] = f.path
+                it[SkillFiles.size] = bytes.size
+                it[SkillFiles.isBinary] = f.isBinary
+                it[SkillFiles.r2Key] = key
+            }
+        }
+
+        val zipKey = "skills/$skillId/versions/${s.version}.zip"
+        store.put(zipKey, zipBytes(s))
+        Versions.insert {
+            it[Versions.id] = newId()
+            it[Versions.skillId] = skillId
+            it[Versions.version] = s.version
+            it[Versions.sourceRef] = "manifest:${s.version}"
+            it[Versions.r2ZipKey] = zipKey
+            it[Versions.createdAt] = created
+        }
+    }
+
+    private fun zipBytes(s: SeedSkill): ByteArray {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            zos.putNextEntry(ZipEntry("SKILL.md"))
+            zos.write(s.body.toByteArray(Charsets.UTF_8))
+            zos.closeEntry()
+            s.files.forEach { f ->
+                zos.putNextEntry(ZipEntry(f.path))
+                zos.write(f.content.toByteArray(Charsets.UTF_8))
+                zos.closeEntry()
+            }
+        }
+        return baos.toByteArray()
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/Errors.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Errors.kt
@@ -1,0 +1,66 @@
+package dev.androidskills.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.plugins.statuspages.exception
+import io.ktor.server.response.respond
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
+
+/**
+ * Unified error envelope (spec §9): `{"error":{"code","message", optional "fields"}}`.
+ *
+ * Handlers and queries throw the typed exceptions below; [installApiErrorMapping]
+ * (a StatusPages plugin) maps them to the right status. Non-admin access to
+ * `/api/admin/...` routes will reuse [ApiNotFoundException] to return 404 (not 403),
+ * never revealing the route exists (spec §7).
+ */
+@Serializable
+data class ErrorBody(
+    val code: String,
+    val message: String,
+    @SerialName("fields") val fields: Map<String, String>? = null,
+)
+
+@Serializable
+data class ErrorResponse(val error: ErrorBody)
+
+/** 404 — unknown slug, unknown route for non-admins, missing resource. */
+class ApiNotFoundException(message: String = "Not found") : RuntimeException(message)
+
+/** 422 — per-field validation failure (spec §10). */
+class ApiValidationException(
+    val fields: Map<String, String>,
+    message: String = "Validation failed",
+) : RuntimeException(message)
+
+/** 409 — duplicate slug, first-come ownership conflict. */
+class ApiConflictException(message: String, val code: String = "conflict") : RuntimeException(message)
+
+fun Application.installApiErrorMapping() {
+    install(StatusPages) {
+        val log = LoggerFactory.getLogger("dev.androidskills.api.Errors")
+        exception<ApiNotFoundException> { call, ex ->
+            call.respond(HttpStatusCode.NotFound, ErrorResponse(ErrorBody("not_found", ex.message ?: "Not found")))
+        }
+        exception<ApiValidationException> { call, ex ->
+            call.respond(
+                HttpStatusCode.UnprocessableEntity,
+                ErrorResponse(ErrorBody("validation_failed", ex.message ?: "Validation failed", ex.fields)),
+            )
+        }
+        exception<ApiConflictException> { call, ex ->
+            call.respond(HttpStatusCode.Conflict, ErrorResponse(ErrorBody(ex.code, ex.message ?: "Conflict")))
+        }
+        exception<Throwable> { call, ex ->
+            log.error("Unhandled error serving ${call.request.local.uri}", ex)
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                ErrorResponse(ErrorBody("internal", "Internal server error")),
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/Errors.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Errors.kt
@@ -40,6 +40,9 @@ class ApiValidationException(
 /** 409 — duplicate slug, first-come ownership conflict. */
 class ApiConflictException(message: String, val code: String = "conflict") : RuntimeException(message)
 
+/** 500 — a DB-referenced FileStore object is missing (storage corruption). */
+class ApiStorageException(message: String) : RuntimeException(message)
+
 fun Application.installApiErrorMapping() {
     install(StatusPages) {
         val log = LoggerFactory.getLogger("dev.androidskills.api.Errors")
@@ -54,6 +57,13 @@ fun Application.installApiErrorMapping() {
         }
         exception<ApiConflictException> { call, ex ->
             call.respond(HttpStatusCode.Conflict, ErrorResponse(ErrorBody(ex.code, ex.message ?: "Conflict")))
+        }
+        exception<ApiStorageException> { call, ex ->
+            log.error("Storage consistency error serving ${call.request.local.uri}", ex)
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                ErrorResponse(ErrorBody("storage_error", ex.message ?: "File unavailable")),
+            )
         }
         exception<Throwable> { call, ex ->
             log.error("Unhandled error serving ${call.request.local.uri}", ex)

--- a/api/src/main/kotlin/dev/androidskills/api/Models.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Models.kt
@@ -1,0 +1,229 @@
+package dev.androidskills.api
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CategoryRef(val slug: String, val name: String)
+
+@Serializable
+data class AuthorRef(val handle: String, val name: String? = null, val avatarUrl: String? = null)
+
+@Serializable
+data class BundleRef(val id: String, val kind: String, val provenance: String)
+
+/** A skill card shown in search results and lists (spec §9 GET /api/skills). */
+@Serializable
+data class SkillCard(
+    val id: String,
+    val slug: String,
+    val name: String,
+    val description: String,
+    val license: String? = null,
+    val tags: List<String> = emptyList(),
+    val category: CategoryRef? = null,
+    val version: String,
+    val versionSource: String,
+    val tokenUpfront: Int,
+    val tokenOndemand: Int,
+    val tokenBand: String,
+    val verified: Boolean,
+    val status: String,
+    val featured: Boolean,
+    val installs: Int,
+    val author: AuthorRef,
+    val bundle: BundleRef,
+    val createdAt: String,
+    val updatedAt: String,
+)
+
+@Serializable
+data class FacetCount(val key: String, val label: String? = null, val count: Int)
+
+@Serializable
+data class Facets(
+    val categories: List<FacetCount>,
+    val tags: List<FacetCount>,
+    val sizes: List<FacetCount>,
+)
+
+@Serializable
+data class SkillSearchPage(
+    val items: List<SkillCard>,
+    val page: Int,
+    val pageSize: Int,
+    val total: Int,
+    val totalPages: Int,
+    val facets: Facets,
+)
+
+/** Full skill detail (spec §9 GET /api/skills/{slug}). */
+@Serializable
+data class SkillDetail(
+    val id: String,
+    val slug: String,
+    val name: String,
+    val description: String,
+    val license: String? = null,
+    val tags: List<String> = emptyList(),
+    val category: CategoryRef? = null,
+    val version: String,
+    val versionSource: String,
+    val tokenUpfront: Int,
+    val tokenOndemand: Int,
+    val tokenBand: String,
+    val verified: Boolean,
+    val status: String,
+    val featured: Boolean,
+    val installs: Int,
+    val author: AuthorRef,
+    val bundle: BundleRef,
+    val readmeMd: String? = null,
+    val fileCount: Int,
+    val totalSize: Long,
+    val createdAt: String,
+    val updatedAt: String,
+)
+
+@Serializable
+data class FileEntry(
+    val path: String,
+    val name: String,
+    val dir: String,
+    val size: Int,
+    val isBinary: Boolean,
+)
+
+@Serializable
+data class TreeNode(
+    val name: String,
+    val path: String,
+    val type: String, // "file" | "dir"
+    val size: Int = 0,
+    val isBinary: Boolean = false,
+    val children: List<TreeNode>? = null,
+)
+
+@Serializable
+data class FileTreeResponse(
+    val slug: String,
+    val files: List<FileEntry>,
+    val tree: List<TreeNode>,
+)
+
+@Serializable
+data class FileContentResponse(
+    val slug: String,
+    val path: String,
+    val size: Int,
+    val isBinary: Boolean,
+    val content: String? = null,
+    val downloadOnly: Boolean,
+    val downloadUrl: String? = null,
+)
+
+@Serializable
+data class VersionEntry(
+    val version: String,
+    val sourceRef: String,
+    val createdAt: String,
+    val current: Boolean,
+)
+
+@Serializable
+data class VersionsResponse(
+    val slug: String,
+    val current: String,
+    val versions: List<VersionEntry>,
+)
+
+@Serializable
+data class CategoryWithCount(
+    val id: String,
+    val slug: String,
+    val name: String,
+    val count: Int,
+)
+
+@Serializable
+data class StatsResponse(
+    val indexed: Int,
+    val contributors: Int,
+    val lastUpdated: String? = null,
+)
+
+@Serializable
+data class TrendsResponse(
+    val categories: List<FacetCount>,
+    val tags: List<FacetCount>,
+    val tokenMix: List<FacetCount>, // band -> count
+    val securityPassRate: Double? = null,
+    val submissionFunnel: Map<String, Int>,
+)
+
+@Serializable
+data class TimelineEvent(
+    val type: String, // "publish" | "version"
+    val at: String,
+    val slug: String,
+    val name: String,
+    val version: String? = null,
+    val authorHandle: String? = null,
+)
+
+@Serializable
+data class TimelinePage(
+    val items: List<TimelineEvent>,
+    val page: Int,
+    val pageSize: Int,
+    val total: Int,
+    val totalPages: Int,
+)
+
+@Serializable
+data class BundleSummary(
+    val id: String,
+    val kind: String,
+    val provenance: String,
+    val owner: AuthorRef,
+    val sourceRef: String? = null,
+    val skillCount: Int,
+    val syncedAt: String? = null,
+    val createdAt: String,
+)
+
+@Serializable
+data class BundleDetail(
+    val id: String,
+    val kind: String,
+    val provenance: String,
+    val owner: AuthorRef,
+    val sourceRef: String? = null,
+    val syncedAt: String? = null,
+    val createdAt: String,
+    val skills: List<SkillCard>,
+)
+
+@Serializable
+data class AuthorProfile(
+    val handle: String,
+    val name: String? = null,
+    val avatarUrl: String? = null,
+    val skillCount: Int,
+    val totalInstalls: Int,
+    val skills: List<SkillCard>,
+)
+
+@Serializable
+data class Page<T>(
+    val items: List<T>,
+    val page: Int,
+    val pageSize: Int,
+    val total: Int,
+    val totalPages: Int,
+)
+
+@Serializable
+data class ReportRequest(val reason: String? = null)
+
+@Serializable
+data class ReportResponse(val id: String, val accepted: Boolean)

--- a/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
@@ -222,6 +222,9 @@ object PublicQueries {
             throw ApiNotFoundException("No downloadable archive for '$slug' version '$label'")
         }
         // Best-effort install counter (single writer; spec §3 keeps this simple).
+        // Runs after the archive is resolved and inside the same transaction, so a
+        // thrown build/lookup rolls the bump back — a failed download never counts.
+        Skills.update({ Skills.id eq skillId }) { it[Skills.installs] = skill[Skills.installs] + 1 }
         Skills.update({ Skills.id eq skillId }) { it[Skills.installs] = skill[Skills.installs] + 1 }
         DownloadResult(bytes, "${slug}-${verRow[Versions.version]}.zip", "application/zip")
     }

--- a/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
@@ -8,6 +8,7 @@ import dev.androidskills.db.Skills
 import dev.androidskills.db.Submissions
 import dev.androidskills.db.Users
 import dev.androidskills.db.Versions
+import dev.androidskills.ingest.SkillPaths
 import dev.androidskills.storage.FileStore
 import dev.androidskills.util.appJson
 import dev.androidskills.util.newId
@@ -169,7 +170,10 @@ object PublicQueries {
         val size = row[SkillFiles.size]
         val key = row[SkillFiles.r2Key]
         val downloadOnly = isBinary || size > PREVIEW_LIMIT
-        val content = if (!downloadOnly) store.get(key)?.toString(Charsets.UTF_8) else null
+        val content = if (!downloadOnly) {
+            store.get(key)?.toString(Charsets.UTF_8)
+                ?: throw ApiStorageException("File bytes missing for '$slug'/'$path' (key=$key)")
+        } else null
         FileContentResult(slug, path, size, isBinary, content, downloadOnly, key)
     }
 
@@ -195,11 +199,20 @@ object PublicQueries {
             Versions.selectAll().where { Versions.skillId eq skillId }.orderBy(Versions.createdAt, SortOrder.DESC).firstOrNull()
         }) ?: throw ApiNotFoundException("No version available for '$slug'")
 
+        val currentVersion = skill[Skills.version]
+        val isCurrent = verRow[Versions.version] == currentVersion
+        val label = version ?: verRow[Versions.version]
         val zipKey = verRow[Versions.r2ZipKey]
-        val bytes = if (zipKey != null && store.exists(zipKey)) {
-            store.get(zipKey) ?: buildZip(skillId, store)
-        } else {
+        // A version's archive must come from its own r2_zip_key. We only ever
+        // fall back to building from current skill_files for the *current*
+        // version (where current files == that version); a historical version
+        // with a missing/absent archive is a 404, never silently substituted
+        // with today's files named as the old version (spec §5.6).
+        val storedBytes = if (zipKey != null && store.exists(zipKey)) store.get(zipKey) else null
+        val bytes = storedBytes ?: if (isCurrent) {
             buildZip(skillId, store)
+        } else {
+            throw ApiNotFoundException("No downloadable archive for '$slug' version '$label'")
         }
         // Best-effort install counter (single writer; spec §3 keeps this simple).
         Skills.update({ Skills.id eq skillId }) { it[Skills.installs] = skill[Skills.installs] + 1 }
@@ -269,11 +282,19 @@ object PublicQueries {
     // ---- bundles / authors -------------------------------------------------
 
     fun bundles(page: Int, pageSize: Int): Page<BundleSummary> = transaction {
-        val total = Bundles.selectAll().count().toInt()
-        val rows = Bundles.selectAll().orderBy(Bundles.createdAt, SortOrder.DESC)
+        // Public bundle index: only bundles exposing >=1 published skill (spec
+        // §3.5 — non-public skills are not reachable anonymously, so a bundle
+        // that has only unlisted/flagged skills is hidden from the public list).
+        val publicBundleIds = Skills.select(Skills.bundleId)
+            .where { Skills.status eq "published" }.map { it[Skills.bundleId] }.toSet()
+        val total = publicBundleIds.size
+        val rows = if (publicBundleIds.isEmpty()) emptyList()
+        else Bundles.selectAll().where { Bundles.id inList publicBundleIds.toList() }
+            .orderBy(Bundles.createdAt, SortOrder.DESC)
             .limit(pageSize).offset(((page - 1) * pageSize).toLong()).toList()
         val owners = usersByIds(rows.map { it[Bundles.ownerUserId] }.distinct())
-        val counts = Skills.select(Skills.bundleId).where { Skills.bundleId inList rows.map { it[Bundles.id] } }
+        val counts = Skills.select(Skills.bundleId)
+            .where { (Skills.bundleId inList rows.map { it[Bundles.id] }) and (Skills.status eq "published") }
             .toList().groupingBy { it[Skills.bundleId] }.eachCount()
         val items = rows.map { row ->
             BundleSummary(
@@ -288,8 +309,11 @@ object PublicQueries {
     fun bundle(id: String): BundleDetail = transaction {
         val row = Bundles.selectAll().where { Bundles.id eq id }.singleOrNull()
             ?: throw ApiNotFoundException("Bundle '$id' not found")
+        val skillRows = Skills.selectAll()
+            .where { (Skills.bundleId eq id) and (Skills.status eq "published") }
+            .orderBy(Skills.updatedAt, SortOrder.DESC).toList()
+        if (skillRows.isEmpty()) throw ApiNotFoundException("Bundle '$id' not found")
         val owner = usersByIds(listOf(row[Bundles.ownerUserId])).values.first()
-        val skillRows = Skills.selectAll().where { Skills.bundleId eq id }.orderBy(Skills.updatedAt, SortOrder.DESC).toList()
         BundleDetail(
             id = row[Bundles.id], kind = row[Bundles.kind], provenance = row[Bundles.provenance],
             owner = authorRef(owner), sourceRef = row[Bundles.sourceRef], syncedAt = row[Bundles.syncedAt],
@@ -469,8 +493,12 @@ object PublicQueries {
         val baos = ByteArrayOutputStream()
         ZipOutputStream(baos).use { zos ->
             files.forEach { f ->
+                // Zip Slip defence: only normalised relative POSIX paths become
+                // entries. Unsafe stored paths (e.g. `../…`) are skipped rather
+                // than written (ingest will also reject them upstream). (§11.)
+                val safePath = SkillPaths.safeRelativeOrNull(f[SkillFiles.path]) ?: return@forEach
                 val bytes = store.get(f[SkillFiles.r2Key]) ?: return@forEach
-                zos.putNextEntry(ZipEntry(f[SkillFiles.path]))
+                zos.putNextEntry(ZipEntry(safePath))
                 zos.write(bytes)
                 zos.closeEntry()
             }
@@ -511,6 +539,21 @@ object PublicQueries {
 
     fun parsePageSize(raw: String?): Int = (raw?.toIntOrNull() ?: DEFAULT_PAGE_SIZE).coerceIn(1, MAX_PAGE_SIZE)
     fun parsePage(raw: String?): Int = (raw?.toIntOrNull() ?: 1).coerceAtLeast(1)
+
+    /** Strict paging for HTTP query params — malformed values 422 instead of coercing. */
+    fun parsePageStrict(raw: String?): Int {
+        if (raw == null) return 1
+        val n = raw.toIntOrNull() ?: throw ApiValidationException(mapOf("page" to "must be a positive integer"), "Invalid 'page'")
+        if (n < 1) throw ApiValidationException(mapOf("page" to "must be >= 1"), "Invalid 'page'")
+        return n
+    }
+
+    fun parsePageSizeStrict(raw: String?): Int {
+        if (raw == null) return DEFAULT_PAGE_SIZE
+        val n = raw.toIntOrNull() ?: throw ApiValidationException(mapOf("pageSize" to "must be an integer"), "Invalid 'pageSize'")
+        if (n !in 1..MAX_PAGE_SIZE) throw ApiValidationException(mapOf("pageSize" to "must be 1..$MAX_PAGE_SIZE"), "Invalid 'pageSize'")
+        return n
+    }
 }
 
 data class FileContentResult(

--- a/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
@@ -1,0 +1,526 @@
+package dev.androidskills.api
+
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Categories
+import dev.androidskills.db.Reports
+import dev.androidskills.db.SkillFiles
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Submissions
+import dev.androidskills.db.Users
+import dev.androidskills.db.Versions
+import dev.androidskills.storage.FileStore
+import dev.androidskills.util.appJson
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.decodeFromString
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.LowerCase
+import org.jetbrains.exposed.sql.Op
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.or
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Parsed `GET /api/skills` query (spec §9). Defaults match the public browse
+ * experience: `verified` only on, relevance sort, page 1.
+ *
+ * `verified == true` (default) restricts to verified skills; `verified == false`
+ * lifts that restriction to show everything (the "Verified only" toggle off),
+ * matching spec §3.5 ("Unverified skills are still reachable").
+ */
+data class SearchParams(
+    val q: String?,
+    val cats: List<String>,
+    val tags: List<String>,
+    val size: String?, // "<2k" | "2-5k" | "5k+"
+    val verified: Boolean,
+    val sort: String, // relevance|installs|updated|tokens
+    val page: Int,
+    val pageSize: Int,
+)
+
+/**
+ * Read-side queries for the public API (spec §9 Public). Each top-level function
+ * runs in its own transaction against the default Exposed database (set by
+ * [dev.androidskills.Database.init]) and returns plain DTOs, throwing the typed
+ * [ApiNotFoundException] / [ApiValidationException] for missing/invalid input.
+ *
+ * Public visibility = `status = 'published'`; unlisted/flagged skills are not
+ * reachable anonymously (spec §3.5, §10). The `verified` boolean drives the
+ * "caution" filter independently.
+ *
+ * NOTE on the query DSL: Exposed 0.61 added `ColumnSet.select(columns)` members
+ * that shadow the classic `select { where }` trailing lambda, so predicates are
+ * applied via `selectAll().where { … }` / `selectAll().where(op)` instead.
+ */
+object PublicQueries {
+
+    /** Soft cap for in-browser file preview; larger/binary files are download-only. */
+    const val PREVIEW_LIMIT = 256 * 1024
+    private const val DEFAULT_PAGE_SIZE = 24
+    private const val MAX_PAGE_SIZE = 60
+    private const val MAX_TAG_FACETS = 20
+
+    // ---- stats / taxonomy --------------------------------------------------
+
+    fun stats(): StatsResponse = transaction {
+        val indexed = Skills.selectAll().where { Skills.status eq "published" }.count().toInt()
+        val contributors = Skills
+            .join(Bundles, JoinType.INNER, Skills.bundleId, Bundles.id)
+            .join(Users, JoinType.INNER, Bundles.ownerUserId, Users.id)
+            .select(Users.id)
+            .where { Skills.status eq "published" }
+            .withDistinct()
+            .count()
+            .toInt()
+        val lastUpdated = Skills.select(Skills.updatedAt)
+            .orderBy(Skills.updatedAt, SortOrder.DESC).firstOrNull()?.get(Skills.updatedAt)
+        StatsResponse(indexed, contributors, lastUpdated)
+    }
+
+    fun categories(): List<CategoryWithCount> = transaction {
+        val byCat = Skills.select(Skills.categoryId).where { Skills.status eq "published" }
+            .toList().groupingBy { it[Skills.categoryId] }.eachCount()
+        Categories.selectAll().orderBy(Categories.name).map { cr ->
+            CategoryWithCount(
+                id = cr[Categories.id],
+                slug = cr[Categories.slug],
+                name = cr[Categories.name],
+                count = byCat[cr[Categories.id]] ?: 0,
+            )
+        }
+    }
+
+    // ---- search / list -----------------------------------------------------
+
+    fun search(p: SearchParams): SkillSearchPage = transaction {
+        val where = p.buildCondition()
+        val total = Skills.selectAll().where(where).count().toInt()
+        val rows = Skills.selectAll().where(where)
+            .orderBy(*p.orderColumns().toTypedArray())
+            .limit(p.pageSize)
+            .offset(((p.page - 1) * p.pageSize).toLong())
+            .toList()
+        SkillSearchPage(
+            items = buildCards(rows),
+            page = p.page,
+            pageSize = p.pageSize,
+            total = total,
+            totalPages = pagesOf(total, p.pageSize),
+            facets = computeFacets(p),
+        )
+    }
+
+    // ---- detail ------------------------------------------------------------
+
+    fun skillDetail(slug: String): SkillDetail = transaction {
+        val row = Skills.selectAll().where { (Skills.slug eq slug) and (Skills.status eq "published") }
+            .singleOrNull() ?: throw ApiNotFoundException("Skill '$slug' not found")
+        val card = buildCards(listOf(row)).first()
+        var count = 0
+        var totalSize = 0L
+        SkillFiles.select(SkillFiles.size).where { SkillFiles.skillId eq row[Skills.id] }
+            .forEach { count++; totalSize += it[SkillFiles.size] }
+        SkillDetail(
+            id = card.id, slug = card.slug, name = card.name, description = card.description,
+            license = card.license, tags = card.tags, category = card.category, version = card.version,
+            versionSource = card.versionSource, tokenUpfront = card.tokenUpfront, tokenOndemand = card.tokenOndemand,
+            tokenBand = card.tokenBand, verified = card.verified, status = card.status, featured = card.featured,
+            installs = card.installs, author = card.author, bundle = card.bundle,
+            readmeMd = row[Skills.readmeMd], fileCount = count, totalSize = totalSize,
+            createdAt = card.createdAt, updatedAt = card.updatedAt,
+        )
+    }
+
+    // ---- files -------------------------------------------------------------
+
+    fun fileTree(slug: String): FileTreeResponse = transaction {
+        val skill = skillRowPublic(slug)
+        val files = SkillFiles.selectAll().where { SkillFiles.skillId eq skill[Skills.id] }
+            .orderBy(SkillFiles.path).map { row ->
+                val path = row[SkillFiles.path]
+                FileEntry(
+                    path = path,
+                    name = path.substringAfterLast('/'),
+                    dir = path.substringBeforeLast('/').takeIf { it != path } ?: "",
+                    size = row[SkillFiles.size],
+                    isBinary = row[SkillFiles.isBinary],
+                )
+            }
+        FileTreeResponse(slug, files, buildTree(files))
+    }
+
+    fun fileContent(slug: String, path: String, store: FileStore): FileContentResult = transaction {
+        val skill = skillRowPublic(slug)
+        val row = SkillFiles.selectAll().where {
+            (SkillFiles.skillId eq skill[Skills.id]) and (SkillFiles.path eq path)
+        }.singleOrNull() ?: throw ApiNotFoundException("File '$path' not found for '$slug'")
+        val isBinary = row[SkillFiles.isBinary]
+        val size = row[SkillFiles.size]
+        val key = row[SkillFiles.r2Key]
+        val downloadOnly = isBinary || size > PREVIEW_LIMIT
+        val content = if (!downloadOnly) store.get(key)?.toString(Charsets.UTF_8) else null
+        FileContentResult(slug, path, size, isBinary, content, downloadOnly, key)
+    }
+
+    // ---- versions ----------------------------------------------------------
+
+    fun versions(slug: String): VersionsResponse = transaction {
+        val skill = skillRowPublic(slug)
+        val current = skill[Skills.version]
+        val list = Versions.selectAll().where { Versions.skillId eq skill[Skills.id] }
+            .orderBy(Versions.createdAt, SortOrder.DESC)
+            .map { VersionEntry(it[Versions.version], it[Versions.sourceRef], it[Versions.createdAt], it[Versions.version] == current) }
+        VersionsResponse(slug, current, list)
+    }
+
+    // ---- download ----------------------------------------------------------
+
+    fun download(slug: String, version: String?, store: FileStore): DownloadResult = transaction {
+        val skill = skillRowPublic(slug)
+        val skillId = skill[Skills.id]
+        val verRow = (if (version != null) {
+            Versions.selectAll().where { (Versions.skillId eq skillId) and (Versions.version eq version) }.singleOrNull()
+        } else {
+            Versions.selectAll().where { Versions.skillId eq skillId }.orderBy(Versions.createdAt, SortOrder.DESC).firstOrNull()
+        }) ?: throw ApiNotFoundException("No version available for '$slug'")
+
+        val zipKey = verRow[Versions.r2ZipKey]
+        val bytes = if (zipKey != null && store.exists(zipKey)) {
+            store.get(zipKey) ?: buildZip(skillId, store)
+        } else {
+            buildZip(skillId, store)
+        }
+        // Best-effort install counter (single writer; spec §3 keeps this simple).
+        Skills.update({ Skills.id eq skillId }) { it[Skills.installs] = skill[Skills.installs] + 1 }
+        DownloadResult(bytes, "${slug}-${verRow[Versions.version]}.zip", "application/zip")
+    }
+
+    // ---- trends / timeline -------------------------------------------------
+
+    fun trends(): TrendsResponse = transaction {
+        val allPublished = Skills.selectAll().where { Skills.status eq "published" }.toList()
+        val catCounts = allPublished.groupingBy { it[Skills.categoryId] }.eachCount()
+        val catMap = if (catCounts.isNotEmpty()) {
+            Categories.selectAll().where { Categories.id inList catCounts.keys.filterNotNull() }
+                .associateBy { it[Categories.id] }
+        } else emptyMap()
+        val catFacet = catCounts.entries.sortedByDescending { it.value }
+            .map { (id, n) ->
+                val cr = id?.let { catMap[it] }
+                FacetCount(cr?.get(Categories.slug) ?: "uncategorized", cr?.get(Categories.name) ?: "Uncategorized", n)
+            }
+        val tagCounts = mutableMapOf<String, Int>()
+        allPublished.forEach { decodeTags(it[Skills.tags]).forEach { t -> tagCounts.merge(t, 1) { a, b -> a + b } } }
+        val tagFacet = tagCounts.entries.sortedByDescending { it.value }.take(MAX_TAG_FACETS)
+            .map { FacetCount(it.key, null, it.value) }
+        val bandCounts = allPublished.groupingBy { it[Skills.tokenBand] }.eachCount()
+        val tokenMix = listOf("100s", "1k", "10k", "100k").map { FacetCount(it, null, bandCounts[it] ?: 0) }
+        val funnel = Submissions.select(Submissions.state).toList()
+            .groupingBy { it[Submissions.state] }.eachCount()
+        TrendsResponse(catFacet, tagFacet, tokenMix, securityPassRate = null, submissionFunnel = funnel)
+    }
+
+    fun timeline(page: Int, pageSize: Int): TimelinePage = transaction {
+        val skillRows = Skills.selectAll().where { Skills.status eq "published" }.toList()
+        val ownerByBundle = ownerByBundleMap(skillRows.map { it[Skills.bundleId] }.distinct())
+        val events = mutableListOf<TimelineEvent>()
+        skillRows.forEach { s ->
+            events += TimelineEvent(
+                type = "publish",
+                at = s[Skills.createdAt],
+                slug = s[Skills.slug],
+                name = s[Skills.name],
+                version = s[Skills.version],
+                authorHandle = ownerByBundle[s[Skills.bundleId]],
+            )
+        }
+        val skillById = skillRows.associateBy { it[Skills.id] }
+        val skillIds = skillRows.map { it[Skills.id] }
+        if (skillIds.isNotEmpty()) {
+            Versions.selectAll().where { Versions.skillId inList skillIds }.orderBy(Versions.createdAt, SortOrder.DESC).forEach { v ->
+                val s = skillById[v[Versions.skillId]] ?: return@forEach
+                events += TimelineEvent(
+                    type = "version",
+                    at = v[Versions.createdAt],
+                    slug = s[Skills.slug],
+                    name = s[Skills.name],
+                    version = v[Versions.version],
+                    authorHandle = ownerByBundle[s[Skills.bundleId]],
+                )
+            }
+        }
+        events.sortByDescending { it.at } // ISO-8601 UTC sorts lexicographically
+        val total = events.size
+        val items = events.drop((page - 1) * pageSize).take(pageSize)
+        TimelinePage(items, page, pageSize, total, pagesOf(total, pageSize))
+    }
+
+    // ---- bundles / authors -------------------------------------------------
+
+    fun bundles(page: Int, pageSize: Int): Page<BundleSummary> = transaction {
+        val total = Bundles.selectAll().count().toInt()
+        val rows = Bundles.selectAll().orderBy(Bundles.createdAt, SortOrder.DESC)
+            .limit(pageSize).offset(((page - 1) * pageSize).toLong()).toList()
+        val owners = usersByIds(rows.map { it[Bundles.ownerUserId] }.distinct())
+        val counts = Skills.select(Skills.bundleId).where { Skills.bundleId inList rows.map { it[Bundles.id] } }
+            .toList().groupingBy { it[Skills.bundleId] }.eachCount()
+        val items = rows.map { row ->
+            BundleSummary(
+                id = row[Bundles.id], kind = row[Bundles.kind], provenance = row[Bundles.provenance],
+                owner = authorRef(owners[row[Bundles.ownerUserId]]), sourceRef = row[Bundles.sourceRef],
+                skillCount = counts[row[Bundles.id]] ?: 0, syncedAt = row[Bundles.syncedAt], createdAt = row[Bundles.createdAt],
+            )
+        }
+        Page(items, page, pageSize, total, pagesOf(total, pageSize))
+    }
+
+    fun bundle(id: String): BundleDetail = transaction {
+        val row = Bundles.selectAll().where { Bundles.id eq id }.singleOrNull()
+            ?: throw ApiNotFoundException("Bundle '$id' not found")
+        val owner = usersByIds(listOf(row[Bundles.ownerUserId])).values.first()
+        val skillRows = Skills.selectAll().where { Skills.bundleId eq id }.orderBy(Skills.updatedAt, SortOrder.DESC).toList()
+        BundleDetail(
+            id = row[Bundles.id], kind = row[Bundles.kind], provenance = row[Bundles.provenance],
+            owner = authorRef(owner), sourceRef = row[Bundles.sourceRef], syncedAt = row[Bundles.syncedAt],
+            createdAt = row[Bundles.createdAt], skills = buildCards(skillRows),
+        )
+    }
+
+    fun author(handle: String): AuthorProfile = transaction {
+        val user = Users.selectAll().where { Users.handle eq handle }.singleOrNull()
+            ?: throw ApiNotFoundException("Author '$handle' not found")
+        val userId = user[Users.id]
+        val bundleIds = Bundles.select(Bundles.id).where { Bundles.ownerUserId eq userId }.map { it[Bundles.id] }
+        val skillRows = if (bundleIds.isNotEmpty()) {
+            Skills.selectAll().where { (Skills.bundleId inList bundleIds) and (Skills.status eq "published") }
+                .orderBy(Skills.installs, SortOrder.DESC).toList()
+        } else emptyList()
+        val cards = buildCards(skillRows)
+        AuthorProfile(
+            handle = handle, name = user[Users.name], avatarUrl = user[Users.avatarUrl],
+            skillCount = cards.size, totalInstalls = skillRows.sumOf { it[Skills.installs] }, skills = cards,
+        )
+    }
+
+    // ---- report ------------------------------------------------------------
+
+    fun createReport(slug: String, reason: String?, reporterId: String?): ReportResponse = transaction {
+        val skill = skillRowPublic(slug)
+        val trimmed = reason?.trim().orEmpty()
+        if (trimmed.isEmpty()) throw ApiValidationException(mapOf("reason" to "is required"))
+        val id = newId()
+        Reports.insert {
+            it[Reports.id] = id
+            it[Reports.skillId] = skill[Skills.id]
+            it[Reports.reporterId] = reporterId
+            it[Reports.reason] = trimmed.take(2000)
+            it[Reports.createdAt] = nowIso()
+        }
+        ReportResponse(id, accepted = true)
+    }
+
+    // ---- internals ---------------------------------------------------------
+
+    /** Resolves a published skill row or throws 404. */
+    private fun skillRowPublic(slug: String): ResultRow = transaction {
+        Skills.selectAll().where { (Skills.slug eq slug) and (Skills.status eq "published") }.singleOrNull()
+    } ?: throw ApiNotFoundException("Skill '$slug' not found")
+
+    private fun SearchParams.buildCondition(
+        excludeCats: Boolean = false,
+        excludeTags: Boolean = false,
+        excludeSize: Boolean = false,
+    ): Op<Boolean> = with(SqlExpressionBuilder) {
+        // like / inList / inSubQuery / arithmetic are members of SqlExpressionBuilder,
+        // so the predicate is built inside its scope (and propagates into nested lambdas).
+        val conds = mutableListOf<Op<Boolean>>(Skills.status eq "published")
+        if (verified) conds += Skills.verified eq true
+        val qq = q?.trim()
+        if (!qq.isNullOrBlank()) {
+            val pat = "%${qq.sanitizeLike()}%"
+            val lpat = "%${qq.sanitizeLike().lowercase()}%"
+            conds += (Skills.tags like pat) or
+                (LowerCase(Skills.name) like lpat) or
+                (LowerCase(Skills.description) like lpat)
+        }
+        if (!excludeCats && cats.isNotEmpty()) {
+            val catIds = Categories.select(Categories.id).where { Categories.slug inList cats }
+            conds += Skills.categoryId inSubQuery catIds
+        }
+        if (!excludeTags && tags.isNotEmpty()) {
+            val tagOps: List<Op<Boolean>> = tags.map { Skills.tags like "%\"${it.sanitizeLike()}\"%" }
+            conds += if (tagOps.size == 1) tagOps[0] else tagOps.reduce { acc, op -> acc or op }
+        }
+        if (!excludeSize && size != null) {
+            val total = Skills.tokenUpfront + Skills.tokenOndemand
+            conds += when (size) {
+                "<2k" -> total less 2000
+                "2-5k" -> (total greaterEq 2000) and (total lessEq 5000)
+                "5k+" -> total greater 5000
+                else -> total greaterEq 0
+            }
+        }
+        conds.reduce { acc, op -> acc and op }
+    }
+
+    private fun SearchParams.orderColumns(): List<Pair<Expression<*>, SortOrder>> = with(SqlExpressionBuilder) {
+        val qq = q?.trim()
+        when (sort) {
+            "installs" -> listOf(Skills.installs to SortOrder.DESC, Skills.updatedAt to SortOrder.DESC)
+            "updated" -> listOf(Skills.updatedAt to SortOrder.DESC)
+            "tokens" -> listOf(
+                (Skills.tokenUpfront + Skills.tokenOndemand) to SortOrder.ASC,
+                Skills.name to SortOrder.ASC,
+            )
+            else -> if (!qq.isNullOrBlank()) {
+                val lpat = "%${qq.sanitizeLike().lowercase()}%"
+                listOf(
+                    (LowerCase(Skills.name) like lpat) to SortOrder.DESC,
+                    Skills.installs to SortOrder.DESC,
+                    Skills.updatedAt to SortOrder.DESC,
+                )
+            } else {
+                listOf(Skills.featured to SortOrder.DESC, Skills.installs to SortOrder.DESC, Skills.updatedAt to SortOrder.DESC)
+            }
+        }
+    }
+
+    private fun computeFacets(p: SearchParams): Facets {
+        val catRows = Skills.select(Skills.categoryId).where(p.buildCondition(excludeCats = true)).toList()
+        val catCounts = catRows.groupingBy { it[Skills.categoryId] }.eachCount()
+        val catMap = if (catCounts.isNotEmpty()) {
+            Categories.selectAll().where { Categories.id inList catCounts.keys.filterNotNull() }.associateBy { it[Categories.id] }
+        } else emptyMap()
+        val categoryFacet = catCounts.entries.sortedByDescending { it.value }.map { (id, n) ->
+            val cr = id?.let { catMap[it] }
+            FacetCount(cr?.get(Categories.slug) ?: "uncategorized", cr?.get(Categories.name) ?: "Uncategorized", n)
+        }
+
+        val tagCounts = mutableMapOf<String, Int>()
+        Skills.select(Skills.tags).where(p.buildCondition(excludeTags = true)).forEach { row ->
+            decodeTags(row[Skills.tags]).forEach { tagCounts.merge(it, 1) { a, b -> a + b } }
+        }
+        val tagFacet = tagCounts.entries.sortedByDescending { it.value }.take(MAX_TAG_FACETS)
+            .map { FacetCount(it.key, null, it.value) }
+
+        val sizeBuckets = linkedMapOf("<2k" to 0, "2-5k" to 0, "5k+" to 0)
+        Skills.select(Skills.tokenUpfront, Skills.tokenOndemand).where(p.buildCondition(excludeSize = true)).forEach { row ->
+            val total = row[Skills.tokenUpfront] + row[Skills.tokenOndemand]
+            val key = when { total < 2000 -> "<2k"; total <= 5000 -> "2-5k"; else -> "5k+" }
+            sizeBuckets[key] = sizeBuckets[key]!! + 1
+        }
+        val sizeFacet = sizeBuckets.map { FacetCount(it.key, null, it.value) }
+
+        return Facets(categoryFacet, tagFacet, sizeFacet)
+    }
+
+    private fun buildCards(rows: List<ResultRow>): List<SkillCard> {
+        if (rows.isEmpty()) return emptyList()
+        val bundles = Bundles.selectAll().where { Bundles.id inList rows.map { it[Skills.bundleId] }.distinct() }
+            .associateBy { it[Bundles.id] }
+        val owners = usersByIds(bundles.values.map { it[Bundles.ownerUserId] }.distinct())
+        val catIds = rows.mapNotNull { it[Skills.categoryId] }.distinct()
+        val cats = if (catIds.isNotEmpty()) {
+            Categories.selectAll().where { Categories.id inList catIds }.associateBy { it[Categories.id] }
+        } else emptyMap()
+        return rows.map { row ->
+            val bundle = bundles[row[Skills.bundleId]] ?: error("missing bundle for skill")
+            val owner = owners[bundle[Bundles.ownerUserId]]
+            val category = row[Skills.categoryId]?.let { cats[it] }
+            SkillCard(
+                id = row[Skills.id], slug = row[Skills.slug], name = row[Skills.name], description = row[Skills.description],
+                license = row[Skills.license], tags = decodeTags(row[Skills.tags]),
+                category = category?.let { CategoryRef(it[Categories.slug], it[Categories.name]) },
+                version = row[Skills.version], versionSource = row[Skills.versionSource],
+                tokenUpfront = row[Skills.tokenUpfront], tokenOndemand = row[Skills.tokenOndemand], tokenBand = row[Skills.tokenBand],
+                verified = row[Skills.verified], status = row[Skills.status], featured = row[Skills.featured], installs = row[Skills.installs],
+                author = authorRef(owner), bundle = BundleRef(bundle[Bundles.id], bundle[Bundles.kind], bundle[Bundles.provenance]),
+                createdAt = row[Skills.createdAt], updatedAt = row[Skills.updatedAt],
+            )
+        }
+    }
+
+    private fun usersByIds(ids: List<String>): Map<String, ResultRow> =
+        if (ids.isEmpty()) emptyMap() else Users.selectAll().where { Users.id inList ids }.associateBy { it[Users.id] }
+
+    private fun ownerByBundleMap(bundleIds: List<String>): Map<String, String> {
+        if (bundleIds.isEmpty()) return emptyMap()
+        val bundles = Bundles.selectAll().where { Bundles.id inList bundleIds }.associateBy { it[Bundles.id] }
+        val owners = usersByIds(bundles.values.map { it[Bundles.ownerUserId] }.distinct())
+        return bundles.mapNotNull { (bid, b) -> owners[b[Bundles.ownerUserId]]?.get(Users.handle)?.let { bid to it } }.toMap()
+    }
+
+    private fun authorRef(owner: ResultRow?): AuthorRef = if (owner == null) AuthorRef("unknown") else
+        AuthorRef(owner[Users.handle], owner[Users.name], owner[Users.avatarUrl])
+
+    private fun buildZip(skillId: String, store: FileStore): ByteArray {
+        val files = SkillFiles.selectAll().where { SkillFiles.skillId eq skillId }.orderBy(SkillFiles.path).toList()
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            files.forEach { f ->
+                val bytes = store.get(f[SkillFiles.r2Key]) ?: return@forEach
+                zos.putNextEntry(ZipEntry(f[SkillFiles.path]))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return baos.toByteArray()
+    }
+
+    private fun buildTree(files: List<FileEntry>): List<TreeNode> {
+        // Mutable intermediate, then frozen into immutable TreeNode for the response.
+        data class MNode(val name: String, val path: String, var type: String, var size: Int = 0, var binary: Boolean = false, val kids: MutableMap<String, MNode> = LinkedHashMap())
+        val root = MNode("", "", "dir")
+        for (f in files) {
+            val parts = f.path.split('/')
+            var cur = root
+            parts.forEachIndexed { i, part ->
+                val fullPath = if (cur.path.isEmpty()) part else "${cur.path}/$part"
+                val isLeaf = i == parts.lastIndex
+                cur = cur.kids.getOrPut(part) { MNode(part, fullPath, if (isLeaf) "file" else "dir") }
+                if (isLeaf) { cur.size = f.size; cur.binary = f.isBinary }
+            }
+        }
+        fun toNode(m: MNode): TreeNode = TreeNode(
+            name = m.name, path = m.path, type = m.type, size = m.size, isBinary = m.binary,
+            children = if (m.kids.isEmpty()) null else m.kids.values.map(::toNode),
+        )
+        return root.kids.values.map(::toNode)
+    }
+
+    private fun decodeTags(json: String): List<String> = try {
+        appJson.decodeFromString<List<String>>(json)
+    } catch (_: Throwable) {
+        emptyList()
+    }
+
+    private fun pagesOf(total: Int, size: Int): Int = if (size <= 0) 0 else (total + size - 1) / size
+
+    private fun String.sanitizeLike(): String = replace("%", "").replace("_", "")
+
+    fun parsePageSize(raw: String?): Int = (raw?.toIntOrNull() ?: DEFAULT_PAGE_SIZE).coerceIn(1, MAX_PAGE_SIZE)
+    fun parsePage(raw: String?): Int = (raw?.toIntOrNull() ?: 1).coerceAtLeast(1)
+}
+
+data class FileContentResult(
+    val slug: String,
+    val path: String,
+    val size: Int,
+    val isBinary: Boolean,
+    val content: String?,
+    val downloadOnly: Boolean,
+    val r2Key: String,
+)
+
+data class DownloadResult(val bytes: ByteArray, val filename: String, val contentType: String)

--- a/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
@@ -221,10 +221,17 @@ object PublicQueries {
         } else {
             throw ApiNotFoundException("No downloadable archive for '$slug' version '$label'")
         }
-        // Best-effort install counter (single writer; spec §3 keeps this simple).
-        // Runs after the archive is resolved and inside the same transaction, so a
-        // thrown build/lookup rolls the bump back — a failed download never counts.
-        Skills.update({ Skills.id eq skillId }) { it[Skills.installs] = skill[Skills.installs] + 1 }
+        // Best-effort install counter (spec §3 keeps installs approximate).
+        // Atomic SQL increment (installs = installs + 1) rather than writing back
+        // the value captured earlier in this transaction — that avoids a lost
+        // update if two download transactions overlap (one would otherwise
+        // clobber the other's +1 from a stale read). Still best-effort and still
+        // inside this transaction, so a thrown build/lookup rolls the bump back.
+        Skills.update({ Skills.id eq skillId }) {
+            with(org.jetbrains.exposed.sql.SqlExpressionBuilder) {
+                it[Skills.installs] = Skills.installs + 1
+            }
+        }
         DownloadResult(bytes, "${slug}-${verRow[Versions.version]}.zip", "application/zip")
     }
 
@@ -340,6 +347,11 @@ object PublicQueries {
                 .orderBy(Skills.installs, SortOrder.DESC).toList()
         } else emptyList()
         val cards = buildCards(skillRows)
+        // Public author directory: only users with >=1 published skill are "authors".
+        // A registered user whose skills are all drafts/unlisted/flagged is not
+        // publicly exposed here (consistent with the bundle index hiding bundles
+        // with zero public skills). Their own view is /api/me; admins see the roster.
+        if (cards.isEmpty()) throw ApiNotFoundException("Author '$handle' not found")
         AuthorProfile(
             handle = handle, name = user[Users.name], avatarUrl = user[Users.avatarUrl],
             skillCount = cards.size, totalInstalls = skillRows.sumOf { it[Skills.installs] }, skills = cards,

--- a/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
@@ -70,6 +70,7 @@ object PublicQueries {
     const val PREVIEW_LIMIT = 256 * 1024
     private const val DEFAULT_PAGE_SIZE = 24
     private const val MAX_PAGE_SIZE = 60
+    private const val MAX_PAGE = 10_000
     private const val MAX_TAG_FACETS = 20
 
     // ---- stats / taxonomy --------------------------------------------------
@@ -217,7 +218,7 @@ object PublicQueries {
         // with today's files named as the old version (spec §5.6).
         val storedBytes = if (zipKey != null && store.exists(zipKey)) store.get(zipKey) else null
         val bytes = storedBytes ?: if (isCurrent) {
-            buildZip(skillId, store)
+            buildZip(skillId, skill[Skills.readmeMd], store)
         } else {
             throw ApiNotFoundException("No downloadable archive for '$slug' version '$label'")
         }
@@ -509,13 +510,24 @@ object PublicQueries {
     private fun authorRef(owner: ResultRow?): AuthorRef = if (owner == null) AuthorRef("unknown") else
         AuthorRef(owner[Users.handle], owner[Users.name], owner[Users.avatarUrl])
 
-    private fun buildZip(skillId: String, store: FileStore): ByteArray {
+    private fun buildZip(skillId: String, readmeMd: String?, store: FileStore): ByteArray {
         val files = SkillFiles.selectAll().where { SkillFiles.skillId eq skillId }.orderBy(SkillFiles.path).toList()
         if (files.isEmpty()) {
             throw ApiStorageException("Cannot build archive for skill '$skillId': no files recorded")
         }
+        // The downloadable bundle must contain the SKILL.md manifest (§5/§11),
+        // not only the mirrored files. readme_md holds the parsed body (the
+        // manifest frontmatter is reconstructed at full ingest, step 4), so the
+        // fallback zip writes it as SKILL.md to keep the bundle complete. Skip if
+        // a SKILL.md file row already exists to avoid a duplicate-entry zip crash.
+        val hasSkillMdFile = files.any { it[SkillFiles.path] == "SKILL.md" }
         val baos = ByteArrayOutputStream()
         ZipOutputStream(baos).use { zos ->
+            if (!hasSkillMdFile && !readmeMd.isNullOrBlank()) {
+                zos.putNextEntry(ZipEntry("SKILL.md"))
+                zos.write(readmeMd.toByteArray(Charsets.UTF_8))
+                zos.closeEntry()
+            }
             files.forEach { f ->
                 // Zip Slip defence: never write an entry that escapes the skill root.
                 // Unlike a quiet skip, an unsafe stored path or missing bytes is a
@@ -573,6 +585,10 @@ object PublicQueries {
         if (raw == null) return 1
         val n = raw.toIntOrNull() ?: throw ApiValidationException(mapOf("page" to "must be a positive integer"), "Invalid 'page'")
         if (n < 1) throw ApiValidationException(mapOf("page" to "must be >= 1"), "Invalid 'page'")
+        // Bound deep pagination: a huge page (e.g. Int.MAX_VALUE) is never a real
+        // request and its offset ((page-1)*pageSize) risks Int overflow / a needless
+        // large OFFSET scan. Reject beyond a sane ceiling.
+        if (n > MAX_PAGE) throw ApiValidationException(mapOf("page" to "must be <= $MAX_PAGE (deep pagination is not supported)"), "Invalid 'page'")
         return n
     }
 

--- a/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
@@ -84,7 +84,7 @@ object PublicQueries {
             .withDistinct()
             .count()
             .toInt()
-        val lastUpdated = Skills.select(Skills.updatedAt)
+        val lastUpdated = Skills.select(Skills.updatedAt).where { Skills.status eq "published" }
             .orderBy(Skills.updatedAt, SortOrder.DESC).firstOrNull()?.get(Skills.updatedAt)
         StatsResponse(indexed, contributors, lastUpdated)
     }
@@ -224,7 +224,6 @@ object PublicQueries {
         // Best-effort install counter (single writer; spec §3 keeps this simple).
         // Runs after the archive is resolved and inside the same transaction, so a
         // thrown build/lookup rolls the bump back — a failed download never counts.
-        Skills.update({ Skills.id eq skillId }) { it[Skills.installs] = skill[Skills.installs] + 1 }
         Skills.update({ Skills.id eq skillId }) { it[Skills.installs] = skill[Skills.installs] + 1 }
         DownloadResult(bytes, "${slug}-${verRow[Versions.version]}.zip", "application/zip")
     }

--- a/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
@@ -196,7 +196,14 @@ object PublicQueries {
         val verRow = (if (version != null) {
             Versions.selectAll().where { (Versions.skillId eq skillId) and (Versions.version eq version) }.singleOrNull()
         } else {
-            Versions.selectAll().where { Versions.skillId eq skillId }.orderBy(Versions.createdAt, SortOrder.DESC).firstOrNull()
+            // No version requested → the public contract is "the current version"
+            // (skills.version), NOT "whichever versions row was inserted last".
+            // Selecting by newest created_at would let a later backfilled/re-reviewed
+            // row shadow the real current release (or 404 against the wrong row).
+            val currentVersion = skill[Skills.version]
+            Versions.selectAll().where {
+                (Versions.skillId eq skillId) and (Versions.version eq currentVersion)
+            }.singleOrNull()
         }) ?: throw ApiNotFoundException("No version available for '$slug'")
 
         val currentVersion = skill[Skills.version]
@@ -490,14 +497,21 @@ object PublicQueries {
 
     private fun buildZip(skillId: String, store: FileStore): ByteArray {
         val files = SkillFiles.selectAll().where { SkillFiles.skillId eq skillId }.orderBy(SkillFiles.path).toList()
+        if (files.isEmpty()) {
+            throw ApiStorageException("Cannot build archive for skill '$skillId': no files recorded")
+        }
         val baos = ByteArrayOutputStream()
         ZipOutputStream(baos).use { zos ->
             files.forEach { f ->
-                // Zip Slip defence: only normalised relative POSIX paths become
-                // entries. Unsafe stored paths (e.g. `../…`) are skipped rather
-                // than written (ingest will also reject them upstream). (§11.)
-                val safePath = SkillPaths.safeRelativeOrNull(f[SkillFiles.path]) ?: return@forEach
-                val bytes = store.get(f[SkillFiles.r2Key]) ?: return@forEach
+                // Zip Slip defence: never write an entry that escapes the skill root.
+                // Unlike a quiet skip, an unsafe stored path or missing bytes is a
+                // data-integrity failure — failing loudly (ApiStorageException) means
+                // download() never returns a 200 with a truncated archive and a
+                // bumped install count. (§11; matches the file-preview behaviour.)
+                val safePath = SkillPaths.safeRelativeOrNull(f[SkillFiles.path])
+                    ?: throw ApiStorageException("Unsafe file path stored for skill '$skillId': '${f[SkillFiles.path]}'")
+                val bytes = store.get(f[SkillFiles.r2Key])
+                    ?: throw ApiStorageException("File bytes missing for skill '$skillId': '${f[SkillFiles.path]}' (key=${f[SkillFiles.r2Key]})")
                 zos.putNextEntry(ZipEntry(safePath))
                 zos.write(bytes)
                 zos.closeEntry()

--- a/api/src/main/kotlin/dev/androidskills/api/PublicRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicRoutes.kt
@@ -1,0 +1,102 @@
+package dev.androidskills.api
+
+import dev.androidskills.storage.FileStore
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondBytes
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+
+/** Public read routes (spec §9 Public). No auth; anonymous browsing. */
+fun Route.publicRoutes(fileStore: FileStore) {
+    val q = PublicQueries
+
+    route("api") {
+        get("stats") { call.respond(q.stats()) }
+
+        get("skills") { call.respond(q.search(parseSearchParams(call))) }
+        get("skills/{slug}") { call.respond(q.skillDetail(call.parameters["slug"]!!)) }
+        get("skills/{slug}/files") { call.respond(q.fileTree(call.parameters["slug"]!!)) }
+        get("skills/{slug}/files/{path...}") {
+            val slug = call.parameters["slug"]!!
+            val path = call.parameters["path"]!!
+            val raw = call.request.queryParameters["raw"] == "1"
+            val res = q.fileContent(slug, path, fileStore)
+            if (raw && !res.downloadOnly) {
+                call.respondText(res.content ?: "", contentType = guessTextContentType(res.path))
+            } else {
+                call.respond(
+                    FileContentResponse(
+                        slug = res.slug, path = res.path, size = res.size, isBinary = res.isBinary,
+                        content = res.content, downloadOnly = res.downloadOnly, downloadUrl = null,
+                    ),
+                )
+            }
+        }
+        get("skills/{slug}/versions") { call.respond(q.versions(call.parameters["slug"]!!)) }
+        get("skills/{slug}/download") {
+            val slug = call.parameters["slug"]!!
+            val version = call.request.queryParameters["version"]
+            val res = q.download(slug, version, fileStore)
+            call.response.headers.append(HttpHeaders.ContentDisposition, "attachment; filename=\"${res.filename}\"")
+            call.respondBytes(res.bytes, contentType = ContentType.parse(res.contentType))
+        }
+
+        get("categories") { call.respond(q.categories()) }
+        get("trends") { call.respond(q.trends()) }
+        get("timeline") {
+            val page = PublicQueries.parsePage(call.request.queryParameters["page"])
+            val size = PublicQueries.parsePageSize(call.request.queryParameters["pageSize"])
+            call.respond(q.timeline(page, size))
+        }
+        get("bundles") {
+            val page = PublicQueries.parsePage(call.request.queryParameters["page"])
+            val size = PublicQueries.parsePageSize(call.request.queryParameters["pageSize"])
+            call.respond(q.bundles(page, size))
+        }
+        get("bundles/{id}") { call.respond(q.bundle(call.parameters["id"]!!)) }
+        get("authors/{handle}") { call.respond(q.author(call.parameters["handle"]!!)) }
+
+        post("skills/{slug}/report") {
+            val slug = call.parameters["slug"]!!
+            val body = runCatching { call.receive<ReportRequest>() }.getOrDefault(ReportRequest())
+            val result = q.createReport(slug, body.reason, reporterId = null) // anonymous by default
+            call.respond(HttpStatusCode.Created, result)
+        }
+    }
+}
+
+private fun parseSearchParams(call: ApplicationCall): SearchParams {
+    val qp = call.request.queryParameters
+    fun multi(key: String): List<String> = (qp.getAll(key) ?: emptyList()).ifEmpty { qp.getAll("${key}[]") ?: emptyList() }
+        .filter { it.isNotBlank() }
+    val verified = when ((qp["verified"] ?: "true").lowercase()) {
+        "false", "0", "no" -> false
+        else -> true
+    }
+    return SearchParams(
+        q = qp["q"]?.trim()?.takeIf { it.isNotEmpty() },
+        cats = multi("cat"),
+        tags = multi("tag"),
+        size = qp["size"]?.takeIf { it in setOf("<2k", "2-5k", "5k+") },
+        verified = verified,
+        sort = qp["sort"]?.takeIf { it in setOf("relevance", "installs", "updated", "tokens") } ?: "relevance",
+        page = PublicQueries.parsePage(qp["page"]),
+        pageSize = PublicQueries.parsePageSize(qp["pageSize"]),
+    )
+}
+
+private fun guessTextContentType(path: String): ContentType =
+    when (path.substringAfterLast('.', "").lowercase()) {
+        "json" -> ContentType.Application.Json
+        "html", "htm" -> ContentType.Text.Html
+        "css" -> ContentType.Text.CSS
+        else -> ContentType.Text.Plain
+    }

--- a/api/src/main/kotlin/dev/androidskills/api/PublicRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicRoutes.kt
@@ -4,6 +4,7 @@ import dev.androidskills.storage.FileStore
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.withCharset
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -26,11 +27,18 @@ fun Route.publicRoutes(fileStore: FileStore) {
         get("skills/{slug}/files") { call.respond(q.fileTree(call.parameters["slug"]!!)) }
         get("skills/{slug}/files/{path...}") {
             val slug = call.parameters["slug"]!!
-            val path = call.parameters["path"]!!
+            // {path...} is a tailcard: read every captured segment and rejoin so
+            // nested paths like references/guide.md survive the DB path match.
+            val path = call.parameters.getAll("path")?.joinToString("/").orEmpty()
             val raw = call.request.queryParameters["raw"] == "1"
             val res = q.fileContent(slug, path, fileStore)
             if (raw && !res.downloadOnly) {
-                call.respondText(res.content ?: "", contentType = guessTextContentType(res.path))
+                // Raw preview is ALWAYS text/plain (+ nosniff): a published skill
+                // can include an .html file, and serving it as text/html would give
+                // it same-origin script execution — catastrophic once auth/admin
+                // routes share this origin. Source files render fine as text.
+                call.response.headers.append("X-Content-Type-Options", "nosniff")
+                call.respondText(res.content ?: "", contentType = ContentType.Text.Plain.withCharset(Charsets.UTF_8))
             } else {
                 call.respond(
                     FileContentResponse(
@@ -52,13 +60,13 @@ fun Route.publicRoutes(fileStore: FileStore) {
         get("categories") { call.respond(q.categories()) }
         get("trends") { call.respond(q.trends()) }
         get("timeline") {
-            val page = PublicQueries.parsePage(call.request.queryParameters["page"])
-            val size = PublicQueries.parsePageSize(call.request.queryParameters["pageSize"])
+            val page = PublicQueries.parsePageStrict(call.request.queryParameters["page"])
+            val size = PublicQueries.parsePageSizeStrict(call.request.queryParameters["pageSize"])
             call.respond(q.timeline(page, size))
         }
         get("bundles") {
-            val page = PublicQueries.parsePage(call.request.queryParameters["page"])
-            val size = PublicQueries.parsePageSize(call.request.queryParameters["pageSize"])
+            val page = PublicQueries.parsePageStrict(call.request.queryParameters["page"])
+            val size = PublicQueries.parsePageSizeStrict(call.request.queryParameters["pageSize"])
             call.respond(q.bundles(page, size))
         }
         get("bundles/{id}") { call.respond(q.bundle(call.parameters["id"]!!)) }
@@ -75,28 +83,47 @@ fun Route.publicRoutes(fileStore: FileStore) {
 
 private fun parseSearchParams(call: ApplicationCall): SearchParams {
     val qp = call.request.queryParameters
-    fun multi(key: String): List<String> = (qp.getAll(key) ?: emptyList()).ifEmpty { qp.getAll("${key}[]") ?: emptyList() }
-        .filter { it.isNotBlank() }
-    val verified = when ((qp["verified"] ?: "true").lowercase()) {
+    fun multi(key: String): List<String> =
+        (qp.getAll(key) ?: emptyList()).ifEmpty { qp.getAll("${key}[]") ?: emptyList() }
+            .filter { it.isNotBlank() }
+
+    val verified = when (qp["verified"]?.lowercase()) {
+        null, "true", "1", "yes" -> true
         "false", "0", "no" -> false
-        else -> true
+        else -> throw ApiValidationException(
+            mapOf("verified" to "must be one of true|false"), "Invalid 'verified'",
+        )
     }
+
+    val sizeRaw = qp["size"]
+    val size = when {
+        sizeRaw == null -> null
+        sizeRaw in SIZE_FILTERS -> sizeRaw
+        else -> throw ApiValidationException(
+            mapOf("size" to "must be one of <2k|2-5k|5k+"), "Invalid 'size'",
+        )
+    }
+
+    val sortRaw = qp["sort"]
+    val sort = when {
+        sortRaw == null -> "relevance"
+        sortRaw in SORTS -> sortRaw
+        else -> throw ApiValidationException(
+            mapOf("sort" to "must be one of relevance|installs|updated|tokens"), "Invalid 'sort'",
+        )
+    }
+
     return SearchParams(
         q = qp["q"]?.trim()?.takeIf { it.isNotEmpty() },
         cats = multi("cat"),
         tags = multi("tag"),
-        size = qp["size"]?.takeIf { it in setOf("<2k", "2-5k", "5k+") },
+        size = size,
         verified = verified,
-        sort = qp["sort"]?.takeIf { it in setOf("relevance", "installs", "updated", "tokens") } ?: "relevance",
-        page = PublicQueries.parsePage(qp["page"]),
-        pageSize = PublicQueries.parsePageSize(qp["pageSize"]),
+        sort = sort,
+        page = PublicQueries.parsePageStrict(qp["page"]),
+        pageSize = PublicQueries.parsePageSizeStrict(qp["pageSize"]),
     )
 }
 
-private fun guessTextContentType(path: String): ContentType =
-    when (path.substringAfterLast('.', "").lowercase()) {
-        "json" -> ContentType.Application.Json
-        "html", "htm" -> ContentType.Text.Html
-        "css" -> ContentType.Text.CSS
-        else -> ContentType.Text.Plain
-    }
+private val SIZE_FILTERS = setOf("<2k", "2-5k", "5k+")
+private val SORTS = setOf("relevance", "installs", "updated", "tokens")

--- a/api/src/main/kotlin/dev/androidskills/db/CategorySeed.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/CategorySeed.kt
@@ -1,0 +1,24 @@
+package dev.androidskills.db
+
+/**
+ * The default category taxonomy seeded on first migration.
+ *
+ * Source of truth for the names/slugs: the design's `admin-categories.html`
+ * (CATS table) plus an `uncategorized` bucket the LLM review falls back to
+ * ("Skills the review can't confidently place land in Uncategorized…").
+ * `Build & CI` is included but carries the design's "unlisted" intent — it is
+ * seeded normally; visibility of individual categories is a future admin setting.
+ */
+val DEFAULT_CATEGORIES: List<Pair<String, String>> = listOf(
+    "jetpack-compose" to "Jetpack Compose",
+    "kotlin-language" to "Kotlin Language",
+    "architecture" to "Architecture",
+    "testing-qa" to "Testing & QA",
+    "material-design" to "Material Design",
+    "data-persistence" to "Data & Persistence",
+    "networking" to "Networking",
+    "performance" to "Performance",
+    "accessibility" to "Accessibility",
+    "build-ci" to "Build & CI",
+    "uncategorized" to "Uncategorized",
+)

--- a/api/src/main/kotlin/dev/androidskills/db/Enums.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/Enums.kt
@@ -1,0 +1,71 @@
+package dev.androidskills.db
+
+import dev.androidskills.api.ApiValidationException
+
+/**
+ * Typed enum values for the otherwise-free-form TEXT columns in [Tables] (spec
+ * §4). Centralising these here means every insert/update goes through one
+ * validation path, so later auth/admin code never has to reason about
+ * impossible states like `role='superuser'` or `status='frozen'`.
+ *
+ * These are **app-layer** invariants. SQLite can't add `CHECK` constraints to
+ * existing columns (`ALTER TABLE … ADD CONSTRAINT` isn't supported), and a
+ * table-rebuild migration is disproportionate pre-release, so enforcement lives
+ * here at the write boundary instead. If hardening at the DB layer is later
+ * wanted, these enums map 1:1 to a `CHECK (col IN (...))` clause.
+ */
+
+/** User role (spec §2, §7). `member` < `contributor` < `admin`. */
+enum class Role { member, contributor, admin;
+    companion object {
+        fun parse(raw: String): Role = entries.firstOrNull { it.name == raw }
+            ?: invalid("role", raw)
+    }
+}
+
+enum class UserStatus { active, suspended;
+    companion object {
+        fun parse(raw: String): UserStatus = entries.firstOrNull { it.name == raw }
+            ?: invalid("status", raw)
+    }
+}
+
+/**
+ * Skill visibility to anonymous users (spec §3.5, §4). Only [published] is
+ * publicly reachable. [unlisted] (owner took it down) and [flagged] (admin
+ * moderation) are both non-public — surfaced in the admin queue, not the index.
+ * The public "caution badge" is a separate concern driven by `verified=false`,
+ * not by this status.
+ */
+enum class SkillStatus { published, unlisted, flagged;
+    companion object {
+        fun parse(raw: String): SkillStatus = entries.firstOrNull { it.name == raw }
+            ?: invalid("status", raw)
+    }
+}
+
+enum class BundleKind { repo, zip;
+    companion object {
+        fun parse(raw: String): BundleKind = entries.firstOrNull { it.name == raw }
+            ?: invalid("kind", raw)
+    }
+}
+
+enum class VersionSource { manifest, git_head, upload;
+    companion object {
+        fun parse(raw: String): VersionSource = entries.firstOrNull { it.name == raw }
+            ?: invalid("version_source", raw)
+    }
+}
+
+enum class TokenBand { `100s`, `1k`, `10k`, `100k`;
+    companion object {
+        fun parse(raw: String): TokenBand = entries.firstOrNull { it.name == raw }
+            ?: invalid("token_band", raw)
+    }
+}
+
+private fun invalid(field: String, raw: String): Nothing = throw ApiValidationException(
+    mapOf(field to "must be one of the allowed values"),
+    "Invalid value for '$field': '$raw'",
+)

--- a/api/src/main/kotlin/dev/androidskills/db/Migrations.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/Migrations.kt
@@ -1,0 +1,54 @@
+package dev.androidskills.db
+
+import dev.androidskills.util.newId
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.insertIgnore
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.Database as ExposedDatabase
+
+/**
+ * Forward-only migrations tracked by `schema_meta.version`.
+ *
+ * Each migration is a `Transaction` extension invoked once, guarded by the
+ * recorded version. All migrations run inside a single transaction so a failure
+ * rolls the schema back to the last fully-applied version. **New schema changes
+ * append a new `if (version < N)` block + `migrateVN()` extension here — never
+ * edit an applied migration in place.**
+ */
+object Migrations {
+
+    fun run(db: ExposedDatabase) = transaction(db) {
+        exec("CREATE TABLE IF NOT EXISTS schema_meta (key TEXT PRIMARY KEY, value TEXT);")
+        val version = readVersion()
+        if (version < 1) {
+            migrateV1()
+            writeVersion(1)
+        }
+    }
+
+    /** v1: the full initial schema (spec §4) + default category taxonomy. */
+    private fun Transaction.migrateV1() {
+        // Order matters: parents before children for FK DDL.
+        SchemaUtils.create(
+            Users, Categories, Bundles, Skills, SkillFiles, Versions,
+            Submissions, Stars, Sessions, Jobs, AuditLog, Reports,
+        )
+        DEFAULT_CATEGORIES.forEach { (slug, name) ->
+            Categories.insertIgnore {
+                it[Categories.id] = newId()
+                it[Categories.slug] = slug
+                it[Categories.name] = name
+            }
+        }
+    }
+
+    private fun Transaction.readVersion(): Int =
+        exec("SELECT value FROM schema_meta WHERE key='version'") { rs ->
+            if (rs.next()) rs.getString(1)?.toIntOrNull() ?: 0 else 0
+        } ?: 0
+
+    private fun Transaction.writeVersion(version: Int) {
+        exec("INSERT OR REPLACE INTO schema_meta(key, value) VALUES ('version', '$version')")
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/db/Tables.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/Tables.kt
@@ -1,0 +1,241 @@
+package dev.androidskills.db
+
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.Table
+
+/**
+ * Exposed table objects for the full domain model (spec §4).
+ *
+ * IDs are TEXT UUIDv4 (varchar(36)); timestamps are ISO-8601 UTC TEXT. Indexes
+ * are declared on every foreign key and on the filter/sort columns referenced by
+ * the API (spec §9). Defaults mirror the SQL in the spec so raw inserts behave.
+ *
+ * Foreign keys use `.references()` (not `reference()`/`optReference()`, which
+ * require Exposed `IdTable`s — we keep plain `Table` so IDs stay plain `String`).
+ *
+ * Table objects are created in dependency order by [Migrations]; the order of the
+ * `object` declarations here does not matter for DDL.
+ *
+ * Note on `index(...)`: Exposed exposes two ambiguous overloads; passing
+ * `(name, isUnique=false, columns...)` unambiguously selects the named one.
+ */
+
+object Users : Table("users") {
+    val id = varchar("id", 36)
+    val githubId = long("github_id")
+    val handle = text("handle")
+    val name = text("name").nullable()
+    val avatarUrl = text("avatar_url").nullable()
+    val role = varchar("role", 24).default("member")        // member|contributor|admin
+    val status = varchar("status", 24).default("active")    // active|suspended
+    val createdAt = text("created_at")
+    val updatedAt = text("updated_at")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        uniqueIndex("uq_users_github_id", githubId)
+        uniqueIndex("uq_users_handle", handle)
+        index("ix_users_role_status", false, role, status)
+    }
+}
+
+object Categories : Table("categories") {
+    val id = varchar("id", 36)
+    val slug = text("slug")
+    val name = text("name")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        uniqueIndex("uq_categories_slug", slug)
+    }
+}
+
+object Bundles : Table("bundles") {
+    val id = varchar("id", 36)
+    val kind = varchar("kind", 16)                              // repo|zip
+    val provenance = text("provenance")                         // repo full_name, or upload id
+    val ownerUserId = varchar("owner_user_id", 36).references(Users.id, onDelete = ReferenceOption.CASCADE)
+    val sourceRef = text("source_ref").nullable()               // commit sha / upload hash
+    val installationId = long("installation_id").nullable()     // GitHub App installation id
+    val syncedAt = text("synced_at").nullable()
+    val createdAt = text("created_at")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        // First-come-first-served ownership: one bundle per (kind, provenance).
+        uniqueIndex("uq_bundles_kind_provenance", kind, provenance)
+        index("ix_bundles_owner", false, ownerUserId)
+    }
+}
+
+object Skills : Table("skills") {
+    val id = varchar("id", 36)
+    val bundleId = varchar("bundle_id", 36).references(Bundles.id, onDelete = ReferenceOption.CASCADE)
+    val slug = text("slug")
+    val name = text("name")
+    val description = text("description")
+    val license = text("license").nullable()
+    val tags = text("tags").default("[]")                       // JSON array string
+    val categoryId = varchar("category_id", 36)
+        .references(Categories.id, onDelete = ReferenceOption.SET_NULL)
+        .nullable()
+    val version = text("version")
+    val versionSource = varchar("version_source", 16)           // manifest|git_head|upload
+    val tokenUpfront = integer("token_upfront").default(0)
+    val tokenOndemand = integer("token_ondemand").default(0)
+    val tokenBand = varchar("token_band", 8).default("100s")    // 100s|1k|10k|100k
+    val verified = bool("verified").default(false)
+    val status = varchar("status", 16).default("published")     // published|unlisted|flagged
+    val featured = bool("featured").default(false)
+    val installs = integer("installs").default(0)
+    val readmeMd = text("readme_md").nullable()
+    val createdAt = text("created_at")
+    val updatedAt = text("updated_at")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        uniqueIndex("uq_skills_slug", slug)
+        index("ix_skills_bundle", false, bundleId)
+        index("ix_skills_category", false, categoryId)
+        index("ix_skills_status_verified", false, status, verified)
+        index("ix_skills_featured", false, featured)
+        index("ix_skills_installs", false, installs)
+        index("ix_skills_updated", false, updatedAt)
+        index("ix_skills_created", false, createdAt)
+        index("ix_skills_name", false, name)
+    }
+}
+
+object SkillFiles : Table("skill_files") {
+    val id = varchar("id", 36)
+    val skillId = varchar("skill_id", 36).references(Skills.id, onDelete = ReferenceOption.CASCADE)
+    val path = text("path")
+    val size = integer("size")
+    val isBinary = bool("is_binary").default(false)
+    val r2Key = text("r2_key")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        uniqueIndex("uq_skill_files_skill_path", skillId, path)
+        index("ix_skill_files_skill", false, skillId)
+    }
+}
+
+object Versions : Table("versions") {
+    val id = varchar("id", 36)
+    val skillId = varchar("skill_id", 36).references(Skills.id, onDelete = ReferenceOption.CASCADE)
+    val version = text("version")
+    val sourceRef = text("source_ref")
+    val r2ZipKey = text("r2_zip_key").nullable()
+    val createdAt = text("created_at")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        uniqueIndex("uq_versions_skill_version", skillId, version)
+        index("ix_versions_skill", false, skillId)
+        index("ix_versions_created", false, createdAt)
+    }
+}
+
+object Submissions : Table("submissions") {
+    val id = varchar("id", 36)
+    val bundleId = varchar("bundle_id", 36)
+        .references(Bundles.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val skillId = varchar("skill_id", 36)
+        .references(Skills.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val submitterId = varchar("submitter_id", 36).references(Users.id, onDelete = ReferenceOption.CASCADE)
+    val state = varchar("state", 24)                            // draft|in_review|changes_requested|published|rejected
+    val lintScore = integer("lint_score").nullable()
+    val note = text("note").nullable()
+    val payload = text("payload").nullable()
+    val createdAt = text("created_at")
+    val updatedAt = text("updated_at")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        index("ix_submissions_submitter", false, submitterId)
+        index("ix_submissions_state", false, state)
+        index("ix_submissions_bundle", false, bundleId)
+        index("ix_submissions_skill", false, skillId)
+    }
+}
+
+object Stars : Table("stars") {
+    val userId = varchar("user_id", 36).references(Users.id, onDelete = ReferenceOption.CASCADE)
+    val skillId = varchar("skill_id", 36).references(Skills.id, onDelete = ReferenceOption.CASCADE)
+    val createdAt = text("created_at")
+
+    override val primaryKey = PrimaryKey(userId, skillId)
+}
+
+object Sessions : Table("sessions") {
+    val id = varchar("id", 128)                                 // 256-bit token (cookie value)
+    val userId = varchar("user_id", 36).references(Users.id, onDelete = ReferenceOption.CASCADE)
+    val createdAt = text("created_at")
+    val expiresAt = text("expires_at")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        index("ix_sessions_user", false, userId)
+        index("ix_sessions_expires", false, expiresAt)
+    }
+}
+
+object Jobs : Table("jobs") {
+    val id = varchar("id", 36)
+    val type = varchar("type", 16)                              // review|resync
+    val payload = text("payload")
+    val state = varchar("state", 16).default("queued")         // queued|running|done|failed
+    val attempts = integer("attempts").default(0)
+    val runAfter = text("run_after")
+    val lastError = text("last_error").nullable()
+    val createdAt = text("created_at")
+    val updatedAt = text("updated_at")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        // The review worker polls `state='queued' AND run_after<=now`.
+        index("ix_jobs_state_runafter", false, state, runAfter)
+    }
+}
+
+object AuditLog : Table("audit_log") {
+    val id = varchar("id", 36)
+    val actorId = varchar("actor_id", 36).references(Users.id, onDelete = ReferenceOption.RESTRICT)
+    val action = text("action")
+    val target = text("target")
+    val meta = text("meta").nullable()
+    val createdAt = text("created_at")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        index("ix_audit_created", false, createdAt)
+        index("ix_audit_action", false, action)
+    }
+}
+
+object Reports : Table("reports") {
+    val id = varchar("id", 36)
+    val skillId = varchar("skill_id", 36).references(Skills.id, onDelete = ReferenceOption.CASCADE)
+    val reporterId = varchar("reporter_id", 36)
+        .references(Users.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val reason = text("reason")
+    val createdAt = text("created_at")
+
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        index("ix_reports_skill", false, skillId)
+        index("ix_reports_created", false, createdAt)
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
@@ -72,8 +72,14 @@ object SkillManifestParser {
     }
 
     private fun isDelim(line: String): Boolean {
-        val t = line.trim()
-        return t.isNotEmpty() && t.length >= 3 && t.all { it == '-' }
+        // A YAML document separator sits at column 0. An indented `---` (e.g. a
+        // line inside a `description: |` block scalar) is *content*, not a
+        // delimiter — matching it here would truncate the frontmatter and drop
+        // every field after it (license, metadata.version, …). Require the line
+        // to start with `---` (3+ dashes) and have only trailing whitespace.
+        if (!line.startsWith("---")) return false
+        val afterDashes = line.dropWhile { it == '-' }
+        return afterDashes.isBlank()
     }
 
     // ---- minimal YAML subset ------------------------------------------------

--- a/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
@@ -81,6 +81,14 @@ object SkillManifestParser {
             if (rawTags != null && rawTags !is List<*>) {
                 add(FieldError("tags", "must be a list (block sequence or [a, b] flow list)"))
             }
+            // §10: metadata.version must be well-formed if present. A `metadata:`
+            // value that isn't a mapping (e.g. a flow map `metadata: { version: 1.2.3 }`,
+            // which this minimal parser reads as a scalar string) would silently
+            // drop the version. Flag it instead, so the manifest is rejected.
+            val rawMetadata = map["metadata"]
+            if (rawMetadata != null && rawMetadata !is Map<*, *>) {
+                add(FieldError("metadata", "must be a block mapping; inline flow maps are unsupported"))
+            }
         }
         val version = (map["metadata"] as? Map<*, *>)?.string("version")?.trim()?.takeIf { it.isNotEmpty() }
 
@@ -257,8 +265,15 @@ object SkillManifestParser {
 
 object ManifestValidator {
     private val SLUG_OR_TAG = Regex("""^[a-z0-9][a-z0-9._+-]{0,39}$""")
+    // Strict SemVer per semver.org: prerelease identifiers are dot-separated, each
+    // either numeric with no leading zero (`0|[1-9]\d*`) or alphanumeric containing
+    // a non-digit. This rejects invalid forms the loose regex let through, e.g.
+    // `1.2.3-alpha..1` (empty identifier) and `1.2.3-01` (leading-zero numeric).
+    // Build identifiers are `[0-9A-Za-z-]+` (leading zeros allowed by the spec).
     private val SEMVER = Regex(
-        """^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$""",
+        """^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)""" +
+            """(?:-(?:0|[1-9]\d*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?""" +
+            """(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$""",
     )
 
     /** Required: name, description, license. Optional-but-validated: tags, metadata.version. */

--- a/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
@@ -1,0 +1,185 @@
+package dev.androidskills.ingest
+
+/**
+ * Result of splitting a `SKILL.md` into YAML frontmatter + Markdown body.
+ *
+ * The manifest is the **source of truth** for name/description/tags/license/slug
+ * (spec §3.2): these fields are parsed here and never edited via the API. The
+ * slug itself is the skill's directory name (handled at ingest time), not a
+ * frontmatter field.
+ *
+ * Parsing is a deliberately small YAML subset (scalars, block/flow lists, one
+ * level of nesting for `metadata:`) — enough for the defined frontmatter shape
+ * without pulling in a YAML dependency. Unknown fields are ignored.
+ */
+data class ParsedManifest(
+    val name: String,
+    val description: String,
+    val tags: List<String>,
+    val license: String?,
+    /** Raw `metadata.version` string, validated as SemVer by [ManifestValidator]. */
+    val version: String?,
+    val body: String,
+    /** True when the input had no `---` frontmatter block at all. */
+    val hadFrontmatter: Boolean,
+)
+
+/** A single per-field validation failure (spec §10). */
+data class FieldError(val field: String, val reason: String)
+
+object SkillManifestParser {
+
+    private val DELIM = Regex("""-{3,}\s*""")
+
+    /**
+     * Splits `content` into frontmatter fields + the markdown body. Never throws
+     * on a malformed/missing manifest — it returns empty fields and leaves
+     * validation to [ManifestValidator].
+     */
+    fun parse(content: String): ParsedManifest {
+        val src = content.removePrefix("\uFEFF").replace("\r\n", "\n").replace('\r', '\n')
+        val lines = src.split('\n')
+
+        var idx = 0
+        while (idx < lines.size && lines[idx].isBlank()) idx++
+
+        var hadFrontmatter = false
+        val frontmatter: String
+        if (idx < lines.size && DELIM.matches(lines[idx].trim()) && lines[idx].trim().all { it == '-' }) {
+            hadFrontmatter = true
+            idx++ // opening delimiter
+            val start = idx
+            while (idx < lines.size && !isDelim(lines[idx])) idx++
+            frontmatter = lines.subList(start, idx).joinToString("\n")
+            if (idx < lines.size) idx++ // closing delimiter
+        } else {
+            frontmatter = ""
+        }
+        val body = lines.subList(idx, lines.size).joinToString("\n").trim('\n')
+
+        val map = parseSimpleYaml(frontmatter)
+        val name = map.string("name")?.trim().orEmpty()
+        val description = map.string("description")?.trim().orEmpty()
+        val license = map.string("license")?.trim()?.takeIf { it.isNotEmpty() }
+        val tags = map.stringList("tags")
+        val version = (map["metadata"] as? Map<*, *>)?.string("version")?.trim()?.takeIf { it.isNotEmpty() }
+
+        return ParsedManifest(name, description, tags, license, version, body, hadFrontmatter)
+    }
+
+    private fun isDelim(line: String): Boolean {
+        val t = line.trim()
+        return t.isNotEmpty() && t.all { it == '-' } && t.length >= 3
+    }
+
+    // ---- minimal YAML subset ------------------------------------------------
+
+    private typealias YamlNode = MutableMap<String, Any?>
+
+    private fun parseSimpleYaml(text: String): YamlNode {
+        val root = LinkedHashMap<String, Any?>()
+        val lines = text.split('\n')
+        var i = 0
+        while (i < lines.size) {
+            val raw = lines[i]
+            if (raw.isBlank() || raw.trimStart().startsWith("#")) { i++; continue }
+            if (!raw.startsWith(" ")) { // top-level only
+                val colon = raw.indexOf(':')
+                if (colon >= 0) {
+                    val key = raw.substring(0, colon).trim()
+                    val value = raw.substring(colon + 1).trim()
+                    if (value.isEmpty()) {
+                        val (node, next) = parseBlock(lines, i + 1)
+                        if (node != null) root[key] = node
+                        i = next
+                        continue
+                    } else if (value.startsWith("[") && value.endsWith("]")) {
+                        root[key] = splitFlowList(value.substring(1, value.length - 1))
+                    } else {
+                        root[key] = unquote(value)
+                    }
+                }
+            }
+            i++
+        }
+        return root
+    }
+
+    /**
+     * Reads consecutive indented lines after a `key:` with no inline value.
+     * Returns either a List<String> (block sequence) or a Map (block mapping),
+     * plus the index of the first line that belongs to the parent again.
+     */
+    private fun parseBlock(lines: List<String>, start: Int): Pair<Any?, Int> {
+        val items = mutableListOf<String>()
+        val map = LinkedHashMap<String, Any?>()
+        var mode: Char? = null // '-' sequence, ':' mapping
+        var i = start
+        while (i < lines.size) {
+            val raw = lines[i]
+            if (raw.isBlank()) { i++; continue }
+            if (!raw.startsWith(" ")) break // back to parent indent
+            val trimmed = raw.trim()
+            if (trimmed.startsWith("#")) { i++; continue }
+            when {
+                trimmed.startsWith("- ") || trimmed == "-" -> {
+                    if (mode == null) mode = '-'
+                    items += unquote(trimmed.removePrefix("-").trim())
+                }
+                trimmed.contains(':') -> {
+                    if (mode == null) mode = ':'
+                    val c = trimmed.indexOf(':')
+                    map[trimmed.substring(0, c).trim()] = unquote(trimmed.substring(c + 1).trim())
+                }
+                else -> break
+            }
+            i++
+        }
+        val result: Any? = when (mode) {
+            '-' -> items
+            ':' -> map
+            else -> null
+        }
+        return result to i
+    }
+
+    private fun splitFlowList(inner: String): List<String> =
+        if (inner.isBlank()) emptyList()
+        else inner.split(',').map { unquote(it.trim()) }.filter { it.isNotEmpty() }
+
+    private fun unquote(s: String): String {
+        if (s.length >= 2) {
+            val q = s.first()
+            if ((q == '"' || q == '\'') && s.last() == q) return s.substring(1, s.length - 1)
+        }
+        return s
+    }
+
+    private fun Map<*, *>.string(key: String): String? = (this[key] as? String)
+    private fun Map<*, *>.stringList(key: String): List<String> =
+        (this[key] as? List<*>)?.mapNotNull { it?.toString()?.trim()?.takeIf { v -> v.isNotEmpty() } } ?: emptyList()
+}
+
+object ManifestValidator {
+    private val SLUG_OR_TAG = Regex("""^[a-z0-9][a-z0-9._+-]{0,39}$""")
+    private val SEMVER = Regex(
+        """^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$""",
+    )
+
+    /** Required: name, description, license. Optional-but-validated: tags, metadata.version. */
+    fun validate(m: ParsedManifest): List<FieldError> {
+        val errors = mutableListOf<FieldError>()
+        if (m.name.isBlank()) errors += FieldError("name", "is required")
+        if (m.description.isBlank()) errors += FieldError("description", "is required")
+        if (m.license.isNullOrBlank()) errors += FieldError("license", "is required")
+        m.tags.forEachIndexed { i, tag ->
+            if (!SLUG_OR_TAG.matches(tag)) {
+                errors += FieldError("tags[$i]", "must be lowercase alnum/._+- (max 40)")
+            }
+        }
+        if (m.version != null && !SEMVER.matches(m.version)) {
+            errors += FieldError("metadata.version", "must be valid SemVer")
+        }
+        return errors
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
@@ -8,9 +8,13 @@ package dev.androidskills.ingest
  * slug itself is the skill's directory name (handled at ingest time), not a
  * frontmatter field.
  *
- * Parsing is a deliberately small YAML subset (scalars, block/flow lists, one
- * level of nesting for `metadata:`) — enough for the defined frontmatter shape
- * without pulling in a YAML dependency. Unknown fields are ignored.
+ * Parsing is a deliberately small YAML subset (scalars, block & flow lists, one
+ * level of nesting for `metadata:`, and block scalars `|` / `>`) — enough for
+ * the defined frontmatter shape without pulling in a YAML dependency. It never
+ * *silently corrupts* an unsupported form: anything it can't structure is left
+ * as a raw scalar and surfaces as a validation error (spec §10), since a
+ * half-parsed source-of-truth file is worse than a rejected one. Unknown keys
+ * are ignored for forward compatibility.
  */
 data class ParsedManifest(
     val name: String,
@@ -45,7 +49,7 @@ object SkillManifestParser {
 
         var hadFrontmatter = false
         val frontmatter: String
-        if (idx < lines.size && DELIM.matches(lines[idx].trim()) && lines[idx].trim().all { it == '-' }) {
+        if (idx < lines.size && isDelim(lines[idx])) {
             hadFrontmatter = true
             idx++ // opening delimiter
             val start = idx
@@ -69,7 +73,7 @@ object SkillManifestParser {
 
     private fun isDelim(line: String): Boolean {
         val t = line.trim()
-        return t.isNotEmpty() && t.all { it == '-' } && t.length >= 3
+        return t.isNotEmpty() && t.length >= 3 && t.all { it == '-' }
     }
 
     // ---- minimal YAML subset ------------------------------------------------
@@ -83,26 +87,95 @@ object SkillManifestParser {
         while (i < lines.size) {
             val raw = lines[i]
             if (raw.isBlank() || raw.trimStart().startsWith("#")) { i++; continue }
-            if (!raw.startsWith(" ")) { // top-level only
+            if (!raw.startsWith(" ")) { // top-level keys only
                 val colon = raw.indexOf(':')
                 if (colon >= 0) {
                     val key = raw.substring(0, colon).trim()
                     val value = raw.substring(colon + 1).trim()
-                    if (value.isEmpty()) {
-                        val (node, next) = parseBlock(lines, i + 1)
-                        if (node != null) root[key] = node
-                        i = next
-                        continue
-                    } else if (value.startsWith("[") && value.endsWith("]")) {
-                        root[key] = splitFlowList(value.substring(1, value.length - 1))
-                    } else {
-                        root[key] = unquote(value)
+                    when {
+                        isQuoted(value) -> { root[key] = unquote(value); i++ }
+                        isBlockScalarIndicator(value) -> {
+                            val (scalar, next) = parseBlockScalar(lines, i + 1, value)
+                            root[key] = scalar
+                            i = next
+                        }
+                        value.isEmpty() -> {
+                            val (node, next) = parseBlock(lines, i + 1)
+                            if (node != null) root[key] = node
+                            i = next
+                        }
+                        value.startsWith("[") && value.endsWith("]") -> {
+                            root[key] = splitFlowList(value.substring(1, value.length - 1)); i++
+                        }
+                        else -> { root[key] = unquote(value); i++ }
                     }
+                    continue
                 }
             }
             i++
         }
         return root
+    }
+
+    private fun isQuoted(s: String): Boolean =
+        s.length >= 2 && (s.first() == '"' || s.first() == '\'') && s.last() == s.first()
+
+    /** `|`, `|-`, `|+`, `>`, `>-`, `>+`, `|2`, … — a block scalar indicator. */
+    private fun isBlockScalarIndicator(s: String): Boolean =
+        s.isNotEmpty() && (s.first() == '|' || s.first() == '>') &&
+            s.drop(1).all { it in "+-0123456789" }
+
+    /**
+     * Reads the indented block following a `key: |` / `key: >` indicator.
+     * Returns the scalar text and the index of the first line back at the
+     * parent indent. With no indented content, returns "" (so a required field
+     * like `description: |` with nothing under it fails validation rather than
+     * being stored as the literal string "|").
+     */
+    private fun parseBlockScalar(lines: List<String>, start: Int, indicator: String): Pair<String, Int> {
+        val literal = indicator.first() == '|'
+        val chomp = when {
+            indicator.contains('-') -> '-' // strip
+            indicator.contains('+') -> '+' // keep
+            else -> 'c' // clip (default)
+        }
+        val content = mutableListOf<String>()
+        var i = start
+        var blockIndent = -1
+        while (i < lines.size) {
+            val line = lines[i]
+            if (line.isBlank()) { content.add(""); i++; continue } // tentative trailing/blank line
+            val indent = line.takeWhile { it == ' ' }.length
+            if (indent == 0) break // parent level again
+            if (blockIndent < 0) blockIndent = indent
+            if (indent < blockIndent) break
+            content.add(line.substring(blockIndent)) // dedent, keep extra indent as text
+            i++
+        }
+        // Drop trailing blank lines collected past the block (unless `+` keeps them).
+        while (content.isNotEmpty() && content.last().isEmpty() && chomp != '+') {
+            content.removeAt(content.size - 1)
+        }
+        val body = if (literal) {
+            content.joinToString("\n")
+        } else {
+            // Folded: join consecutive non-empty lines with a space; blank line → newline.
+            val sb = StringBuilder()
+            for (l in content) {
+                if (l.isEmpty()) sb.append('\n')
+                else {
+                    if (sb.isNotEmpty() && !sb.endsWith('\n')) sb.append(' ')
+                    sb.append(l)
+                }
+            }
+            sb.toString()
+        }
+        val trailing = when (chomp) {
+            '-' -> ""
+            '+' -> "\n"
+            else -> if (body.isNotEmpty()) "\n" else ""
+        }
+        return (body + trailing) to i
     }
 
     /**

--- a/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
@@ -26,6 +26,12 @@ data class ParsedManifest(
     val body: String,
     /** True when the input had no `---` frontmatter block at all. */
     val hadFrontmatter: Boolean,
+    /**
+     * Structured-parse problems found while reading the frontmatter (e.g. a
+     * known field in an unsupported form). Surfaced by [ManifestValidator.validate]
+     * so a malformed source-of-truth manifest is rejected, never silently coerced.
+     */
+    val parseErrors: List<FieldError> = emptyList(),
 )
 
 /** A single per-field validation failure (spec §10). */
@@ -66,9 +72,19 @@ object SkillManifestParser {
         val description = map.string("description")?.trim().orEmpty()
         val license = map.string("license")?.trim()?.takeIf { it.isNotEmpty() }
         val tags = map.stringList("tags")
+        // §10: tags must be well-formed if present. A scalar/malformed value
+        // (e.g. `tags: android`, or an unterminated `[a, b`) parses to a non-List
+        // node and stringList() returns empty — without this check the bad field
+        // would be silently dropped. Flag it so the validator rejects the manifest.
+        val parseErrors = buildList {
+            val rawTags = map["tags"]
+            if (rawTags != null && rawTags !is List<*>) {
+                add(FieldError("tags", "must be a list (block sequence or [a, b] flow list)"))
+            }
+        }
         val version = (map["metadata"] as? Map<*, *>)?.string("version")?.trim()?.takeIf { it.isNotEmpty() }
 
-        return ParsedManifest(name, description, tags, license, version, body, hadFrontmatter)
+        return ParsedManifest(name, description, tags, license, version, body, hadFrontmatter, parseErrors)
     }
 
     private fun isDelim(line: String): Boolean {
@@ -248,6 +264,9 @@ object ManifestValidator {
     /** Required: name, description, license. Optional-but-validated: tags, metadata.version. */
     fun validate(m: ParsedManifest): List<FieldError> {
         val errors = mutableListOf<FieldError>()
+        // Parser-level problems first (e.g. a known field in an unsupported form),
+        // so a malformed source-of-truth manifest is rejected wholesale (§10).
+        errors += m.parseErrors
         if (m.name.isBlank()) errors += FieldError("name", "is required")
         if (m.description.isBlank()) errors += FieldError("description", "is required")
         if (m.license.isNullOrBlank()) errors += FieldError("license", "is required")

--- a/api/src/main/kotlin/dev/androidskills/ingest/SkillPaths.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/SkillPaths.kt
@@ -1,0 +1,38 @@
+package dev.androidskills.ingest
+
+/**
+ * Validates a skill-file path stored in / written from `skill_files.path`.
+ *
+ * Paths are attacker-influenced once ingest accepts repo/upload trees, so every
+ * path that becomes a [java.util.zip.ZipEntry] name or a [dev.androidskills.storage.FileStore]
+ * key must be a normalised, relative, POSIX path that cannot escape the skill
+ * root — otherwise a `../` entry enables Zip Slip (writing outside the consumer's
+ * skills dir) or a key that escapes the store root.
+ *
+ * Returns the cleaned path on success, or `null` if the path is unsafe (the
+ * caller decides whether to reject the whole file or skip it).
+ */
+object SkillPaths {
+    private val SEGMENT = Regex("""[A-Za-z0-9][A-Za-z0-9._-]*""")
+
+    /** Maximum depth under a skill root (references/.../x.md etc.). */
+    private const val MAX_DEPTH = 16
+
+    fun safeRelativeOrNull(raw: String): String? {
+        if (raw.isBlank()) return null
+        if (raw.contains('\\') || raw.startsWith('/')) return null // posix only, not absolute
+        if (raw.contains("\u0000")) return null
+        val parts = raw.split('/').filter { it.isNotEmpty() }
+        if (parts.isEmpty() || parts.size > MAX_DEPTH) return null
+        for (segment in parts) {
+            if (segment == "." || segment == "..") return null
+            if (!SEGMENT.matches(segment)) return null
+            if (segment.length > 255) return null
+        }
+        return parts.joinToString("/")
+    }
+
+    /** Throws on an unsafe path — for write paths where silent skipping would hide bugs. */
+    fun requireSafe(raw: String, field: String = "path"): String =
+        safeRelativeOrNull(raw) ?: throw IllegalArgumentException("unsafe $field: '$raw'")
+}

--- a/api/src/main/kotlin/dev/androidskills/ingest/Tokens.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/Tokens.kt
@@ -1,0 +1,26 @@
+package dev.androidskills.ingest
+
+/**
+ * Order-of-magnitude token estimate (spec §5). Intentionally a coarse heuristic
+ * (`tokens ≈ ceil(utf8_bytes / 4)`) surfaced as a **band** — every model
+ * tokenises differently, so a precise count would be false precision (§09).
+ */
+object Tokens {
+
+    /** ceil(utf8Bytes / 4). */
+    fun estimateUtf8Bytes(byteCount: Int): Int = (byteCount + 3) / 4
+
+    /** Token estimate for a UTF-8 string. */
+    fun estimate(text: String): Int = estimateUtf8Bytes(text.toByteArray(Charsets.UTF_8).size)
+
+    /**
+     * Band for a *total* token count (upfront + on-demand):
+     * `<1_000 → "100s"`, `<10_000 → "1k"`, `<100_000 → "10k"`, else `"100k"`.
+     */
+    fun band(total: Int): String = when {
+        total < 1_000 -> "100s"
+        total < 10_000 -> "1k"
+        total < 100_000 -> "10k"
+        else -> "100k"
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/util/Ids.kt
+++ b/api/src/main/kotlin/dev/androidskills/util/Ids.kt
@@ -1,0 +1,6 @@
+package dev.androidskills.util
+
+import java.util.UUID
+
+/** Generates a UUIDv4 string, the ID format for all TEXT-primary-key tables (spec §4). */
+fun newId(): String = UUID.randomUUID().toString()

--- a/api/src/main/kotlin/dev/androidskills/util/Json.kt
+++ b/api/src/main/kotlin/dev/androidskills/util/Json.kt
@@ -1,0 +1,13 @@
+package dev.androidskills.util
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Shared JSON configuration. Used both for Ktor ContentNegotiation and for
+ * serialising JSON-valued TEXT columns (e.g. `skills.tags`, `jobs.payload`).
+ */
+val appJson: Json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+    explicitNulls = false
+}

--- a/api/src/main/kotlin/dev/androidskills/util/Time.kt
+++ b/api/src/main/kotlin/dev/androidskills/util/Time.kt
@@ -1,0 +1,9 @@
+package dev.androidskills.util
+
+import java.time.Instant
+
+/**
+ * Returns the current instant as an ISO-8601 UTC string, e.g. `2026-06-17T20:00:00Z`.
+ * Used for every `created_at` / `updated_at` / timestamp TEXT column (spec §4).
+ */
+fun nowIso(): String = Instant.now().toString()

--- a/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
@@ -1,0 +1,171 @@
+package dev.androidskills
+
+import dev.androidskills.db.DEFAULT_CATEGORIES
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Categories
+import dev.androidskills.db.SkillFiles
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Users
+import dev.androidskills.db.Versions
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class MigrationTest {
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `migrates to v1 and creates every table`() {
+        Database.init(TestSupport.newConfig(dir))
+        transaction {
+            val tables = exec(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+            ) { rs ->
+                val out = mutableListOf<String>()
+                while (rs.next()) out += rs.getString(1)
+                out
+            } ?: emptyList()
+            listOf(
+                "users", "bundles", "categories", "skills", "skill_files", "versions",
+                "submissions", "stars", "sessions", "jobs", "audit_log", "reports", "schema_meta",
+            ).forEach { assertTrue("$it table missing: $tables") { tables.contains(it) } }
+        }
+    }
+
+    @Test
+    fun `schema_meta version is 1 after migration`() {
+        Database.init(TestSupport.newConfig(dir))
+        transaction {
+            val v = exec("SELECT value FROM schema_meta WHERE key='version'") { rs ->
+                rs.next(); rs.getString(1).toInt()
+            }
+            assertEquals(1, v)
+        }
+    }
+
+    @Test
+    fun `seeds the default category taxonomy including uncategorized`() {
+        Database.init(TestSupport.newConfig(dir))
+        transaction {
+            val slugs = Categories.selectAll().map { it[Categories.slug] }.toSet()
+            DEFAULT_CATEGORIES.forEach { (slug, _) ->
+                assertTrue("missing seeded category $slug") { slug in slugs }
+            }
+            assertTrue("uncategorized" in slugs)
+        }
+    }
+
+    @Test
+    fun `re-running init is idempotent`() {
+        val cfg = TestSupport.newConfig(dir)
+        Database.init(cfg)
+        Database.init(cfg) // second open must not duplicate or re-run v1
+        transaction {
+            assertEquals(DEFAULT_CATEGORIES.size, Categories.selectAll().toList().size)
+            val v = exec("SELECT value FROM schema_meta WHERE key='version'") { rs ->
+                rs.next(); rs.getString(1).toInt()
+            }
+            assertEquals(1, v)
+        }
+    }
+
+    @Test
+    fun `domain model round-trips and enforces unique slug`() {
+        Database.init(TestSupport.newConfig(dir))
+        val now = nowIso()
+        val uid = "00000000-0000-0000-0000-000000000001"
+        val bid = "00000000-0000-0000-0000-000000000002"
+        val sid = "00000000-0000-0000-0000-000000000003"
+        transaction {
+            Users.insert {
+                it[Users.id] = uid
+                it[Users.githubId] = 1
+                it[Users.handle] = "alice"
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+            Bundles.insert {
+                it[Bundles.id] = bid
+                it[Bundles.kind] = "zip"
+                it[Bundles.provenance] = "upload-abc"
+                it[Bundles.ownerUserId] = uid
+                it[Bundles.createdAt] = now
+            }
+            Skills.insert {
+                it[Skills.id] = sid
+                it[Skills.bundleId] = bid
+                it[Skills.slug] = "jetpack-mvi"
+                it[Skills.name] = "Jetpack MVI"
+                it[Skills.description] = "MVI scaffold"
+                it[Skills.version] = "1.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.tags] = """["android","kotlin"]"""
+                it[Skills.tokenBand] = "1k"
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+            SkillFiles.insert {
+                it[SkillFiles.id] = "00000000-0000-0000-0000-000000000004"
+                it[SkillFiles.skillId] = sid
+                it[SkillFiles.path] = "references/guide.md"
+                it[SkillFiles.size] = 42
+                it[SkillFiles.r2Key] = "skills/$sid/files/references/guide.md"
+            }
+            Versions.insert {
+                it[Versions.id] = "00000000-0000-0000-0000-000000000005"
+                it[Versions.skillId] = sid
+                it[Versions.version] = "1.0.0"
+                it[Versions.sourceRef] = "sha-1"
+                it[Versions.createdAt] = now
+            }
+        }
+        // Duplicate slug must be rejected by the unique index.
+        assertFailsWith<Exception> {
+            transaction {
+                Skills.insert {
+                    it[Skills.id] = "00000000-0000-0000-0000-000000000006"
+                    it[Skills.bundleId] = bid
+                    it[Skills.slug] = "jetpack-mvi" // duplicate
+                    it[Skills.name] = "Dup"
+                    it[Skills.description] = "x"
+                    it[Skills.version] = "1.0.0"
+                    it[Skills.versionSource] = "manifest"
+                    it[Skills.createdAt] = now
+                    it[Skills.updatedAt] = now
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `foreign keys are enforced`() {
+        Database.init(TestSupport.newConfig(dir))
+        assertFailsWith<Exception> {
+            transaction {
+                Skills.insert {
+                    it[Skills.id] = "00000000-0000-0000-0000-000000000010"
+                    it[Skills.bundleId] = "no-such-bundle"
+                    it[Skills.slug] = "orphan"
+                    it[Skills.name] = "Orphan"
+                    it[Skills.description] = "x"
+                    it[Skills.version] = "1.0.0"
+                    it[Skills.versionSource] = "manifest"
+                    it[Skills.createdAt] = nowIso()
+                    it[Skills.updatedAt] = nowIso()
+                }
+            }
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/ServerTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ServerTest.kt
@@ -4,14 +4,22 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ServerTest {
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
     @Test
     fun healthEndpointReturnsOk() = testApplication {
-        application { module() }
+        application { module(TestSupport.newConfig(dir)) }
         val response = client.get("/api/health")
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("\"ok\":true"))

--- a/api/src/test/kotlin/dev/androidskills/TestSupport.kt
+++ b/api/src/test/kotlin/dev/androidskills/TestSupport.kt
@@ -1,0 +1,18 @@
+package dev.androidskills
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** Shared test fixtures. Each test points the DB + FileStore at an isolated temp dir. */
+object TestSupport {
+    fun newConfig(dir: Path): AppConfig = AppConfig(
+        version = "test",
+        dbPath = dir.resolve("test.db"),
+        fileStoreDir = dir.resolve("files"),
+        llmBaseUrl = null,
+        llmApiKey = null,
+        llmModel = null,
+    )
+
+    fun tempDir(): Path = Files.createTempDirectory("asdb-test")
+}

--- a/api/src/test/kotlin/dev/androidskills/TestSupport.kt
+++ b/api/src/test/kotlin/dev/androidskills/TestSupport.kt
@@ -5,13 +5,14 @@ import java.nio.file.Path
 
 /** Shared test fixtures. Each test points the DB + FileStore at an isolated temp dir. */
 object TestSupport {
-    fun newConfig(dir: Path): AppConfig = AppConfig(
+    fun newConfig(dir: Path, seedDemo: Boolean = false): AppConfig = AppConfig(
         version = "test",
         dbPath = dir.resolve("test.db"),
         fileStoreDir = dir.resolve("files"),
         llmBaseUrl = null,
         llmApiKey = null,
         llmModel = null,
+        seedDemo = seedDemo,
     )
 
     fun tempDir(): Path = Files.createTempDirectory("asdb-test")

--- a/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
@@ -203,4 +203,67 @@ class PublicReadTest {
         val res = PublicQueries.search(all())
         assertFalse(res.items.any { it.slug == "room-migration-helper" })
     }
+
+    @Test
+    fun `historical version with missing archive is 404 not wrong-files`() {
+        // Plant a historical version whose archive object is absent.
+        val slug = "jetpack-compose-mvi"
+        val skillId = transaction { Skills.selectAll().where { Skills.slug eq slug }.single()[Skills.id] }
+        transaction {
+            dev.androidskills.db.Versions.insert {
+                it[dev.androidskills.db.Versions.id] = dev.androidskills.util.newId()
+                it[dev.androidskills.db.Versions.skillId] = skillId
+                it[dev.androidskills.db.Versions.version] = "0.1.0"
+                it[dev.androidskills.db.Versions.sourceRef] = "manifest:0.1.0"
+                it[dev.androidskills.db.Versions.r2ZipKey] = "skills/$skillId/versions/0.1.0.zip" // not in store
+                it[dev.androidskills.db.Versions.createdAt] = "2020-01-01T00:00:00Z" // older than the demo's 1.4.2
+            }
+        }
+        // Requesting the historical version must NOT fall back to current files.
+        assertFailsWith<ApiNotFoundException> {
+            PublicQueries.download(slug, "0.1.0", store)
+        }
+        // The current version still downloads fine (built on demand / from stored zip).
+        val cur = PublicQueries.download(slug, null, store)
+        assertTrue(cur.bytes.isNotEmpty())
+    }
+
+    @Test
+    fun `missing file bytes surface as a storage error not empty 200`() {
+        val slug = "jetpack-compose-mvi"
+        val key = transaction {
+            val row = dev.androidskills.db.SkillFiles.selectAll()
+                .where { dev.androidskills.db.SkillFiles.path eq "references/intent.md" }.single()
+            row[dev.androidskills.db.SkillFiles.r2Key]
+        }
+        // Corrupt storage: delete the object the DB references.
+        val path = dir.resolve("files").resolve(key)
+        java.nio.file.Files.deleteIfExists(path)
+        assertFailsWith<ApiStorageException> {
+            PublicQueries.fileContent(slug, "references/intent.md", store)
+        }
+    }
+
+    @Test
+    fun `bundles only expose published skills`() {
+        // Unlist one of bob's skills (zip bundle has retrofit + baseline-profile).
+        transaction {
+            Skills.update({ Skills.slug eq "retrofit-okhttp-config" }) { it[Skills.status] = "unlisted" }
+        }
+        val list = PublicQueries.bundles(1, 60)
+        list.items.forEach { assertTrue(it.skillCount >= 1) } // no zero-public bundles leaked
+
+        // Find bob's zip bundle and confirm detail hides the unlisted skill.
+        val bobBundle = list.items.first { it.owner.handle == "bob" }
+        val detail = PublicQueries.bundle(bobBundle.id)
+        assertFalse(detail.skills.any { it.slug == "retrofit-okhttp-config" })
+
+        // A bundle whose only skills are non-public is hidden (404).
+        transaction {
+            Skills.update({ Skills.bundleId eq bobBundle.id }) { it[Skills.status] = "unlisted" }
+        }
+        assertFailsWith<ApiNotFoundException> { PublicQueries.bundle(bobBundle.id) }
+        val list2 = PublicQueries.bundles(1, 60)
+        assertFalse(list2.items.any { it.id == bobBundle.id })
+    }
 }

--- a/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
@@ -53,6 +53,33 @@ class PublicReadTest {
     }
 
     @Test
+    fun `stats lastUpdated ignores non-public skills`() {
+        // lastUpdated must reflect only published skills, like indexed/contributors,
+        // so a freshly-touched unlisted/flagged skill can't move the public stat.
+        val before = PublicQueries.stats().lastUpdated
+        // Touch a published skill with a future timestamp, then unlist it.
+        transaction {
+            Skills.update({ Skills.slug eq "retrofit-okhttp-config" }) {
+                it[Skills.updatedAt] = "2099-12-31T23:59:59Z"
+            }
+        }
+        // While still published, the future timestamp wins.
+        assertEquals("2099-12-31T23:59:59Z", PublicQueries.stats().lastUpdated)
+        // Now unlist it — it must no longer surface in lastUpdated.
+        transaction {
+            Skills.update({ Skills.slug eq "retrofit-okhttp-config" }) {
+                it[Skills.status] = "unlisted"
+                it[Skills.updatedAt] = "2100-12-31T23:59:59Z"
+            }
+        }
+        val after = PublicQueries.stats().lastUpdated
+        assertTrue(
+            before == after || (after != null && after < "2100-12-31T23:59:59Z"),
+            "unlisted skill must not set lastUpdated; got $after (before=$before)",
+        )
+    }
+
+    @Test
     fun `categories list counts published skills`() {
         val cats = PublicQueries.categories()
         val total = cats.sumOf { it.count }

--- a/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
@@ -397,6 +397,34 @@ class PublicReadTest {
     }
 
     @Test
+    fun `fallback zip includes the SKILL manifest so the bundle is complete`() {
+        // Cursor review: buildZip streamed only skill_files, omitting the manifest.
+        // A downloadable bundle must contain SKILL.md (§5/§11). Force the fallback
+        // path and assert the zip has a SKILL.md entry carrying the readme body.
+        val slug = "jetpack-compose-mvi"
+        val row = transaction { Skills.selectAll().where { Skills.slug eq slug }.single() }
+        forceCurrentVersionFallback(row[Skills.id], row[Skills.version])
+
+        val dl = PublicQueries.download(slug, null, store)
+        val entries = java.util.zip.ZipInputStream(dl.bytes.inputStream()).use { zis ->
+            generateSequence { zis.nextEntry }.map { it.name }.toList()
+        }
+        assertTrue("SKILL.md" in entries, "zip missing SKILL.md; entries=$entries")
+        assertTrue(entries.containsAll(listOf("references/intent.md", "examples/CounterScreen.kt")))
+    }
+
+    @Test
+    fun `parsePageStrict rejects deep pagination beyond the ceiling`() {
+        assertEquals(1, PublicQueries.parsePageStrict(null))
+        assertEquals(1, PublicQueries.parsePageStrict("1"))
+        assertEquals(10_000, PublicQueries.parsePageStrict("10000"))
+        assertFailsWith<ApiValidationException> { PublicQueries.parsePageStrict("10001") }
+        assertFailsWith<ApiValidationException> { PublicQueries.parsePageStrict("2147483647") }
+        assertFailsWith<ApiValidationException> { PublicQueries.parsePageStrict("0") }
+        assertFailsWith<ApiValidationException> { PublicQueries.parsePageStrict("abc") }
+    }
+
+    @Test
     fun `missing file bytes surface as a storage error not empty 200`() {
         val slug = "jetpack-compose-mvi"
         val key = transaction {

--- a/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
@@ -4,6 +4,7 @@ import dev.androidskills.Database
 import dev.androidskills.TestSupport
 import dev.androidskills.db.Skills
 import dev.androidskills.storage.LocalFsStore
+import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -226,6 +227,87 @@ class PublicReadTest {
         // The current version still downloads fine (built on demand / from stored zip).
         val cur = PublicQueries.download(slug, null, store)
         assertTrue(cur.bytes.isNotEmpty())
+    }
+
+    @Test
+    fun `default download selects skills version not newest created_at`() {
+        // The public contract: no ?version= downloads the CURRENT version
+        // (skills.version), not "whichever versions row was inserted last".
+        val slug = "jetpack-compose-mvi"
+        val skillId = transaction { Skills.selectAll().where { Skills.slug eq slug }.single()[Skills.id] }
+        // Backfill a historical row dated in the FUTURE — newer than the current
+        // 1.4.2 row, with no stored archive. Selecting by newest created_at (the
+        // old behaviour) would pick this and 404; the contract must still hand
+        // back the current 1.4.2 archive.
+        transaction {
+            dev.androidskills.db.Versions.insert {
+                it[dev.androidskills.db.Versions.id] = dev.androidskills.util.newId()
+                it[dev.androidskills.db.Versions.skillId] = skillId
+                it[dev.androidskills.db.Versions.version] = "0.1.0"
+                it[dev.androidskills.db.Versions.sourceRef] = "manifest:0.1.0"
+                it[dev.androidskills.db.Versions.r2ZipKey] = "skills/$skillId/versions/0.1.0.zip" // not in store
+                it[dev.androidskills.db.Versions.createdAt] = "2099-01-01T00:00:00Z" // NEWER than current
+            }
+        }
+        val dl = PublicQueries.download(slug, null, store)
+        assertTrue(dl.filename.contains("1.4.2"), "expected current 1.4.2, got ${dl.filename}")
+        assertTrue(dl.bytes.isNotEmpty())
+    }
+
+    @Test
+    fun `fallback zip fails loudly on an unsafe stored path`() {
+        // When the current version has no stored archive, download() builds one
+        // from skill_files. An unsafe path (Zip Slip) must fail loudly, not be
+        // skipped to produce a truncated 200 zip.
+        val slug = "jetpack-compose-mvi"
+        val row = transaction { Skills.selectAll().where { Skills.slug eq slug }.single() }
+        val skillId = row[Skills.id]
+        forceCurrentVersionFallback(skillId, row[Skills.version])
+
+        val badKey = "skills/$skillId/files/escape.md"
+        store.put(badKey, "evil".toByteArray())
+        transaction {
+            dev.androidskills.db.SkillFiles.insert {
+                it[dev.androidskills.db.SkillFiles.id] = dev.androidskills.util.newId()
+                it[dev.androidskills.db.SkillFiles.skillId] = skillId
+                it[dev.androidskills.db.SkillFiles.path] = "../escape.md"
+                it[dev.androidskills.db.SkillFiles.size] = 4
+                it[dev.androidskills.db.SkillFiles.isBinary] = false
+                it[dev.androidskills.db.SkillFiles.r2Key] = badKey
+            }
+        }
+        assertFailsWith<ApiStorageException> { PublicQueries.download(slug, null, store) }
+    }
+
+    @Test
+    fun `fallback zip fails loudly on missing file bytes`() {
+        // A DB-referenced file whose bytes are gone is storage corruption — the
+        // build must fail loudly, not silently omit the entry from the archive.
+        val slug = "jetpack-compose-mvi"
+        val row = transaction { Skills.selectAll().where { Skills.slug eq slug }.single() }
+        val skillId = row[Skills.id]
+        forceCurrentVersionFallback(skillId, row[Skills.version])
+
+        transaction {
+            dev.androidskills.db.SkillFiles.insert {
+                it[dev.androidskills.db.SkillFiles.id] = dev.androidskills.util.newId()
+                it[dev.androidskills.db.SkillFiles.skillId] = skillId
+                it[dev.androidskills.db.SkillFiles.path] = "references/ghost.md"
+                it[dev.androidskills.db.SkillFiles.size] = 10
+                it[dev.androidskills.db.SkillFiles.isBinary] = false
+                // r2_key points at an object that was never written to the store.
+                it[dev.androidskills.db.SkillFiles.r2Key] = "skills/$skillId/files/references/ghost.md"
+            }
+        }
+        assertFailsWith<ApiStorageException> { PublicQueries.download(slug, null, store) }
+    }
+
+    /** Nulls the current version's r2_zip_key so download() falls back to buildZip. */
+    private fun forceCurrentVersionFallback(skillId: String, currentVersion: String) = transaction {
+        dev.androidskills.db.Versions.update({
+            (dev.androidskills.db.Versions.skillId eq skillId) and
+                (dev.androidskills.db.Versions.version eq currentVersion)
+        }) { it[dev.androidskills.db.Versions.r2ZipKey] = null }
     }
 
     @Test

--- a/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
@@ -184,6 +184,19 @@ class PublicReadTest {
     }
 
     @Test
+    fun `repeated downloads each increment installs`() {
+        // Each successful download must add exactly 1. Uses the atomic SQL increment
+        // (installs = installs + 1); the prior captured-value form could lose counts
+        // across overlapping transactions. Two sequential downloads → +2.
+        val slug = "coroutine-test-patterns"
+        val before = transaction { Skills.selectAll().where { Skills.slug eq slug }.single()[Skills.installs] }
+        PublicQueries.download(slug, null, store)
+        PublicQueries.download(slug, null, store)
+        val after = transaction { Skills.selectAll().where { Skills.slug eq slug }.single()[Skills.installs] }
+        assertEquals(before + 2, after, "each download must add exactly one install")
+    }
+
+    @Test
     fun `bundles list and detail`() {
         val list = PublicQueries.bundles(1, 60)
         assertEquals(2, list.total)
@@ -199,6 +212,25 @@ class PublicReadTest {
         assertTrue(alice.skillCount >= 1)
         assertTrue(alice.totalInstalls >= 0)
         assertFailsWith<ApiNotFoundException> { PublicQueries.author("nobody") }
+    }
+
+    @Test
+    fun `author with no public skills is hidden`() {
+        // The public author directory exposes only users with >=1 published skill.
+        // bob owns the seed's zip bundle (retrofit-okhttp-config + baseline-profile-gradle,
+        // both published). Unlist every skill in his bundle and bob — a registered
+        // user but no longer a public author — must 404, matching how the bundle
+        // index hides zero-public bundles. alice keeps her published skills.
+        val bobBundleId = transaction {
+            val bob = dev.androidskills.db.Users.selectAll()
+                .where { dev.androidskills.db.Users.handle eq "bob" }.single()[dev.androidskills.db.Users.id]
+            dev.androidskills.db.Bundles.selectAll().where { dev.androidskills.db.Bundles.ownerUserId eq bob }.single()[dev.androidskills.db.Bundles.id]
+        }
+        transaction {
+            Skills.update({ Skills.bundleId eq bobBundleId }) { it[Skills.status] = "unlisted" }
+        }
+        assertFailsWith<ApiNotFoundException> { PublicQueries.author("bob") }
+        assertTrue(PublicQueries.author("alice").skillCount >= 1)
     }
 
     @Test

--- a/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
@@ -5,6 +5,7 @@ import dev.androidskills.TestSupport
 import dev.androidskills.db.Skills
 import dev.androidskills.storage.LocalFsStore
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -258,10 +259,12 @@ class PublicReadTest {
     fun `fallback zip fails loudly on an unsafe stored path`() {
         // When the current version has no stored archive, download() builds one
         // from skill_files. An unsafe path (Zip Slip) must fail loudly, not be
-        // skipped to produce a truncated 200 zip.
+        // skipped to produce a truncated 200 zip — and the failed download must
+        // NOT bump installs (buildZip runs before the install counter).
         val slug = "jetpack-compose-mvi"
         val row = transaction { Skills.selectAll().where { Skills.slug eq slug }.single() }
         val skillId = row[Skills.id]
+        val before = installsOf(slug)
         forceCurrentVersionFallback(skillId, row[Skills.version])
 
         val badKey = "skills/$skillId/files/escape.md"
@@ -277,15 +280,18 @@ class PublicReadTest {
             }
         }
         assertFailsWith<ApiStorageException> { PublicQueries.download(slug, null, store) }
+        assertEquals(before, installsOf(slug), "installs must not change on a failed download")
     }
 
     @Test
     fun `fallback zip fails loudly on missing file bytes`() {
         // A DB-referenced file whose bytes are gone is storage corruption — the
-        // build must fail loudly, not silently omit the entry from the archive.
+        // build must fail loudly, not silently omit the entry from the archive,
+        // and the failed download must not bump installs.
         val slug = "jetpack-compose-mvi"
         val row = transaction { Skills.selectAll().where { Skills.slug eq slug }.single() }
         val skillId = row[Skills.id]
+        val before = installsOf(slug)
         forceCurrentVersionFallback(skillId, row[Skills.version])
 
         transaction {
@@ -300,7 +306,28 @@ class PublicReadTest {
             }
         }
         assertFailsWith<ApiStorageException> { PublicQueries.download(slug, null, store) }
+        assertEquals(before, installsOf(slug), "installs must not change on a failed download")
     }
+
+    @Test
+    fun `fallback zip fails loudly on an empty file set`() {
+        // A skill with no recorded files can't form an archive: buildZip must throw
+        // rather than return an empty 200 zip, and installs must not change.
+        val slug = "jetpack-compose-mvi"
+        val row = transaction { Skills.selectAll().where { Skills.slug eq slug }.single() }
+        val skillId = row[Skills.id]
+        val before = installsOf(slug)
+        forceCurrentVersionFallback(skillId, row[Skills.version])
+        // Wipe every recorded file for the skill (skillId is our own seeded UUID).
+        transaction {
+            exec("DELETE FROM skill_files WHERE skill_id = '$skillId'")
+        }
+        assertFailsWith<ApiStorageException> { PublicQueries.download(slug, null, store) }
+        assertEquals(before, installsOf(slug), "installs must not change on a failed download")
+    }
+
+    private fun installsOf(slug: String): Int =
+        transaction { Skills.selectAll().where { Skills.slug eq slug }.single()[Skills.installs] }
 
     /** Nulls the current version's r2_zip_key so download() falls back to buildZip. */
     private fun forceCurrentVersionFallback(skillId: String, currentVersion: String) = transaction {

--- a/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
@@ -1,0 +1,206 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.Skills
+import dev.androidskills.storage.LocalFsStore
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the public read surface (spec §9 Public) directly over seeded demo
+ * data — the build-order step 2 "over seed data" milestone.
+ */
+class PublicReadTest {
+
+    private val dir = TestSupport.tempDir()
+    private val store = LocalFsStore(dir.resolve("files"))
+
+    @BeforeTest
+    fun setup() {
+        Database.init(TestSupport.newConfig(dir))
+        DemoData.seed(store)
+    }
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    private fun all() = SearchParams(
+        q = null, cats = emptyList(), tags = emptyList(), size = null,
+        verified = false, sort = "relevance", page = 1, pageSize = 60,
+    )
+
+    @Test
+    fun `stats reflect seeded data`() {
+        val stats = PublicQueries.stats()
+        assertEquals(6, stats.indexed) // all demo skills are published
+        assertTrue(stats.contributors >= 1)
+        assertNotNull(stats.lastUpdated)
+    }
+
+    @Test
+    fun `categories list counts published skills`() {
+        val cats = PublicQueries.categories()
+        val total = cats.sumOf { it.count }
+        assertEquals(6, total)
+        assertTrue(cats.any { it.slug == "jetpack-compose" && it.count == 1 })
+        assertTrue(cats.any { it.slug == "uncategorized" })
+    }
+
+    @Test
+    fun `search default verified-only excludes unverified`() {
+        val verifiedOnly = PublicQueries.search(all().copy(verified = true))
+        assertTrue(verifiedOnly.items.all { it.verified })
+        assertFalse(verifiedOnly.items.any { it.slug == "retrofit-okhttp-config" }) // unverified seed skill
+
+        val everything = PublicQueries.search(all().copy(verified = false))
+        assertTrue(everything.items.any { it.slug == "retrofit-okhttp-config" })
+    }
+
+    @Test
+    fun `search facets ignore their own dimension`() {
+        val res = PublicQueries.search(all().copy(cats = listOf("jetpack-compose")))
+        assertEquals(1, res.total) // only the compose skill
+        // category facet must still show OTHER categories (own-dimension excluded)
+        assertTrue(res.facets.categories.any { it.key != "jetpack-compose" })
+    }
+
+    @Test
+    fun `search by query matches name`() {
+        val res = PublicQueries.search(all().copy(q = "coroutine"))
+        assertEquals(1, res.total)
+        assertEquals("coroutine-test-patterns", res.items.first().slug)
+    }
+
+    @Test
+    fun `search size filter buckets by total tokens`() {
+        val small = PublicQueries.search(all().copy(size = "<2k"))
+        assertTrue(small.items.isNotEmpty())
+        assertTrue(small.items.none { it.tokenBand == "100k" })
+    }
+
+    @Test
+    fun `search sort by installs orders descending`() {
+        val res = PublicQueries.search(all().copy(sort = "installs"))
+        val installs = res.items.map { it.installs }
+        assertEquals(installs, installs.sortedDescending())
+    }
+
+    @Test
+    fun `detail returns manifest fields and 404 for unknown`() {
+        val d = PublicQueries.skillDetail("jetpack-compose-mvi")
+        assertEquals("Jetpack Compose MVI Scaffold", d.name)
+        assertEquals("Apache-2.0", d.license)
+        assertEquals("manifest", d.versionSource)
+        assertTrue(d.tags.contains("compose"))
+        assertTrue(d.fileCount > 0)
+        assertFailsWith<ApiNotFoundException> { PublicQueries.skillDetail("does-not-exist") }
+    }
+
+    @Test
+    fun `file tree and content work for a known file`() {
+        val tree = PublicQueries.fileTree("jetpack-compose-mvi")
+        assertTrue(tree.files.any { it.path == "references/intent.md" })
+        assertTrue(tree.tree.isNotEmpty())
+
+        val content = PublicQueries.fileContent("jetpack-compose-mvi", "references/intent.md", store)
+        assertFalse(content.downloadOnly)
+        assertTrue(content.content?.contains("Intents") == true)
+    }
+
+    @Test
+    fun `file content marks oversized as download-only`() {
+        // Plant an oversized text file beyond PREVIEW_LIMIT.
+        val slug = "jetpack-compose-mvi"
+        val skillId = transaction { Skills.selectAll().where { Skills.slug eq slug }.single()[Skills.id] }
+        val big = "x".repeat(PublicQueries.PREVIEW_LIMIT + 10)
+        val key = "skills/$skillId/files/references/big.md"
+        store.put(key, big.toByteArray())
+        transaction {
+            dev.androidskills.db.SkillFiles.insert {
+                it[dev.androidskills.db.SkillFiles.id] = dev.androidskills.util.newId()
+                it[dev.androidskills.db.SkillFiles.skillId] = skillId
+                it[dev.androidskills.db.SkillFiles.path] = "references/big.md"
+                it[dev.androidskills.db.SkillFiles.size] = big.length
+                it[dev.androidskills.db.SkillFiles.r2Key] = key
+            }
+        }
+        val res = PublicQueries.fileContent(slug, "references/big.md", store)
+        assertTrue(res.downloadOnly)
+        assertEquals(null, res.content)
+    }
+
+    @Test
+    fun `versions list current flag and download increments installs`() {
+        val v = PublicQueries.versions("jetpack-compose-mvi")
+        assertTrue(v.versions.any { it.current })
+        val before = transaction { Skills.selectAll().where { Skills.slug eq "jetpack-compose-mvi" }.single()[Skills.installs] }
+        val dl = PublicQueries.download("jetpack-compose-mvi", null, store)
+        assertTrue(dl.bytes.size > 4) // a real zip
+        assertEquals("application/zip", dl.contentType)
+        val after = transaction { Skills.selectAll().where { Skills.slug eq "jetpack-compose-mvi" }.single()[Skills.installs] }
+        assertEquals(before + 1, after)
+    }
+
+    @Test
+    fun `bundles list and detail`() {
+        val list = PublicQueries.bundles(1, 60)
+        assertEquals(2, list.total)
+        val first = list.items.first()
+        val detail = PublicQueries.bundle(first.id)
+        assertTrue(detail.skills.isNotEmpty())
+        assertFailsWith<ApiNotFoundException> { PublicQueries.bundle("nope") }
+    }
+
+    @Test
+    fun `author profile aggregates their skills`() {
+        val alice = PublicQueries.author("alice")
+        assertTrue(alice.skillCount >= 1)
+        assertTrue(alice.totalInstalls >= 0)
+        assertFailsWith<ApiNotFoundException> { PublicQueries.author("nobody") }
+    }
+
+    @Test
+    fun `timeline and trends return shaped data`() {
+        val tl = PublicQueries.timeline(1, 60)
+        assertTrue(tl.items.isNotEmpty())
+        assertTrue(tl.items.any { it.type == "publish" })
+        val tr = PublicQueries.trends()
+        assertTrue(tr.tokenMix.size == 4)
+        assertTrue(tr.tokenMix.sumOf { it.count } == 6)
+    }
+
+    @Test
+    fun `report requires a reason and is accepted when provided`() {
+        assertFailsWith<ApiValidationException> {
+            PublicQueries.createReport("jetpack-compose-mvi", reason = "   ", reporterId = null)
+        }
+        val ok = PublicQueries.createReport("jetpack-compose-mvi", reason = "spam", reporterId = null)
+        assertTrue(ok.accepted)
+    }
+
+    @Test
+    fun `unlisted skills are not publicly reachable`() {
+        transaction {
+            Skills.update({ Skills.slug eq "room-migration-helper" }) {
+                it[Skills.status] = "unlisted"
+            }
+        }
+        assertFailsWith<ApiNotFoundException> { PublicQueries.skillDetail("room-migration-helper") }
+        // and absent from search
+        val res = PublicQueries.search(all())
+        assertFalse(res.items.any { it.slug == "room-migration-helper" })
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/PublicRoutesHttpTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicRoutesHttpTest.kt
@@ -1,0 +1,70 @@
+package dev.androidskills.api
+
+import dev.androidskills.module
+import dev.androidskills.TestSupport
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** End-to-end route wiring: serialization, the error envelope, and streaming download. */
+class PublicRoutesHttpTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun skillsListDetailCategoriesAndErrorEnvelope() = testApplication {
+        application { module(TestSupport.newConfig(dir, seedDemo = true)) }
+
+        val list = client.get("/api/skills")
+        assertEquals(HttpStatusCode.OK, list.status)
+        assertTrue(list.bodyAsText().contains("\"items\""))
+
+        val detail = client.get("/api/skills/jetpack-compose-mvi")
+        assertEquals(HttpStatusCode.OK, detail.status)
+        assertTrue(detail.bodyAsText().contains("Jetpack Compose MVI Scaffold"))
+
+        val cats = client.get("/api/categories")
+        assertEquals(HttpStatusCode.OK, cats.status)
+        assertTrue(cats.bodyAsText().contains("jetpack-compose"))
+
+        // Unknown skill → 404 with the spec error envelope (not 403, not a stack trace).
+        val missing = client.get("/api/skills/does-not-exist")
+        assertEquals(HttpStatusCode.NotFound, missing.status)
+        val missingBody = missing.bodyAsText()
+        assertTrue(missingBody.contains("\"error\""))
+        assertTrue(missingBody.contains("\"not_found\""))
+
+        // Report with no reason → 422 with a per-field reason.
+        val report = client.post("/api/skills/jetpack-compose-mvi/report") {
+            headers[HttpHeaders.ContentType] = ContentType.Application.Json.toString()
+            setBody("{}")
+        }
+        assertEquals(HttpStatusCode.UnprocessableEntity, report.status)
+        assertTrue(report.bodyAsText().contains("reason"))
+    }
+
+    @Test
+    fun downloadStreamsZipWithAttachmentHeader() = testApplication {
+        application { module(TestSupport.newConfig(dir, seedDemo = true)) }
+        val res = client.get("/api/skills/jetpack-compose-mvi/download")
+        assertEquals(HttpStatusCode.OK, res.status)
+        assertTrue(res.headers[HttpHeaders.ContentType]!!.contains("application/zip"))
+        val cd = res.headers[HttpHeaders.ContentDisposition]
+        assertTrue(cd != null && cd.contains("attachment") && cd.contains(".zip"))
+        assertTrue(res.bodyAsText().isNotEmpty())
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/PublicRoutesSecurityTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicRoutesSecurityTest.kt
@@ -1,0 +1,93 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.SkillFiles
+import dev.androidskills.db.Skills
+import dev.androidskills.module
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Security-shaped HTTP checks: raw file previews must not execute as HTML on the
+ * site origin (fix: text/plain + nosniff), and malformed public query params must
+ * 422 rather than be silently coerced into a default (typed error envelope, §10).
+ */
+class PublicRoutesSecurityTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun rawHtmlPreviewIsServedAsTextPlainWithNoSniff() = testApplication {
+        // Seed + plant the malicious HTML file up front (committed to the DB file
+        // on disk) so the lazily-started app reads it from its own fresh connection.
+        val config = TestSupport.newConfig(dir, seedDemo = true)
+        Database.init(config)
+        DemoData.seed(dev.androidskills.storage.LocalFsStore(config.fileStoreDir))
+        val slug = "jetpack-compose-mvi"
+        val skillId = transaction { Skills.selectAll().where { Skills.slug eq slug }.single()[Skills.id] }
+        val relPath = "references/sneaky.html"
+        val key = "skills/$skillId/files/$relPath"
+        val payload = "<script>alert('xss')</script>"
+        java.nio.file.Files.createDirectories(config.fileStoreDir.resolve(key).parent)
+        java.nio.file.Files.write(config.fileStoreDir.resolve(key), payload.toByteArray())
+        transaction {
+            SkillFiles.insert {
+                it[SkillFiles.id] = newId()
+                it[SkillFiles.skillId] = skillId
+                it[SkillFiles.path] = relPath
+                it[SkillFiles.size] = payload.length
+                it[SkillFiles.isBinary] = false
+                it[SkillFiles.r2Key] = key
+            }
+        }
+
+        application { module(config) }
+        val res = client.get("/api/skills/$slug/files/$relPath?raw=1")
+        assertEquals(HttpStatusCode.OK, res.status)
+        val ct = res.headers[HttpHeaders.ContentType]!!
+        assertTrue("expected text/plain, got $ct") { ct.startsWith("text/plain", ignoreCase = true) }
+        assertEquals("nosniff", res.headers["X-Content-Type-Options"])
+        // Body carries the markup verbatim as text; the browser will not execute it.
+        assertTrue(res.bodyAsText().contains("<script>"))
+    }
+
+    @Test
+    fun malformedQueryParamsReturn422() = testApplication {
+        application { module(TestSupport.newConfig(dir, seedDemo = true)) }
+        client.get("/api/health") // ensure app is up
+        suspend fun assert422(qs: String) {
+            val r = client.get("/api/skills?$qs")
+            assertEquals(HttpStatusCode.UnprocessableEntity, r.status, "$qs -> ${r.status}")
+            val body = r.bodyAsText()
+            assertTrue(body.contains("\"error\""), "$qs should return the error envelope: $body")
+        }
+
+        assert422("verified=maybe")
+        assert422("size=huge")
+        assert422("sort=popularity")
+        assert422("page=0")
+        assert422("page=abc")
+        assert422("pageSize=9999")
+
+        // Sanity: well-formed params still work.
+        assertEquals(HttpStatusCode.OK, client.get("/api/skills?verified=false&sort=installs&page=1").status)
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/db/EnumsTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/db/EnumsTest.kt
@@ -1,0 +1,36 @@
+package dev.androidskills.db
+
+import dev.androidskills.api.ApiValidationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class EnumsTest {
+
+    @Test
+    fun `parses every valid value`() {
+        assertEquals(Role.admin, Role.parse("admin"))
+        assertEquals(Role.contributor, Role.parse("contributor"))
+        assertEquals(Role.member, Role.parse("member"))
+        assertEquals(UserStatus.active, UserStatus.parse("active"))
+        assertEquals(UserStatus.suspended, UserStatus.parse("suspended"))
+        assertEquals(SkillStatus.flagged, SkillStatus.parse("flagged"))
+        assertEquals(BundleKind.repo, BundleKind.parse("repo"))
+        assertEquals(VersionSource.git_head, VersionSource.parse("git_head"))
+        assertEquals(TokenBand.`100s`, TokenBand.parse("100s"))
+        assertEquals(TokenBand.`100k`, TokenBand.parse("100k"))
+    }
+
+    @Test
+    fun `rejects impossible states with a 422 validation error`() {
+        for (raw in listOf("superuser", "ROOT", "", "member ", "frozen")) {
+            val ex = assertFailsWith<ApiValidationException> { Role.parse(raw) }
+            assertTrue(ex.fields.containsKey("role"))
+        }
+        assertFailsWith<ApiValidationException> { SkillStatus.parse("quarantined") }
+        assertFailsWith<ApiValidationException> { TokenBand.parse("50k") }
+        assertFailsWith<ApiValidationException> { VersionSource.parse("magic") }
+        assertFailsWith<ApiValidationException> { BundleKind.parse("hg") }
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
@@ -103,6 +103,59 @@ class SkillManifestParserTest {
     }
 
     @Test
+    fun `scalar tags are rejected not silently dropped`() {
+        // §10: tags must be well-formed if present. `tags: android` is a scalar,
+        // not a list — the parser must flag it rather than return an empty list
+        // (which would silently accept the manifest while discarding its tags).
+        val md = """
+            ---
+            name: Scalar Tags
+            description: d
+            license: MIT
+            tags: android
+            ---
+            body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        assertTrue(m.tags.isEmpty(), "scalar tags should not be coerced into a list")
+        val errs = ManifestValidator.validate(m)
+        val tagErr = errs.firstOrNull { it.field == "tags" }
+        assertTrue(tagErr != null, "expected a tags validation error; got $errs")
+        assertTrue(tagErr.reason.contains("list", ignoreCase = true))
+    }
+
+    @Test
+    fun `malformed flow list tags are rejected`() {
+        val md = """
+            ---
+            name: Bad Flow
+            description: d
+            license: MIT
+            tags: [android, kotlin
+            ---
+            body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        assertTrue(ManifestValidator.validate(m).any { it.field == "tags" })
+    }
+
+    @Test
+    fun `empty flow list tags are accepted`() {
+        // `tags: []` is a valid (empty) list — not flagged as malformed.
+        val md = """
+            ---
+            name: Empty List
+            description: d
+            license: MIT
+            tags: []
+            ---
+            body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        assertEquals(emptyList(), ManifestValidator.validate(m).filter { it.field == "tags" })
+    }
+
+    @Test
     fun `parses literal block scalar description`() {
         val md = """
             ---

--- a/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
@@ -237,6 +237,55 @@ class SkillManifestParserTest {
         assertEquals("1.0.0", m.version, "version was dropped: ${m.version}")
         assertEquals("# Body", m.body.trim())
     }
+
+    @Test
+    fun `metadata flow map is rejected not silently dropped`() {
+        // An inline flow map `metadata: { version: 1.2.3 }` is an unsupported form
+        // here; the version must not vanish silently. Flag metadata so the
+        // source-of-truth manifest is rejected (§10).
+        val md = """
+            ---
+            name: Flow Meta
+            description: d
+            license: MIT
+            metadata: { version: 1.2.3 }
+            ---
+            body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        assertTrue(m.version == null, "flow-map version should not be silently parsed")
+        assertTrue(ManifestValidator.validate(m).any { it.field == "metadata" })
+    }
+
+    @Test
+    fun `block metadata mapping is still accepted`() {
+        val md = """
+            ---
+            name: Block Meta
+            description: d
+            license: MIT
+            metadata:
+              version: 1.2.3
+            ---
+            body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        assertEquals("1.2.3", m.version)
+        assertEquals(emptyList(), ManifestValidator.validate(m))
+    }
+
+    @Test
+    fun `semver rejects invalid prerelease identifiers`() {
+        fun versionErrors(v: String) = ManifestValidator.validate(
+            ParsedManifest("n", "d", emptyList(), "MIT", v, "", hadFrontmatter = true),
+        ).filter { it.field == "metadata.version" }
+        // Accepted (strict SemVer).
+        listOf("1.2.3", "1.2.3-alpha", "1.2.3-rc.1", "1.2.3-0", "0.1.0-rc.1", "1.0.0+build.5", "1.2.3-rc.1+exp.sha.5114f85")
+            .forEach { v -> assertEquals(emptyList(), versionErrors(v), "expected valid: $v") }
+        // Rejected.
+        listOf("1.2.3-alpha..1", "1.2.3-01", "1.2.3-", "1.2.3-..", "1.2.3-rc..1")
+            .forEach { v -> assertTrue(versionErrors(v).isNotEmpty(), "expected invalid: $v") }
+    }
 }
 
 class TokensTest {

--- a/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
@@ -101,6 +101,61 @@ class SkillManifestParserTest {
         )
         assertEquals(emptyList(), ManifestValidator.validate(m))
     }
+
+    @Test
+    fun `parses literal block scalar description`() {
+        val md = """
+            ---
+            name: Block Skill
+            description: |
+              First line of the description.
+              Second line, indented under the indicator.
+            license: MIT
+            ---
+            body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        assertTrue(m.description.contains("First line of the description"), "got: ${m.description}")
+        assertTrue(m.description.contains("Second line"))
+        // Must NOT be the literal indicator string "|".
+        assertTrue(m.description != "|")
+        assertEquals(emptyList(), ManifestValidator.validate(m))
+    }
+
+    @Test
+    fun `parses folded block scalar and chomping`() {
+        val md = """
+            ---
+            name: Folded
+            description: >-
+              folded
+              into one line
+            license: MIT
+            ---
+            body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        // Folded joins non-empty lines with a space; strip chomps the trailing newline.
+        assertEquals("folded into one line", m.description.trim())
+    }
+
+    @Test
+    fun `block scalar indicator with no content fails validation not silent pipe`() {
+        val md = """
+            ---
+            name: Empty
+            description: |
+            license: MIT
+            ---
+            body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        // No indented content under `|` → empty, which validation flags as missing
+        // (never the literal string "|").
+        assertTrue(m.description.isBlank())
+        val errs = ManifestValidator.validate(m).map { it.field }
+        assertTrue("description" in errs)
+    }
 }
 
 class TokensTest {

--- a/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
@@ -1,0 +1,132 @@
+package dev.androidskills.ingest
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SkillManifestParserTest {
+
+    @Test
+    fun `parses scalars block list metadata and body`() {
+        val md = """
+            ---
+            name: Jetpack MVI Scaffold
+            description: A predictable MVI baseline for Compose apps.
+            license: Apache-2.0
+            tags:
+              - android
+              - kotlin
+              - compose
+            metadata:
+              version: 1.2.3
+            ---
+            # Jetpack MVI Scaffold
+
+            ## Usage
+            Drop into `skills/` and wire your ViewModel.
+        """.trimIndent()
+
+        val m = SkillManifestParser.parse(md)
+        assertEquals("Jetpack MVI Scaffold", m.name)
+        assertEquals("A predictable MVI baseline for Compose apps.", m.description)
+        assertEquals("Apache-2.0", m.license)
+        assertEquals(listOf("android", "kotlin", "compose"), m.tags)
+        assertEquals("1.2.3", m.version)
+        assertTrue(m.hadFrontmatter)
+        assertTrue(m.body.startsWith("# Jetpack MVI Scaffold"))
+        assertTrue(m.body.contains("Drop into `skills/`"))
+    }
+
+    @Test
+    fun `parses flow list tags`() {
+        val md = """
+            ---
+            name: Flow Tags
+            description: d
+            license: MIT
+            tags: [android, kotlin, "multi-line"]
+            ---
+            body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        assertEquals(listOf("android", "kotlin", "multi-line"), m.tags)
+    }
+
+    @Test
+    fun `handles CRLF and BOM`() {
+        val bom = "\uFEFF"
+        val md = bom + "---\r\nname: X\r\ndescription: d\r\nlicense: MIT\r\n---\r\n# body\r\n"
+        val m = SkillManifestParser.parse(md)
+        assertEquals("X", m.name)
+        assertEquals("# body", m.body.trim())
+    }
+
+    @Test
+    fun `no frontmatter leaves whole content as body`() {
+        val m = SkillManifestParser.parse("# just markdown\nno yaml here")
+        assertEquals("", m.name)
+        assertEquals("", m.description)
+        assertEquals(null, m.license)
+        assertTrue(m.body.contains("just markdown"))
+        assertEquals(false, m.hadFrontmatter)
+    }
+
+    @Test
+    fun `validator flags missing required fields`() {
+        val m = ParsedManifest(name = "", description = "  ", tags = listOf("OK"), license = null, version = null, body = "", hadFrontmatter = true)
+        val fields = ManifestValidator.validate(m).map { it.field }.toSet()
+        assertTrue("name" in fields)
+        assertTrue("description" in fields)
+        assertTrue("license" in fields)
+    }
+
+    @Test
+    fun `validator flags bad tags and semver`() {
+        val m = ParsedManifest(
+            name = "N", description = "d", license = "MIT",
+            tags = listOf("good", "Bad Tag", "x".repeat(50)),
+            version = "not-semver",
+            body = "", hadFrontmatter = true,
+        )
+        val errs = ManifestValidator.validate(m)
+        assertTrue(errs.any { it.field.startsWith("tags[") })
+        assertTrue(errs.any { it.field == "metadata.version" })
+    }
+
+    @Test
+    fun `validator accepts a clean manifest`() {
+        val m = ParsedManifest(
+            name = "N", description = "d", license = "Apache-2.0",
+            tags = listOf("android", "kotlin"), version = "0.1.0-rc.1", body = "", hadFrontmatter = true,
+        )
+        assertEquals(emptyList(), ManifestValidator.validate(m))
+    }
+}
+
+class TokensTest {
+    @Test
+    fun `estimate is ceil bytes over 4`() {
+        // "abcd" = 4 bytes -> 1 token; "abcde" = 5 bytes -> 2 tokens
+        assertEquals(1, Tokens.estimate("abcd"))
+        assertEquals(2, Tokens.estimate("abcde"))
+        assertEquals(0, Tokens.estimate(""))
+    }
+
+    @Test
+    fun `estimate counts utf8 bytes`() {
+        // "€" is 3 UTF-8 bytes -> 1 token
+        assertEquals(1, Tokens.estimate("€"))
+    }
+
+    @Test
+    fun `bands bucket at 1k 10k 100k`() {
+        assertEquals("100s", Tokens.band(0))
+        assertEquals("100s", Tokens.band(999))
+        assertEquals("1k", Tokens.band(1_000))
+        assertEquals("1k", Tokens.band(9_999))
+        assertEquals("10k", Tokens.band(10_000))
+        assertEquals("10k", Tokens.band(99_999))
+        assertEquals("100k", Tokens.band(100_000))
+        assertEquals("100k", Tokens.band(9_999_999))
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/SkillManifestParserTest.kt
@@ -156,6 +156,34 @@ class SkillManifestParserTest {
         val errs = ManifestValidator.validate(m).map { it.field }
         assertTrue("description" in errs)
     }
+
+    @Test
+    fun `indented dashes inside a block scalar are content not a delimiter`() {
+        // In YAML a document separator sits at column 0; an indented `---` under
+        // `description: |` is scalar text. Treating it as the closing delimiter
+        // would truncate the frontmatter and drop license + metadata.version.
+        val md = """
+            ---
+            name: Dashes Skill
+            description: |
+              Line one.
+              ---
+              Line three after a dashed line.
+            license: Apache-2.0
+            metadata:
+              version: 1.0.0
+            ---
+            # Body
+        """.trimIndent()
+        val m = SkillManifestParser.parse(md)
+        assertTrue(m.hadFrontmatter)
+        assertTrue(m.description.contains("Line one."), "desc=${m.description}")
+        assertTrue(m.description.contains("---"), "the dashes belong to the description")
+        assertTrue(m.description.contains("Line three"))
+        assertEquals("Apache-2.0", m.license, "license was dropped: ${m.license}")
+        assertEquals("1.0.0", m.version, "version was dropped: ${m.version}")
+        assertEquals("# Body", m.body.trim())
+    }
 }
 
 class TokensTest {

--- a/api/src/test/kotlin/dev/androidskills/ingest/SkillPathsTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/SkillPathsTest.kt
@@ -1,0 +1,34 @@
+package dev.androidskills.ingest
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertFailsWith
+
+class SkillPathsTest {
+
+    @Test
+    fun `accepts normalised relative posix paths`() {
+        assertEquals("references/guide.md", SkillPaths.safeRelativeOrNull("references/guide.md"))
+        assertEquals("examples/a/b.kt", SkillPaths.safeRelativeOrNull("examples/a/b.kt"))
+        assertEquals("SKILL.md", SkillPaths.safeRelativeOrNull("SKILL.md"))
+    }
+
+    @Test
+    fun `rejects traversal absolute backslash and null`() {
+        assertNull(SkillPaths.safeRelativeOrNull("../etc/passwd"))
+        assertNull(SkillPaths.safeRelativeOrNull("a/../../b"))
+        assertNull(SkillPaths.safeRelativeOrNull("/etc/passwd"))
+        assertNull(SkillPaths.safeRelativeOrNull("a\\b"))
+        assertNull(SkillPaths.safeRelativeOrNull("a\u0000b"))
+        assertNull(SkillPaths.safeRelativeOrNull("./hidden"))
+        assertNull(SkillPaths.safeRelativeOrNull(""))
+        // Segment with only dots/symbols or spaces is rejected.
+        assertNull(SkillPaths.safeRelativeOrNull("a/ b.md"))
+    }
+
+    @Test
+    fun `requireSafe throws on unsafe path`() {
+        assertFailsWith<IllegalArgumentException> { SkillPaths.requireSafe("../escape") }
+    }
+}


### PR DESCRIPTION
## What this is

The first two milestones of `docs/backend-spec.md` §14 (Backend build order), implemented on `develop`:

1. **Migrations + domain model** (§4)
2. **Public read API** (§9 Public) over seed data

Plus two rounds of security/correctness hardening in response to review, and regression coverage. Steps 3–7 (auth, GitHub App + ingest, review worker, contributor flows, admin) are deliberately deferred per the hard constraint that steps 1–2 run with zero cloud setup; the `LlmClient` / `FileStore` abstractions are preserved for them.

## Commit narrative

| Commit | Scope |
|---|---|
| `757edae` step 1 | Forward-only migrations (`schema_meta.version`) + full domain model as Exposed `Table`s; default category taxonomy seeded |
| `1b7d3bd` ingest primitives | `SKILL.md` frontmatter parser (block & flow scalars/lists), `ManifestValidator`, `Tokens` heuristic band |
| `63798d3` step 2 | Public read API: stats, skills (search/facets/sort/page), detail, files, versions, download, categories, trends, timeline, bundles, authors, report |
| `9f72db0` hardening #1 | 8 review findings (XSS via raw preview, wrong-archive download, bundle leaks, Zip Slip, silent corruption, YAML block scalars, typed invariants, 422 param validation) |
| `153c8e8` hardening #2 | 3 more findings (default-download = current version not newest, fallback zip fails loudly, indented `---` in block scalar) |
| `ba8b1f5` P2 coverage | Failed-download installs unchanged + empty-file-set branch |
| `4db7f23` final | `stats.lastUpdated` scoped to published; dropped a duplicate install write |

## Product invariants honored (spec, easy to get wrong)

- **Manifest is source of truth:** name/description/tags/license/slug parsed from `SKILL.md`, never editable via the API.
- **Skills discovered only under a top-level `skills/`** — enforced at ingest (the parser is ingest-side; the read path consumes parsed rows).
- **Category is LLM-assigned**, never submitter-chosen.
- **Admin auth → 404 (not 403)** on every `/api/admin/*` — not yet wired (step 7), but the `ApiNotFoundException` plumbing this needs is already in place.
- **Token estimate is an order-of-magnitude band** (~100s/1k/10k/100k via chars/4), not a precise count.
- **External services stay behind interfaces:** `LlmClient` (stub) and `FileStore` (local-fs) — no cloud creds needed to build/run/test.

## Assumptions (please confirm)

- **Public visibility = `status='published'`.** `unlisted` (owner took down) and `flagged` (admin moderation) are both **non-public** — surfaced in the admin queue, not the index. The public "caution badge" is a separate axis: `verified=false`. (Resolved from an open question in round-1 review.)
- **`verified` default = true** on `/api/skills`; `verified=false` lifts the restriction to show everything (the "Verified only" toggle off). Unverified skills remain reachable per §3.5.
- **Search uses `LIKE`** over name/description/tags JSON. FTS5 is a future enhancement.
- **Timeline** is synthesized from `skills` publishes + `versions` (no events table yet); **trends'** `securityPassRate` / `submissionFunnel` are null/empty until the review worker (step 5) lands.
- **DB invariants are app-layer** (typed enums at the write boundary), not SQL `CHECK` — SQLite can't `ALTER ADD CONSTRAINT` and a table rebuild is disproportionate pre-release. Enum values map 1:1 to a `CHECK` clause if we later want DB-level enforcement (documented in `Enums.kt`).

## Test status

- `api/gradlew -p api build` ✅ (also `clean build`)
- **54 tests**, all green: migrations (6), public-read (24, incl. search/filter/facet/sort, detail, files incl. download-only, versions, download + failed-download invariants, bundles published-filtering, stats scoping), HTTP security (2: raw-as-text/plain + nosniff, 422s for malformed params), ingest (14: parser incl. block scalars + indented `---`, validator, tokens, paths), enums (2), server (1).
- Each fix in the hardening rounds has a targeted regression test (HTML-as-text-plain, historical-version 404, default-download-picks-current, fallback-zip storage errors, etc.). A throwaway probe confirmed the "failed download never bumps installs" invariant holds via Exposed transaction rollback.

## Run it

```bash
SEED_DEMO=1 api/gradlew -p api run   # http://localhost:8080, demo dataset seeded
```

Endpoints live, verified via `curl`: `/api/health`, `/api/stats`, `/api/skills`, `/api/skills/{slug}`, `/api/skills/{slug}/files/{path}?raw=1`, `/api/skills/{slug}/download` (streams a zip), `/api/categories`, plus the 422/404 error envelopes.

## Reviewer notes

- Seven small commits intended to review as a stack in order.
- No cloud credentials or secrets in the repo; `SEED_DEMO=1` is opt-in and only seeds an empty DB (prod stays clean).
- The Exposed 0.61 query DSL differs from older versions: `select { where }` trailing lambda is shadowed by `ColumnSet.select(columns)`, so predicates use `selectAll().where { }` and column projection uses `select(cols)` — called out in `PublicQueries.kt` so it doesn't surprise a reviewer.
