### PR TITLE
api: step 3 — auth (GitHub OAuth, DB sessions, /api/me, admin→404 gate)

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -29,6 +29,13 @@ dependencies {
     implementation(libs.exposed.jdbc)
     implementation(libs.sqlite.jdbc)
 
+    // HTTP client: GitHub OAuth (token exchange + user lookup) in prod.
+    // Tests use an in-process fake OAuthClient, so no network at test time.
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.contentNegotiation)
+
     testImplementation(kotlin("test"))
     testImplementation(ktorLibs.server.testHost)
+    testImplementation(ktorLibs.client.mock)
 }

--- a/api/src/main/kotlin/dev/androidskills/AppConfig.kt
+++ b/api/src/main/kotlin/dev/androidskills/AppConfig.kt
@@ -77,8 +77,10 @@ data class AppConfig(
  * @param sessionCookieDomain Optional cookie `Domain`; null = host-only.
  * @param sessionCookieSecure Adds the `Secure` flag. Relaxed for localhost dev.
  * @param bootstrapAdminGithubId Optional GitHub numeric id promoted to `admin`
- *   on upsert — the explicit first-admin bootstrap (spec leaves admin promotion
- *   to the admin queue in step 7; this is the cold-start affordance). Assumption.
+ *   on **first insert only** (a seed-only cold-start escape hatch; an existing
+ *   user keeps their current role on re-login). Spec leaves admin promotion to
+ *   the admin queue (step 7); this is just the bootstrap affordance. Unset once
+ *   the first admin exists. Assumption.
  */
 data class AuthConfig(
     val oauth: OAuthConfig?,

--- a/api/src/main/kotlin/dev/androidskills/AppConfig.kt
+++ b/api/src/main/kotlin/dev/androidskills/AppConfig.kt
@@ -21,6 +21,13 @@ data class AppConfig(
     val seedDemo: Boolean = false,
     val auth: AuthConfig = AuthConfig.disabled(),
 ) {
+    // P3-2: redact the LLM key (and rely on OAuthConfig.toString) so a logged
+    // AppConfig instance never spills a secret.
+    override fun toString(): String =
+        "AppConfig(version=$version, dbPath=$dbPath, fileStoreDir=$fileStoreDir, " +
+            "llmBaseUrl=$llmBaseUrl, llmApiKey=${if (llmApiKey == null) "null" else "***"}, " +
+            "llmModel=$llmModel, seedDemo=$seedDemo, auth=$auth)"
+
     companion object {
         fun fromEnv(): AppConfig {
             fun env(k: String) = System.getenv(k)?.takeIf { it.isNotBlank() }
@@ -34,9 +41,11 @@ data class AppConfig(
             // Secure cookies by default, but relax for plain-HTTP localhost so a dev
             // browser can actually log in locally (spec §7 wants Secure; the test
             // client and prod-over-HTTPS are unaffected). Overridable via env.
-            val secureDefault = !(publicBaseUrl.startsWith("http://localhost") ||
-                publicBaseUrl.startsWith("http://127.0.0.1") ||
-                publicBaseUrl.startsWith("http://[::1]"))
+            // P3-3: parse the URL host — startsWith("http://localhost") wrongly
+            // treated "http://localhost.evil.com" as localhost (Secure=false).
+            val host = runCatching { java.net.URI(publicBaseUrl).host }.getOrNull()
+            val localHosts = setOf("localhost", "127.0.0.1", "0.0.0.0", "[::1]", "::1")
+            val secureDefault = host == null || host !in localHosts
             return AppConfig(
                 version = env("APP_VERSION") ?: "0.0.1-local",
                 dbPath = dataDir.resolve("androidskills.db"),
@@ -92,4 +101,7 @@ data class AuthConfig(
     }
 }
 
-data class OAuthConfig(val clientId: String, val clientSecret: String)
+data class OAuthConfig(val clientId: String, val clientSecret: String) {
+    // P3-2: never leak the secret if a config instance is logged.
+    override fun toString() = "OAuthConfig(clientId=$clientId, clientSecret=***)"
+}

--- a/api/src/main/kotlin/dev/androidskills/AppConfig.kt
+++ b/api/src/main/kotlin/dev/androidskills/AppConfig.kt
@@ -5,9 +5,10 @@ import java.nio.file.Paths
 
 /**
  * Environment-driven config with local-dev defaults. The cloud-shaped values
- * (LLM endpoint, and later R2 credentials) are read from env / Kamal secrets in
- * prod and simply absent locally, which selects the stub/local implementations.
- * The HTTP port is owned by Ktor (application.conf / PORT), not this object.
+ * (LLM endpoint, R2 credentials, GitHub OAuth) are read from env / Kamal secrets
+ * in prod and simply absent locally, which selects the stub/local/disabled
+ * implementations. The HTTP port is owned by Ktor (application.conf / PORT),
+ * not this object.
  */
 data class AppConfig(
     val version: String,
@@ -18,11 +19,24 @@ data class AppConfig(
     val llmModel: String?,
     /** When true, a small demo dataset is seeded into an empty DB (local/dev only). */
     val seedDemo: Boolean = false,
+    val auth: AuthConfig = AuthConfig.disabled(),
 ) {
     companion object {
         fun fromEnv(): AppConfig {
             fun env(k: String) = System.getenv(k)?.takeIf { it.isNotBlank() }
             val dataDir = Paths.get(env("DATA_DIR") ?: "../data").toAbsolutePath().normalize()
+            val publicBaseUrl = env("PUBLIC_BASE_URL") ?: "http://localhost:8080"
+            val oauthClientId = env("GITHUB_OAUTH_CLIENT_ID")
+            val oauthClientSecret = env("GITHUB_OAUTH_CLIENT_SECRET")
+            val oauth = if (oauthClientId != null && oauthClientSecret != null) {
+                OAuthConfig(oauthClientId, oauthClientSecret)
+            } else null
+            // Secure cookies by default, but relax for plain-HTTP localhost so a dev
+            // browser can actually log in locally (spec §7 wants Secure; the test
+            // client and prod-over-HTTPS are unaffected). Overridable via env.
+            val secureDefault = !(publicBaseUrl.startsWith("http://localhost") ||
+                publicBaseUrl.startsWith("http://127.0.0.1") ||
+                publicBaseUrl.startsWith("http://[::1]"))
             return AppConfig(
                 version = env("APP_VERSION") ?: "0.0.1-local",
                 dbPath = dataDir.resolve("androidskills.db"),
@@ -31,7 +45,51 @@ data class AppConfig(
                 llmApiKey = env("LLM_API_KEY"),
                 llmModel = env("LLM_MODEL"),
                 seedDemo = env("SEED_DEMO")?.equals("1", ignoreCase = true) == true,
+                auth = AuthConfig(
+                    oauth = oauth,
+                    publicBaseUrl = publicBaseUrl,
+                    sessionCookieDomain = env("SESSION_COOKIE_DOMAIN"),
+                    sessionCookieSecure = env("SESSION_COOKIE_SECURE")?.let {
+                        it.equals("1", ignoreCase = true) || it.equals("true", ignoreCase = true)
+                    } ?: secureDefault,
+                    bootstrapAdminGithubId = env("BOOTSTRAP_ADMIN_GITHUB_ID")?.toLongOrNull(),
+                ),
             )
         }
     }
 }
+
+/**
+ * Auth configuration (spec §7, §13). [oauth] is `null` when GitHub OAuth creds
+ * are unset → auth is *disabled*: the start/callback routes report auth
+ * unavailable, no sessions can be created, and `/api/me` is always 401.
+ *
+ * @param publicBaseUrl Canonical site URL; used for the OAuth `redirect_uri`.
+ * @param sessionCookieDomain Optional cookie `Domain`; null = host-only.
+ * @param sessionCookieSecure Adds the `Secure` flag. Relaxed for localhost dev.
+ * @param bootstrapAdminGithubId Optional GitHub numeric id promoted to `admin`
+ *   on upsert — the explicit first-admin bootstrap (spec leaves admin promotion
+ *   to the admin queue in step 7; this is the cold-start affordance). Assumption.
+ */
+data class AuthConfig(
+    val oauth: OAuthConfig?,
+    val publicBaseUrl: String,
+    val sessionCookieDomain: String?,
+    val sessionCookieSecure: Boolean,
+    val bootstrapAdminGithubId: Long?,
+) {
+    companion object {
+        fun disabled() = AuthConfig(
+            oauth = null,
+            publicBaseUrl = "http://localhost:8080",
+            sessionCookieDomain = null,
+            sessionCookieSecure = false,
+            bootstrapAdminGithubId = null,
+        )
+
+        /** Auth is "configured" only when OAuth creds are present (spec §13). */
+        val AuthConfig.enabled: Boolean get() = oauth != null
+    }
+}
+
+data class OAuthConfig(val clientId: String, val clientSecret: String)

--- a/api/src/main/kotlin/dev/androidskills/AppConfig.kt
+++ b/api/src/main/kotlin/dev/androidskills/AppConfig.kt
@@ -95,9 +95,6 @@ data class AuthConfig(
             sessionCookieSecure = false,
             bootstrapAdminGithubId = null,
         )
-
-        /** Auth is "configured" only when OAuth creds are present (spec §13). */
-        val AuthConfig.enabled: Boolean get() = oauth != null
     }
 }
 

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -52,6 +52,15 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
     val llm: LlmClient = StubLlmClient()
     val (resolvedOauth, ghHttp) = resolveOauth(config.auth, oauth)
 
+    // P3-3: surface the resolved cookie posture once at boot — Secure/Domain drive
+    // auth correctness and a mis-set SESSION_COOKIE_DOMAIN is a silent footgun.
+    log.info(
+        "auth: oauth={}, sessionCookie secure={}, domain={}",
+        if (resolvedOauth.configured) "configured" else "disabled",
+        config.auth.sessionCookieSecure,
+        config.auth.sessionCookieDomain ?: "(host-only)",
+    )
+
     if (config.seedDemo && transaction { Skills.selectAll().count() == 0L }) {
         dev.androidskills.api.DemoData.seed(fileStore)
     }

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -2,13 +2,19 @@ package dev.androidskills
 
 import dev.androidskills.api.installApiErrorMapping
 import dev.androidskills.api.publicRoutes
+import dev.androidskills.auth.DisabledOAuthClient
+import dev.androidskills.auth.GitHubOAuthClient
+import dev.androidskills.auth.OAuthClient
+import dev.androidskills.auth.authRoutes
 import dev.androidskills.db.Skills
 import dev.androidskills.llm.LlmClient
 import dev.androidskills.llm.StubLlmClient
 import dev.androidskills.storage.FileStore
 import dev.androidskills.storage.LocalFsStore
+import io.ktor.client.HttpClient
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.install
 import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
@@ -22,8 +28,12 @@ import org.jetbrains.exposed.sql.transactions.transaction
 /**
  * Ktor application module (referenced from application.conf). The entrypoint is
  * io.ktor.server.netty.EngineMain (see main.kt).
+ *
+ * @param oauth Optional injected OAuth client (tests pass a fake). When null, a
+ *   real [GitHubOAuthClient] is built from env creds, or [DisabledOAuthClient]
+ *   when creds are absent (spec §13: "unset → auth disabled").
  */
-fun Application.module(config: AppConfig = AppConfig.fromEnv()) {
+fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClient? = null) {
     Database.init(config)
 
     install(ContentNegotiation) { json() }
@@ -32,10 +42,14 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv()) {
 
     val fileStore: FileStore = LocalFsStore(config.fileStoreDir)
     val llm: LlmClient = StubLlmClient()
+    val (resolvedOauth, ghHttp) = resolveOauth(config.auth, oauth)
 
     if (config.seedDemo && transaction { Skills.selectAll().count() == 0L }) {
         dev.androidskills.api.DemoData.seed(fileStore)
     }
+
+    // Close the GitHub HTTP client on shutdown (clients are long-lived; one per app).
+    if (ghHttp != null) monitor.subscribe(ApplicationStopped) { ghHttp.close() }
 
     routing {
         get("/api/health") {
@@ -46,11 +60,20 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv()) {
                     db = Database.journalMode(),
                     fileStore = fileStore.kind,
                     llm = llm.kind,
+                    auth = if (resolvedOauth.configured) "oauth" else "disabled",
                 ),
             )
         }
         publicRoutes(fileStore)
+        authRoutes(config, resolvedOauth)
     }
+}
+
+private fun resolveOauth(auth: AuthConfig, injected: OAuthClient?): Pair<OAuthClient, HttpClient?> {
+    injected?.let { return it to null }
+    val c = auth.oauth ?: return DisabledOAuthClient() to null
+    val http = GitHubOAuthClient.httpClient()
+    return GitHubOAuthClient(c.clientId, c.clientSecret, http) to http
 }
 
 @Serializable
@@ -60,4 +83,5 @@ data class HealthResponse(
     val db: String,
     val fileStore: String,
     val llm: String,
+    val auth: String,
 )

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -16,11 +16,19 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.install
+import io.ktor.server.application.log
 import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -51,6 +59,12 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
     // Close the GitHub HTTP client on shutdown (clients are long-lived; one per app).
     if (ghHttp != null) monitor.subscribe(ApplicationStopped) { ghHttp.close() }
 
+    // Sweep expired sessions so the table (and its Litestream replica) doesn't
+    // grow unbounded — lookups already ignore expired rows, but they're never
+    // deleted otherwise (P2-1). A startup sweep + hourly run on a self-cancelling
+    // scope; cancelled on ApplicationStopped.
+    startSessionPurge(this)
+
     routing {
         get("/api/health") {
             call.respond(
@@ -75,6 +89,24 @@ private fun resolveOauth(auth: AuthConfig, injected: OAuthClient?): Pair<OAuthCl
     val http = GitHubOAuthClient.httpClient()
     return GitHubOAuthClient(c.clientId, c.clientSecret, http) to http
 }
+
+private fun startSessionPurge(app: Application) {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val job = scope.launch {
+        runCatching { dev.androidskills.auth.SessionStore.purgeExpired() } // startup sweep
+        while (isActive) {
+            delay(SESSION_PURGE_INTERVAL_MS)
+            runCatching { dev.androidskills.auth.SessionStore.purgeExpired() }
+                .onFailure { app.log.warn("Session purge failed", it) }
+        }
+    }
+    app.monitor.subscribe(ApplicationStopped) {
+        job.cancel()
+        scope.cancel()
+    }
+}
+
+private const val SESSION_PURGE_INTERVAL_MS = 60L * 60 * 1000 // 1 hour
 
 @Serializable
 data class HealthResponse(

--- a/api/src/main/kotlin/dev/androidskills/api/Errors.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Errors.kt
@@ -31,6 +31,12 @@ data class ErrorResponse(val error: ErrorBody)
 /** 404 — unknown slug, unknown route for non-admins, missing resource. */
 class ApiNotFoundException(message: String = "Not found") : RuntimeException(message)
 
+/** 401 — no (valid) session; anonymous where a session is required (spec §7, §9). */
+class ApiUnauthorizedException(message: String = "Authentication required") : RuntimeException(message)
+
+/** 400 — malformed request / CSRF state mismatch. */
+class ApiBadRequestException(message: String = "Bad request") : RuntimeException(message)
+
 /** 422 — per-field validation failure (spec §10). */
 class ApiValidationException(
     val fields: Map<String, String>,
@@ -48,6 +54,12 @@ fun Application.installApiErrorMapping() {
         val log = LoggerFactory.getLogger("dev.androidskills.api.Errors")
         exception<ApiNotFoundException> { call, ex ->
             call.respond(HttpStatusCode.NotFound, ErrorResponse(ErrorBody("not_found", ex.message ?: "Not found")))
+        }
+        exception<ApiUnauthorizedException> { call, ex ->
+            call.respond(HttpStatusCode.Unauthorized, ErrorResponse(ErrorBody("unauthorized", ex.message ?: "Authentication required")))
+        }
+        exception<ApiBadRequestException> { call, ex ->
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse(ErrorBody("bad_request", ex.message ?: "Bad request")))
         }
         exception<ApiValidationException> { call, ex ->
             call.respond(

--- a/api/src/main/kotlin/dev/androidskills/auth/Auth.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/Auth.kt
@@ -3,7 +3,6 @@ package dev.androidskills.auth
 import dev.androidskills.AuthConfig
 import dev.androidskills.api.ApiNotFoundException
 import dev.androidskills.api.ApiUnauthorizedException
-import dev.androidskills.db.Role
 import io.ktor.http.Cookie
 import io.ktor.server.application.ApplicationCall
 import io.ktor.util.AttributeKey
@@ -125,6 +124,3 @@ internal fun newState(): String {
     stateRng.nextBytes(bytes)
     return bytes.joinToString("") { "%02x".format(it) }
 }
-
-/** Role ordering helper exposed for future contributor (`contributor`+) gates. */
-fun roleAtLeast(principal: Principal, min: Role): Boolean = principal.role.atLeast(min)

--- a/api/src/main/kotlin/dev/androidskills/auth/Auth.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/Auth.kt
@@ -58,15 +58,26 @@ internal fun clearSessionCookie(call: ApplicationCall, cfg: AuthConfig) {
     call.response.cookies.append(sessionCookie(SESSION_COOKIE, "", cfg, 0, io.ktor.util.date.GMTDate(0)))
 }
 
+/**
+ * The OAuth `state` cookie name. Over HTTPS we use the `__Host-` prefix, which
+ * the cookie jar treats as host-only + Secure + Path=/ + NO Domain — pinning
+ * the CSRF token to this exact host so a sibling-subdomain foothold or MITM
+ * can't plant it (login-CSRF, P2-3). Over plain-HTTP dev we drop the prefix
+ * (a `__Host-` cookie requires Secure and wouldn't be stored/sent) but still
+ * keep the cookie host-only (no Domain).
+ */
+internal fun stateCookieName(cfg: AuthConfig): String =
+    if (cfg.sessionCookieSecure) "__Host-as_oauth_state" else STATE_COOKIE
+
 internal fun setStateCookie(call: ApplicationCall, state: String, cfg: AuthConfig) {
-    call.response.cookies.append(sessionCookie(STATE_COOKIE, state, cfg, STATE_TTL_SECONDS.toInt(), null))
+    call.response.cookies.append(stateCookie(stateCookieName(cfg), state, cfg, STATE_TTL_SECONDS.toInt(), null))
 }
 
 internal fun clearStateCookie(call: ApplicationCall, cfg: AuthConfig) {
-    call.response.cookies.append(sessionCookie(STATE_COOKIE, "", cfg, 0, io.ktor.util.date.GMTDate(0)))
+    call.response.cookies.append(stateCookie(stateCookieName(cfg), "", cfg, 0, io.ktor.util.date.GMTDate(0)))
 }
 
-/** Builds a cookie with the spec's security flags: httpOnly + Secure + SameSite=Lax. */
+/** Session cookie: httpOnly + Secure + SameSite=Lax; keeps [AuthConfig.sessionCookieDomain] when set. */
 private fun sessionCookie(
     name: String, value: String, cfg: AuthConfig, maxAge: Int, expires: io.ktor.util.date.GMTDate?,
 ): Cookie = Cookie(
@@ -76,6 +87,27 @@ private fun sessionCookie(
     maxAge = maxAge,
     expires = expires,
     domain = cfg.sessionCookieDomain,
+    path = "/",
+    secure = cfg.sessionCookieSecure,
+    httpOnly = true,
+    extensions = mapOf("SameSite" to "Lax"),
+)
+
+/**
+ * State cookie: ALWAYS host-only — Domain is never set, so it can't be widened
+ * to a parent/sibling domain (P2-3 login-CSRF). Secure mirrors the session
+ * cookie; the `__Host-` prefix (when Secure) makes the host-only contract
+ * browser-enforced.
+ */
+private fun stateCookie(
+    name: String, value: String, cfg: AuthConfig, maxAge: Int, expires: io.ktor.util.date.GMTDate?,
+): Cookie = Cookie(
+    name = name,
+    value = value,
+    encoding = io.ktor.http.CookieEncoding.URI_ENCODING,
+    maxAge = maxAge,
+    expires = expires,
+    domain = null, // host-only always — never Domain on the CSRF state cookie
     path = "/",
     secure = cfg.sessionCookieSecure,
     httpOnly = true,

--- a/api/src/main/kotlin/dev/androidskills/auth/Auth.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/Auth.kt
@@ -82,9 +82,15 @@ private fun sessionCookie(
     extensions = mapOf("SameSite" to "Lax"),
 )
 
-/** 32 random bytes as lower-case hex = the OAuth `state` (CSRF token). */
+private val stateRng = java.security.SecureRandom()
+
+/** 32 random bytes as lower-case hex = the OAuth `state` (CSRF token).
+ *  Mirrors `SessionStore`'s token generation: [java.security.SecureRandom.nextBytes]
+ *  is the intended API for emitting opaque secrets; `getSeed`/`generateSeed`
+ *  produce *seed material* for seeding other RNGs, not session-style tokens. */
 internal fun newState(): String {
-    val bytes = java.security.SecureRandom.getSeed(32)
+    val bytes = ByteArray(32)
+    stateRng.nextBytes(bytes)
     return bytes.joinToString("") { "%02x".format(it) }
 }
 

--- a/api/src/main/kotlin/dev/androidskills/auth/Auth.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/Auth.kt
@@ -1,0 +1,92 @@
+package dev.androidskills.auth
+
+import dev.androidskills.AuthConfig
+import dev.androidskills.api.ApiNotFoundException
+import dev.androidskills.api.ApiUnauthorizedException
+import dev.androidskills.db.Role
+import io.ktor.http.Cookie
+import io.ktor.server.application.ApplicationCall
+import io.ktor.util.AttributeKey
+
+/**
+ * Per-request auth (spec §7). The session id lives in an httpOnly + Secure +
+ * SameSite=Lax cookie; the row is looked up in the DB on every request so that
+ * suspend/logout revoke immediately (architecture.md: why not stateless JWTs).
+ *
+ * [principal] is resolved lazily and memoized per call, so a handler that calls
+ * both `requireSession()` and later `principal()` hits the DB once. The cookie
+ * is *opaque* (a 256-bit random token) — it carries no claims and cannot be
+ * forged without the row.
+ */
+internal const val SESSION_COOKIE = "as_session"
+internal const val STATE_COOKIE = "as_oauth_state"
+internal const val STATE_TTL_SECONDS = 10 * 60L
+internal const val SESSION_MAX_AGE_SECONDS = 30 * 24 * 3_600L
+
+private class PrincipalBox { var resolved = false; var value: Principal? = null }
+private val PrincipalKey = AttributeKey<PrincipalBox>("asPrincipalBox")
+
+/** Resolves and memoizes the caller's principal (null if anonymous/expired/suspended). */
+suspend fun ApplicationCall.principal(): Principal? {
+    val box = attributes.getOrNull(PrincipalKey) ?: PrincipalBox().also { attributes.put(PrincipalKey, it) }
+    if (!box.resolved) {
+        val token = request.cookies[SESSION_COOKIE]
+        box.value = token?.let { SessionStore.lookup(it) }
+        box.resolved = true
+    }
+    return box.value
+}
+
+/** Session required → 401 when anonymous/expired/suspended. */
+suspend fun ApplicationCall.requireSession(): Principal =
+    principal() ?: throw ApiUnauthorizedException("Authentication required")
+
+/**
+ * Admin required → **404** for everyone who isn't an admin, including anonymous
+ * callers. Never 401/403: that would reveal the route exists (spec §7).
+ */
+suspend fun ApplicationCall.requireAdmin(): Principal =
+    principal()?.requireAdmin() ?: throw ApiNotFoundException("Not found")
+
+// ---- cookies --------------------------------------------------------------
+
+internal fun setSessionCookie(call: ApplicationCall, token: String, cfg: AuthConfig) {
+    call.response.cookies.append(sessionCookie(SESSION_COOKIE, token, cfg, SESSION_MAX_AGE_SECONDS.toInt(), null))
+}
+
+internal fun clearSessionCookie(call: ApplicationCall, cfg: AuthConfig) {
+    call.response.cookies.append(sessionCookie(SESSION_COOKIE, "", cfg, 0, io.ktor.util.date.GMTDate(0)))
+}
+
+internal fun setStateCookie(call: ApplicationCall, state: String, cfg: AuthConfig) {
+    call.response.cookies.append(sessionCookie(STATE_COOKIE, state, cfg, STATE_TTL_SECONDS.toInt(), null))
+}
+
+internal fun clearStateCookie(call: ApplicationCall, cfg: AuthConfig) {
+    call.response.cookies.append(sessionCookie(STATE_COOKIE, "", cfg, 0, io.ktor.util.date.GMTDate(0)))
+}
+
+/** Builds a cookie with the spec's security flags: httpOnly + Secure + SameSite=Lax. */
+private fun sessionCookie(
+    name: String, value: String, cfg: AuthConfig, maxAge: Int, expires: io.ktor.util.date.GMTDate?,
+): Cookie = Cookie(
+    name = name,
+    value = value,
+    encoding = io.ktor.http.CookieEncoding.URI_ENCODING,
+    maxAge = maxAge,
+    expires = expires,
+    domain = cfg.sessionCookieDomain,
+    path = "/",
+    secure = cfg.sessionCookieSecure,
+    httpOnly = true,
+    extensions = mapOf("SameSite" to "Lax"),
+)
+
+/** 32 random bytes as lower-case hex = the OAuth `state` (CSRF token). */
+internal fun newState(): String {
+    val bytes = java.security.SecureRandom.getSeed(32)
+    return bytes.joinToString("") { "%02x".format(it) }
+}
+
+/** Role ordering helper exposed for future contributor (`contributor`+) gates. */
+fun roleAtLeast(principal: Principal, min: Role): Boolean = principal.role.atLeast(min)

--- a/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import org.slf4j.LoggerFactory
 
 /**
  * Auth routes (spec §9 Auth):
@@ -21,6 +22,8 @@ import io.ktor.server.routing.route
  * When OAuth is unconfigured (spec §13), the start/callback endpoints report
  * auth unavailable (503) rather than crashing; `/api/me` is simply always 401.
  */
+private val logger = LoggerFactory.getLogger("dev.androidskills.auth.AuthRoutes")
+
 fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
     val auth = config.auth
     val redirectUri = "${auth.publicBaseUrl.trimEnd('/')}/api/auth/github/callback"
@@ -51,9 +54,18 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
             if (!constantTimeEquals(stateParam, stateCookie)) {
                 throw ApiBadRequestException("OAuth state mismatch")
             }
-            val tokens = oauth.exchange(code, redirectUri)
-            val ghUser = oauth.userInfo(tokens.accessToken)
-            val userId = UsersRepo.upsertFromGitHub(ghUser, auth.bootstrapAdminGithubId)
+            val userId = try {
+                val tokens = oauth.exchange(code, redirectUri)
+                val ghUser = oauth.userInfo(tokens.accessToken)
+                UsersRepo.upsertFromGitHub(ghUser, auth.bootstrapAdminGithubId)
+            } catch (e: OAuthException) {
+                // A normal OAuth failure (bad/expired code, GitHub error, revoked)
+                // is a client/auth error, not a server outage. Map to a controlled
+                // 400 with a stable code and clear the state cookie; log the detail.
+                logger.warn("GitHub OAuth callback failed: {}", e.message)
+                clearStateCookie(call, auth)
+                throw ApiBadRequestException("GitHub sign-in failed. Please try again.")
+            }
             val session = SessionStore.create(userId, SESSION_MAX_AGE_SECONDS)
             clearStateCookie(call, auth)
             setSessionCookie(call, session, auth)

--- a/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
@@ -47,30 +47,37 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
             val code = call.request.queryParameters["code"]
             val stateParam = call.request.queryParameters["state"]
             val stateCookie = call.request.cookies[STATE_COOKIE]
-            // CSRF: the state echoed by GitHub must match the cookie we set on start.
-            if (code.isNullOrBlank() || stateParam.isNullOrBlank() || stateCookie.isNullOrBlank()) {
-                throw ApiBadRequestException("Missing OAuth code/state")
-            }
-            if (!constantTimeEquals(stateParam, stateCookie)) {
-                throw ApiBadRequestException("OAuth state mismatch")
-            }
-            val userId = try {
-                val tokens = oauth.exchange(code, redirectUri)
-                val ghUser = oauth.userInfo(tokens.accessToken)
-                UsersRepo.upsertFromGitHub(ghUser, auth.bootstrapAdminGithubId)
-            } catch (e: OAuthException) {
-                // A normal OAuth failure (bad/expired code, GitHub error, revoked)
-                // is a client/auth error, not a server outage. Map to a controlled
-                // 400 with a stable code and clear the state cookie; log the detail.
-                logger.warn("GitHub OAuth callback failed: {}", e.message)
+            try {
+                // CSRF: the state echoed by GitHub must match the cookie we set on start.
+                if (code.isNullOrBlank() || stateParam.isNullOrBlank() || stateCookie.isNullOrBlank()) {
+                    throw ApiBadRequestException("Missing OAuth code/state")
+                }
+                if (!constantTimeEquals(stateParam, stateCookie)) {
+                    throw ApiBadRequestException("OAuth state mismatch")
+                }
+                val userId = try {
+                    val tokens = oauth.exchange(code, redirectUri)
+                    val ghUser = oauth.userInfo(tokens.accessToken)
+                    UsersRepo.upsertFromGitHub(ghUser, auth.bootstrapAdminGithubId)
+                } catch (e: OAuthException) {
+                    // GitHubOAuthClient translates every auth/network failure into
+                    // OAuthException, so a bad/expired code, a revoked token, or a
+                    // transient GitHub outage is a controlled 400 — never an opaque
+                    // 500. (DB/server errors still propagate as genuine 5xx.)
+                    logger.warn("GitHub OAuth callback failed: {}", e.message)
+                    throw ApiBadRequestException("GitHub sign-in failed. Please try again.")
+                }
+                val session = SessionStore.create(userId, SESSION_MAX_AGE_SECONDS)
+                setSessionCookie(call, session, auth)
+                // Redirect to the site root; the SPA/Astro picks up the session cookie.
+                call.respondRedirect(auth.publicBaseUrl)
+            } finally {
+                // The state cookie is single-use: clear it on EVERY outcome — success,
+                // auth failure (400), validation failure (400), or an unexpected 5xx —
+                // so a stale CSRF cookie can never be replayed. CancellationException
+                // still rethrows after the cookie is cleared. (P1-2 + P3-4.)
                 clearStateCookie(call, auth)
-                throw ApiBadRequestException("GitHub sign-in failed. Please try again.")
             }
-            val session = SessionStore.create(userId, SESSION_MAX_AGE_SECONDS)
-            clearStateCookie(call, auth)
-            setSessionCookie(call, session, auth)
-            // Redirect to the site root; the SPA/Astro picks up the session cookie.
-            call.respondRedirect(auth.publicBaseUrl)
         }
 
         post("auth/logout") {

--- a/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
@@ -1,0 +1,84 @@
+package dev.androidskills.auth
+
+import dev.androidskills.AppConfig
+import dev.androidskills.api.ApiBadRequestException
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+
+/**
+ * Auth routes (spec §9 Auth):
+ *  - GET  /api/auth/github/start    → 302 to GitHub (sets CSRF state cookie)
+ *  - GET  /api/auth/github/callback → exchange code, upsert user, set session cookie, redirect
+ *  - POST /api/auth/logout          → delete session row + clear cookie
+ *  - GET  /api/me                   → current user (401 if anonymous)
+ *
+ * When OAuth is unconfigured (spec §13), the start/callback endpoints report
+ * auth unavailable (503) rather than crashing; `/api/me` is simply always 401.
+ */
+fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
+    val auth = config.auth
+    val redirectUri = "${auth.publicBaseUrl.trimEnd('/')}/api/auth/github/callback"
+
+    route("api") {
+        get("auth/github/start") {
+            if (!oauth.configured) {
+                call.respond(HttpStatusCode.ServiceUnavailable, mapOf("error" to mapOf("code" to "auth_disabled", "message" to "GitHub OAuth is not configured")))
+                return@get
+            }
+            val state = newState()
+            setStateCookie(call, state, auth)
+            call.respondRedirect(oauth.authorizeUrl(state, redirectUri))
+        }
+
+        get("auth/github/callback") {
+            if (!oauth.configured) {
+                call.respond(HttpStatusCode.ServiceUnavailable, mapOf("error" to mapOf("code" to "auth_disabled", "message" to "GitHub OAuth is not configured")))
+                return@get
+            }
+            val code = call.request.queryParameters["code"]
+            val stateParam = call.request.queryParameters["state"]
+            val stateCookie = call.request.cookies[STATE_COOKIE]
+            // CSRF: the state echoed by GitHub must match the cookie we set on start.
+            if (code.isNullOrBlank() || stateParam.isNullOrBlank() || stateCookie.isNullOrBlank()) {
+                throw ApiBadRequestException("Missing OAuth code/state")
+            }
+            if (!constantTimeEquals(stateParam, stateCookie)) {
+                throw ApiBadRequestException("OAuth state mismatch")
+            }
+            val tokens = oauth.exchange(code, redirectUri)
+            val ghUser = oauth.userInfo(tokens.accessToken)
+            val userId = UsersRepo.upsertFromGitHub(ghUser, auth.bootstrapAdminGithubId)
+            val session = SessionStore.create(userId, SESSION_MAX_AGE_SECONDS)
+            clearStateCookie(call, auth)
+            setSessionCookie(call, session, auth)
+            // Redirect to the site root; the SPA/Astro picks up the session cookie.
+            call.respondRedirect(auth.publicBaseUrl)
+        }
+
+        post("auth/logout") {
+            val principal = call.requireSession()
+            SessionStore.delete(principal.sessionId)
+            clearSessionCookie(call, auth)
+            call.respond(mapOf("ok" to true))
+        }
+
+        get("me") {
+            val principal = call.requireSession()
+            call.respond(principal.toMe())
+        }
+    }
+}
+
+/** Constant-time string compare to avoid timing leaks on the state check. */
+private fun constantTimeEquals(a: String, b: String): Boolean {
+    if (a.length != b.length) return false
+    var diff = 0
+    for (i in a.indices) diff = diff or (a[i].code xor b[i].code)
+    return diff == 0
+}

--- a/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
@@ -46,7 +46,7 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
             }
             val code = call.request.queryParameters["code"]
             val stateParam = call.request.queryParameters["state"]
-            val stateCookie = call.request.cookies[STATE_COOKIE]
+            val stateCookie = call.request.cookies[stateCookieName(auth)]
             try {
                 // CSRF: the state echoed by GitHub must match the cookie we set on start.
                 if (code.isNullOrBlank() || stateParam.isNullOrBlank() || stateCookie.isNullOrBlank()) {

--- a/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
@@ -71,13 +71,17 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
                 }
                 val session = SessionStore.create(userId, SESSION_MAX_AGE_SECONDS)
                 setSessionCookie(call, session, auth)
+                // Clear the single-use state cookie BEFORE the redirect is committed —
+                // appending Set-Cookie after respondRedirect is engine-dependent and
+                // may be dropped on a real engine (NEW-2). (The finally below covers
+                // the throw paths; success clears here, before responding.)
+                clearStateCookie(call, auth)
                 // Redirect to the site root; the SPA/Astro picks up the session cookie.
                 call.respondRedirect(auth.publicBaseUrl)
             } finally {
-                // The state cookie is single-use: clear it on EVERY outcome — success,
-                // auth failure (400), validation failure (400), or an unexpected 5xx —
-                // so a stale CSRF cookie can never be replayed. CancellationException
-                // still rethrows after the cookie is cleared. (P1-2 + P3-4.)
+                // Throws (validation 400, auth-failure 400, or an unexpected 5xx):
+                // StatusPages responds AFTER this, so the Set-Cookie lands. The
+                // success path cleared the cookie itself, above (before its redirect).
                 clearStateCookie(call, auth)
             }
         }

--- a/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
@@ -2,6 +2,8 @@ package dev.androidskills.auth
 
 import dev.androidskills.AppConfig
 import dev.androidskills.api.ApiBadRequestException
+import dev.androidskills.api.ErrorBody
+import dev.androidskills.api.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
@@ -31,7 +33,7 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
     route("api") {
         get("auth/github/start") {
             if (!oauth.configured) {
-                call.respond(HttpStatusCode.ServiceUnavailable, mapOf("error" to mapOf("code" to "auth_disabled", "message" to "GitHub OAuth is not configured")))
+                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse(ErrorBody("auth_disabled", "GitHub OAuth is not configured")))
                 return@get
             }
             val state = newState()
@@ -41,7 +43,7 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
 
         get("auth/github/callback") {
             if (!oauth.configured) {
-                call.respond(HttpStatusCode.ServiceUnavailable, mapOf("error" to mapOf("code" to "auth_disabled", "message" to "GitHub OAuth is not configured")))
+                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse(ErrorBody("auth_disabled", "GitHub OAuth is not configured")))
                 return@get
             }
             val code = call.request.queryParameters["code"]

--- a/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
@@ -50,11 +50,13 @@ class GitHubOAuthClient(
             "code" to code,
             "redirect_uri" to redirectUri,
         ).formUrlEncode()
-        val resp: AccessTokenResponse = http.post("https://github.com/login/oauth/access_token") {
-            header("Accept", "application/json")
-            contentType(ContentType.Application.FormUrlEncoded)
-            setBody(form)
-        }.body()
+        val resp: AccessTokenResponse = oauth {
+            http.post("https://github.com/login/oauth/access_token") {
+                header("Accept", "application/json")
+                contentType(ContentType.Application.FormUrlEncoded)
+                setBody(form)
+            }.body()
+        }
         if (resp.error != null || resp.accessToken.isNullOrBlank()) {
             throw OAuthException("GitHub token exchange failed: ${resp.error ?: "no access_token"} (${resp.errorDescription ?: ""})")
         }
@@ -62,10 +64,12 @@ class GitHubOAuthClient(
     }
 
     override suspend fun userInfo(accessToken: String): GitHubUser {
-        val resp: GitHubUserResponse = http.get("https://api.github.com/user") {
-            header("Accept", "application/vnd.github+json")
-            header("Authorization", "Bearer $accessToken")
-        }.body()
+        val resp: GitHubUserResponse = oauth {
+            http.get("https://api.github.com/user") {
+                header("Accept", "application/vnd.github+json")
+                header("Authorization", "Bearer $accessToken")
+            }.body()
+        }
         if (resp.id <= 0L || resp.login.isBlank()) {
             throw OAuthException("GitHub user lookup returned no identity")
         }
@@ -86,6 +90,23 @@ class GitHubOAuthClient(
             expectSuccess = true
         }
     }
+}
+
+/**
+ * Wraps a GitHub HTTP call so the client's contract is uniform: any failure a
+ * caller could see (non-2xx via `expectSuccess`, DNS/connect/timeout, or a body
+ * parse error) becomes an [OAuthException]. Cancellation is preserved. This lets
+ * the route catch one typed exception for all auth/network failures instead of
+ * leaking `ResponseException`/`IOException` to the global 500 handler (P1-2).
+ */
+private suspend inline fun <T> oauth(crossinline block: suspend () -> T): T = try {
+    block()
+} catch (e: kotlinx.coroutines.CancellationException) {
+    throw e
+} catch (e: OAuthException) {
+    throw e
+} catch (e: Exception) {
+    throw OAuthException("GitHub request failed: ${e.message ?: e.javaClass.simpleName}")
 }
 
 @Serializable

--- a/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
@@ -15,7 +15,6 @@ import io.ktor.http.contentType
 import io.ktor.http.formUrlEncode
 import io.ktor.http.takeFrom
 import io.ktor.serialization.kotlinx.json.json
-import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
@@ -60,6 +60,12 @@ class GitHubOAuthClient(
         if (resp.error != null || resp.accessToken.isNullOrBlank()) {
             throw OAuthException("GitHub token exchange failed: ${resp.error ?: "no access_token"} (${resp.errorDescription ?: ""})")
         }
+        // P3-1: refuse to proceed if GitHub didn't grant the scope we need to call
+        // GET /user. (A downscoped/empty token would make the next call 401.)
+        val granted = (resp.scope ?: "").split(' ', ',').map { it.trim() }.filter { it.isNotEmpty() }
+        if ("read:user" !in granted) {
+            throw OAuthException("GitHub did not grant the required 'read:user' scope (got: ${resp.scope ?: "none"})")
+        }
         return OAuthTokens(resp.accessToken, resp.tokenType ?: "bearer", resp.scope)
     }
 

--- a/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
@@ -1,0 +1,106 @@
+package dev.androidskills.auth
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.URLBuilder
+import io.ktor.http.contentType
+import io.ktor.http.formUrlEncode
+import io.ktor.http.takeFrom
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Real GitHub OAuth client over a Ktor CIO HTTP client. Talks to the GitHub
+ * authorize, access-token, and user endpoints. Constructed only when OAuth
+ * creds are present (spec §13); otherwise the app wires [DisabledOAuthClient].
+ *
+ * The [HttpClient] is owned by the caller (Application) and shared/closed with
+ * the app lifecycle — clients are expensive to create and meant to be long-lived.
+ */
+class GitHubOAuthClient(
+    private val clientId: String,
+    private val clientSecret: String,
+    private val http: HttpClient,
+) : OAuthClient {
+
+    override val configured: Boolean = true
+
+    override fun authorizeUrl(state: String, redirectUri: String): String =
+        URLBuilder().takeFrom("https://github.com/login/oauth/authorize").apply {
+            parameters.append("client_id", clientId)
+            parameters.append("redirect_uri", redirectUri)
+            parameters.append("scope", "read:user")
+            parameters.append("state", state)
+        }.buildString()
+
+    override suspend fun exchange(code: String, redirectUri: String): OAuthTokens {
+        val form = listOf(
+            "client_id" to clientId,
+            "client_secret" to clientSecret,
+            "code" to code,
+            "redirect_uri" to redirectUri,
+        ).formUrlEncode()
+        val resp: AccessTokenResponse = http.post("https://github.com/login/oauth/access_token") {
+            header("Accept", "application/json")
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(form)
+        }.body()
+        if (resp.error != null || resp.accessToken.isNullOrBlank()) {
+            throw OAuthException("GitHub token exchange failed: ${resp.error ?: "no access_token"} (${resp.errorDescription ?: ""})")
+        }
+        return OAuthTokens(resp.accessToken, resp.tokenType ?: "bearer", resp.scope)
+    }
+
+    override suspend fun userInfo(accessToken: String): GitHubUser {
+        val resp: GitHubUserResponse = http.get("https://api.github.com/user") {
+            header("Accept", "application/vnd.github+json")
+            header("Authorization", "Bearer $accessToken")
+        }.body()
+        if (resp.id <= 0L || resp.login.isBlank()) {
+            throw OAuthException("GitHub user lookup returned no identity")
+        }
+        return GitHubUser(
+            githubId = resp.id,
+            handle = resp.login,
+            name = resp.name,
+            avatarUrl = resp.avatarUrl,
+        )
+    }
+
+    companion object {
+        /** A ready [HttpClient] configured for GitHub JSON responses. */
+        fun httpClient(): HttpClient = HttpClient(CIO) {
+            install(ContentNegotiation) {
+                json(dev.androidskills.util.appJson)
+            }
+            expectSuccess = true
+        }
+    }
+}
+
+@Serializable
+private data class AccessTokenResponse(
+    @SerialName("access_token") val accessToken: String? = null,
+    @SerialName("token_type") val tokenType: String? = null,
+    val scope: String? = null,
+    val error: String? = null,
+    @SerialName("error_description") val errorDescription: String? = null,
+)
+
+@Serializable
+private data class GitHubUserResponse(
+    val id: Long,
+    val login: String,
+    val name: String? = null,
+    @SerialName("avatar_url") val avatarUrl: String? = null,
+)

--- a/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/GitHubOAuthClient.kt
@@ -59,11 +59,15 @@ class GitHubOAuthClient(
         if (resp.error != null || resp.accessToken.isNullOrBlank()) {
             throw OAuthException("GitHub token exchange failed: ${resp.error ?: "no access_token"} (${resp.errorDescription ?: ""})")
         }
-        // P3-1: refuse to proceed if GitHub didn't grant the scope we need to call
-        // GET /user. (A downscoped/empty token would make the next call 401.)
+        // P3-1: scope sanity check — but ONLY when GitHub returns a non-empty
+        // scope. GitHub App user-to-server tokens (spec §8, step 4) are SCOPELESS:
+        // the token response carries an empty `scope`. Hard-failing on empty would
+        // reject every login the moment we wire the real App. So: an empty/absent
+        // scope is allowed (the subsequent GET /user 401 → OAuthException is the
+        // real guard); a *present-but-missing read:user* scope is rejected.
         val granted = (resp.scope ?: "").split(' ', ',').map { it.trim() }.filter { it.isNotEmpty() }
-        if ("read:user" !in granted) {
-            throw OAuthException("GitHub did not grant the required 'read:user' scope (got: ${resp.scope ?: "none"})")
+        if (granted.isNotEmpty() && "read:user" !in granted) {
+            throw OAuthException("GitHub did not grant the required 'read:user' scope (got: ${resp.scope})")
         }
         return OAuthTokens(resp.accessToken, resp.tokenType ?: "bearer", resp.scope)
     }

--- a/api/src/main/kotlin/dev/androidskills/auth/OAuthClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/OAuthClient.kt
@@ -1,0 +1,40 @@
+package dev.androidskills.auth
+
+/**
+ * GitHub OAuth (spec §7, §8: "OAuth via the GitHub App's user flow"). Kept behind
+ * an interface so step 3 runs and tests with zero cloud setup — tests inject a
+ * fake, prod injects [GitHubOAuthClient], and when creds are absent the routes
+ * get [DisabledOAuthClient] (`configured = false`).
+ */
+interface OAuthClient {
+    val configured: Boolean
+
+    /** The GitHub authorize URL to redirect the browser to (with [state] echoed back). */
+    fun authorizeUrl(state: String, redirectUri: String): String
+
+    /** Exchanges the `code` GitHub redirected with for an access token. */
+    suspend fun exchange(code: String, redirectUri: String): OAuthTokens
+
+    /** Fetches the GitHub user identity behind an access token. */
+    suspend fun userInfo(accessToken: String): GitHubUser
+}
+
+data class OAuthTokens(
+    val accessToken: String,
+    val tokenType: String = "bearer",
+    val scope: String? = null,
+)
+
+/** Raised when GitHub returns an error or an unexpected payload. */
+class OAuthException(message: String) : RuntimeException(message)
+
+/** No creds configured (spec §13: "unset → auth disabled"). */
+class DisabledOAuthClient : OAuthClient {
+    override val configured: Boolean = false
+    override fun authorizeUrl(state: String, redirectUri: String): String =
+        throw OAuthException("GitHub OAuth is not configured")
+    override suspend fun exchange(code: String, redirectUri: String): OAuthTokens =
+        throw OAuthException("GitHub OAuth is not configured")
+    override suspend fun userInfo(accessToken: String): GitHubUser =
+        throw OAuthException("GitHub OAuth is not configured")
+}

--- a/api/src/main/kotlin/dev/androidskills/auth/Principal.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/Principal.kt
@@ -20,10 +20,7 @@ data class Principal(
     val role: Role,
     val status: UserStatus,
     val createdAt: String,
-) {
-    /** A suspended user is never admitted as a principal (spec §7). */
-    val isActive: Boolean get() = status == UserStatus.active
-}
+)
 
 /**
  * Authorization gates. The split keeps the security-relevant invariant in one
@@ -39,9 +36,6 @@ data class Principal(
  */
 fun Principal.requireAdmin(): Principal =
     if (role == Role.admin) this else throw ApiNotFoundException("Not found")
-
-/** Role ordering: member < contributor < admin (spec §2, §7). */
-fun Role.atLeast(min: Role): Boolean = this.ordinal >= min.ordinal
 
 @Serializable
 data class MeResponse(

--- a/api/src/main/kotlin/dev/androidskills/auth/Principal.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/Principal.kt
@@ -1,0 +1,60 @@
+package dev.androidskills.auth
+
+import dev.androidskills.api.ApiNotFoundException
+import dev.androidskills.db.Role
+import dev.androidskills.db.UserStatus
+import kotlinx.serialization.Serializable
+
+/**
+ * The authenticated caller, resolved per-request from the session cookie (spec
+ * §7). Kept intentionally slim: it's the gate every protected route reads, so it
+ * carries exactly what authorization needs (role/status) plus identity for
+ * `/api/me` and audit logging. Heavy profile data stays in the `users` row.
+ */
+data class Principal(
+    val sessionId: String,
+    val userId: String,
+    val handle: String,
+    val name: String?,
+    val avatarUrl: String?,
+    val role: Role,
+    val status: UserStatus,
+    val createdAt: String,
+) {
+    /** A suspended user is never admitted as a principal (spec §7). */
+    val isActive: Boolean get() = status == UserStatus.active
+}
+
+/**
+ * Authorization gates. The split keeps the security-relevant invariant in one
+ * place: **admin routes never reveal their existence**.
+ *
+ *  - `requireSession()` → 401 when anonymous (contributor/`/api/me` routes).
+ *  - `requireAdmin()`   → 404 when *anyone* other than an admin calls, including
+ *    anonymous callers. Returning 401 (or 403) would leak that the route exists
+ *    and merely needs higher privilege (spec §7: "non-admins get 404, not 403").
+ *
+ * `requireAdmin` therefore does **not** chain `requireSession` — an anonymous
+ * caller must also receive 404.
+ */
+fun Principal.requireAdmin(): Principal =
+    if (role == Role.admin) this else throw ApiNotFoundException("Not found")
+
+/** Role ordering: member < contributor < admin (spec §2, §7). */
+fun Role.atLeast(min: Role): Boolean = this.ordinal >= min.ordinal
+
+@Serializable
+data class MeResponse(
+    val id: String,
+    val handle: String,
+    val name: String?,
+    val avatarUrl: String?,
+    val role: String,
+    val status: String,
+    val createdAt: String,
+)
+
+internal fun Principal.toMe() = MeResponse(
+    id = userId, handle = handle, name = name, avatarUrl = avatarUrl,
+    role = role.name, status = status.name, createdAt = createdAt,
+)

--- a/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
@@ -53,7 +53,11 @@ object SessionStore {
         val status = runCatching { UserStatus.parse(user[Users.status]) }.getOrNull()
             ?: return@transaction null
         if (status != UserStatus.active) return@transaction null
-        val role = runCatching { Role.parse(user[Users.role]) }.getOrNull() ?: Role.member
+        // A corrupted role is treated the same as a corrupted status: reject the
+        // session rather than silently degrading to `member` (an unexpected role
+        // value means the row shouldn't be trusted to authorize anything).
+        val role = runCatching { Role.parse(user[Users.role]) }.getOrNull()
+            ?: return@transaction null
         Principal(
             sessionId = token,
             userId = user[Users.id],

--- a/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
@@ -1,0 +1,87 @@
+package dev.androidskills.auth
+
+import dev.androidskills.db.Role
+import dev.androidskills.db.Sessions
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.security.SecureRandom
+import java.time.Instant
+
+/**
+ * DB-backed session store (spec §7). A session id is a 256-bit opaque token
+ * carried by the cookie; the row maps it to a user and an expiry. Because the
+ * lookup is a DB read on every request, suspend (status change) and logout
+ * (row delete) revoke access *immediately* — the explicit reason for not using
+ * stateless JWTs (architecture.md).
+ *
+ * [lookup] returns null for any of: unknown id, expired, missing user, or a
+ * suspended user. That keeps the "suspended → reject" rule (§7) in one place.
+ */
+object SessionStore {
+    private val rng = SecureRandom()
+
+    /** Creates a session row for [userId]; returns the opaque token (cookie value). */
+    fun create(userId: String, maxAgeSeconds: Long): String {
+        val token = randomToken()
+        val now = Instant.now()
+        transaction {
+            Sessions.insert {
+                it[Sessions.id] = token
+                it[Sessions.userId] = userId
+                it[Sessions.createdAt] = nowIso()
+                it[Sessions.expiresAt] = now.plusSeconds(maxAgeSeconds).toString()
+            }
+        }
+        return token
+    }
+
+    fun lookup(token: String): Principal? = transaction {
+        val row = Sessions.selectAll().where { Sessions.id eq token }.singleOrNull() ?: return@transaction null
+        val now = Instant.now()
+        val expiresAt = runCatching { Instant.parse(row[Sessions.expiresAt]) }.getOrNull()
+            ?: return@transaction null
+        if (expiresAt.isBefore(now)) return@transaction null
+        val user = Users.selectAll().where { Users.id eq row[Sessions.userId] }.singleOrNull()
+            ?: return@transaction null
+        // A suspended user is never admitted — even mid-session.
+        val status = runCatching { UserStatus.parse(user[Users.status]) }.getOrNull()
+            ?: return@transaction null
+        if (status != UserStatus.active) return@transaction null
+        val role = runCatching { Role.parse(user[Users.role]) }.getOrNull() ?: Role.member
+        Principal(
+            sessionId = token,
+            userId = user[Users.id],
+            handle = user[Users.handle],
+            name = user[Users.name],
+            avatarUrl = user[Users.avatarUrl],
+            role = role,
+            status = status,
+            createdAt = user[Users.createdAt],
+        )
+    }
+
+    fun delete(token: String): Int {
+        val op = org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq token }
+        return transaction { Sessions.deleteWhere { op } }
+    }
+
+    /** Opportunistic cleanup of expired rows; safe to call periodically. */
+    fun purgeExpired(now: Instant = Instant.now()): Int {
+        val nowStr = now.toString()
+        val op = org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.expiresAt lessEq nowStr }
+        return transaction { Sessions.deleteWhere { op } }
+    }
+
+    /** 256-bit (32-byte) token, lower-case hex. */
+    private fun randomToken(): String {
+        val bytes = ByteArray(32)
+        rng.nextBytes(bytes)
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
@@ -4,7 +4,6 @@ import dev.androidskills.db.Role
 import dev.androidskills.db.Sessions
 import dev.androidskills.db.UserStatus
 import dev.androidskills.db.Users
-import dev.androidskills.util.newId
 import dev.androidskills.util.nowIso
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.selectAll
@@ -71,6 +70,10 @@ object SessionStore {
     }
 
     fun delete(token: String): Int {
+        // `deleteWhere`'s lambda receives ISqlExpressionBuilder (the interface),
+        // which does NOT expose `eq`; only the SqlExpressionBuilder object does,
+        // so we build the Op in that scope. (update()'s predicate, by contrast,
+        // receives SqlExpressionBuilder directly and needs no wrapper.)
         val op = org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq token }
         return transaction { Sessions.deleteWhere { op } }
     }

--- a/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
@@ -32,7 +32,35 @@ data class GitHubUser(
  * resolved by suffixing `-{githubId}` rather than failing the login.
  */
 object UsersRepo {
-    fun upsertFromGitHub(user: GitHubUser, bootstrapAdminGithubId: Long?): String = transaction {
+    /**
+     * Upsert with a bounded retry for the one realistic race: two concurrent
+     * logins resolving the same recycled handle both pass check-then-insert and
+     * the second violates `uq_users_handle`. On that specific error we retry —
+     * the next [uniqueHandle] call sees the winner's row. (P2-2b.)
+     */
+    fun upsertFromGitHub(user: GitHubUser, bootstrapAdminGithubId: Long?): String {
+        var attempt = 0
+        while (true) {
+            try {
+                return upsertOnce(user, bootstrapAdminGithubId)
+            } catch (e: org.jetbrains.exposed.exceptions.ExposedSQLException) {
+                if (++attempt > MAX_HANDLE_RETRIES || !isUniqueHandleViolation(e)) throw e
+            }
+        }
+    }
+
+    private const val MAX_HANDLE_RETRIES = 3
+
+    private fun isUniqueHandleViolation(e: org.jetbrains.exposed.exceptions.ExposedSQLException): Boolean {
+        val text = buildString {
+            append(e.message); append(' ')
+            var c: Throwable? = e.cause
+            while (c != null) { append(c.message); append(' '); c = c.cause }
+        }
+        return text.contains("users.handle", ignoreCase = true)
+    }
+
+    private fun upsertOnce(user: GitHubUser, bootstrapAdminGithubId: Long?): String = transaction {
         val now = nowIso()
         val existing = Users.selectAll().where { Users.githubId eq user.githubId }.singleOrNull()
         if (existing != null) {
@@ -65,23 +93,26 @@ object UsersRepo {
     }
 
     /**
-     * Resolves a `handle` that doesn't collide with another user. Tries the raw
-     * login, then `{login}-{githubId}`, then an incrementing suffix, and finally
-     * a uuid-suffixed fallback — never throws, so a handle collision can't crash
-     * a login. (GitHub handles recycle; collisions across distinct github ids
-     * are rare but possible.)
+     * Resolves a `handle` that doesn't collide with another user. Walks a short
+     * ladder (raw → {login}-{githubId} → …-2..10), then falls back to a full-UUID
+     * suffix — which is **terminal and effectively unique**, so this never throws
+     * (the prior `first{}` over a finite ladder could). [P2-2a.]
+     *
+     * The check-then-insert is inherently a TOCTOU race under concurrency; the
+     * retry in [upsertFromGitHub] handles the losing side.
      */
     private fun uniqueHandle(handle: String, githubId: Long, excludeId: String?): String {
         val base = "$handle-$githubId"
-        // Candidate ladder: raw → {login}-{githubId} → …-2 → …-3 (bounded), then a uuid fallback.
         val candidates = sequence {
             yield(handle)
             yield(base)
             for (i in 2..10) yield("$base-$i")
-            yield("$base-${dev.androidskills.util.newId().take(8)}")
         }
-        return candidates.first { h ->
-            Users.selectAll().where { Users.handle eq h }.none { it[Users.id] != excludeId }
-        }
+        return candidates.firstOrNull { h -> !handleTaken(h, excludeId) }
+            ?: "$base-${newId()}" // full UUID: collision-proof, terminal
     }
+
+    /** True if some *other* user already owns [handle] (excludeId is the self row). */
+    private fun handleTaken(handle: String, excludeId: String?): Boolean =
+        Users.selectAll().where { Users.handle eq handle }.any { it[Users.id] != excludeId }
 }

--- a/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
@@ -60,9 +60,22 @@ object UsersRepo {
         }
     }
 
-    /** Resolves a `handle` that doesn't collide with another user. */
+    /**
+     * Resolves a `handle` that doesn't collide with another user. Tries the raw
+     * login, then `{login}-{githubId}`, then an incrementing suffix, and finally
+     * a uuid-suffixed fallback — never throws, so a handle collision can't crash
+     * a login. (GitHub handles recycle; collisions across distinct github ids
+     * are rare but possible.)
+     */
     private fun uniqueHandle(handle: String, githubId: Long, excludeId: String?): String {
-        val candidates = generateSequence(handle) { "$handle-$githubId" }.take(2)
+        val base = "$handle-$githubId"
+        // Candidate ladder: raw → {login}-{githubId} → …-2 → …-3 (bounded), then a uuid fallback.
+        val candidates = sequence {
+            yield(handle)
+            yield(base)
+            for (i in 2..10) yield("$base-$i")
+            yield("$base-${dev.androidskills.util.newId().take(8)}")
+        }
         return candidates.first { h ->
             Users.selectAll().where { Users.handle eq h }.none { it[Users.id] != excludeId }
         }

--- a/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
@@ -1,0 +1,70 @@
+package dev.androidskills.auth
+
+import dev.androidskills.db.Role
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+/** A GitHub user as returned by `GET /user` (only the fields we persist). */
+data class GitHubUser(
+    val githubId: Long,
+    val handle: String,
+    val name: String?,
+    val avatarUrl: String?,
+)
+
+/**
+ * Upserts a user from a GitHub identity (spec §7 callback). Insert → `member`
+ * by default; an existing user keeps its role unless the [bootstrapAdminGithubId]
+ * cold-start override promotes them. Returns the user id.
+ *
+ * Handles are unique in `users`; GitHub handles are globally unique at a point in
+ * time but can be recycled, so a collision with a *different* github_id is
+ * resolved by suffixing `-{githubId}` rather than failing the login.
+ */
+object UsersRepo {
+    fun upsertFromGitHub(user: GitHubUser, bootstrapAdminGithubId: Long?): String = transaction {
+        val now = nowIso()
+        val existing = Users.selectAll().where { Users.githubId eq user.githubId }.singleOrNull()
+        if (existing != null) {
+            val id = existing[Users.id]
+            val bootstrap = bootstrapAdminGithubId != null && user.githubId == bootstrapAdminGithubId
+            Users.update({ Users.id eq id }) {
+                it[Users.handle] = uniqueHandle(user.handle, user.githubId, excludeId = id)
+                it[Users.name] = user.name
+                it[Users.avatarUrl] = user.avatarUrl
+                if (bootstrap) it[Users.role] = Role.admin.name
+                it[Users.updatedAt] = now
+            }
+            id
+        } else {
+            val id = newId()
+            val role = if (bootstrapAdminGithubId != null && user.githubId == bootstrapAdminGithubId) Role.admin else Role.member
+            Users.insert {
+                it[Users.id] = id
+                it[Users.githubId] = user.githubId
+                it[Users.handle] = uniqueHandle(user.handle, user.githubId, excludeId = null)
+                it[Users.name] = user.name
+                it[Users.avatarUrl] = user.avatarUrl
+                it[Users.role] = role.name
+                it[Users.status] = UserStatus.active.name
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+            id
+        }
+    }
+
+    /** Resolves a `handle` that doesn't collide with another user. */
+    private fun uniqueHandle(handle: String, githubId: Long, excludeId: String?): String {
+        val candidates = generateSequence(handle) { "$handle-$githubId" }.take(2)
+        return candidates.first { h ->
+            Users.selectAll().where { Users.handle eq h }.none { it[Users.id] != excludeId }
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
@@ -19,9 +19,13 @@ data class GitHubUser(
 )
 
 /**
- * Upserts a user from a GitHub identity (spec §7 callback). Insert → `member`
- * by default; an existing user keeps its role unless the [bootstrapAdminGithubId]
- * cold-start override promotes them. Returns the user id.
+ * Upserts a user from a GitHub identity (spec §7 callback). A new user is
+ * inserted as `member` by default; [bootstrapAdminGithubId] is a **seed-only
+ * escape hatch** that promotes a *new* user to `admin` on first insert. It is
+ * intentionally INSERT-only: an existing user keeps whatever role the admin
+ * queue (step 7, spec §3 rule 9) last gave them, so a bootstrap account that
+ * was later demoted/suspended is **not** re-promoted on re-login. Unset it once
+ * the first admin exists. Returns the user id.
  *
  * Handles are unique in `users`; GitHub handles are globally unique at a point in
  * time but can be recycled, so a collision with a *different* github_id is
@@ -33,12 +37,12 @@ object UsersRepo {
         val existing = Users.selectAll().where { Users.githubId eq user.githubId }.singleOrNull()
         if (existing != null) {
             val id = existing[Users.id]
-            val bootstrap = bootstrapAdminGithubId != null && user.githubId == bootstrapAdminGithubId
             Users.update({ Users.id eq id }) {
                 it[Users.handle] = uniqueHandle(user.handle, user.githubId, excludeId = id)
                 it[Users.name] = user.name
                 it[Users.avatarUrl] = user.avatarUrl
-                if (bootstrap) it[Users.role] = Role.admin.name
+                // NOTE: role is NOT touched here — a bootstrap/demoted/suspended
+                // user keeps their current role on re-login (P1-1).
                 it[Users.updatedAt] = now
             }
             id

--- a/api/src/test/kotlin/dev/androidskills/TestSupport.kt
+++ b/api/src/test/kotlin/dev/androidskills/TestSupport.kt
@@ -13,6 +13,14 @@ object TestSupport {
         llmApiKey = null,
         llmModel = null,
         seedDemo = seedDemo,
+        auth = AuthConfig(
+            oauth = null,
+            publicBaseUrl = "http://localhost:8080",
+            sessionCookieDomain = null,
+            // Localhost HTTP → relax Secure so the test client (and a dev browser) carry the cookie.
+            sessionCookieSecure = false,
+            bootstrapAdminGithubId = null,
+        ),
     )
 
     fun tempDir(): Path = Files.createTempDirectory("asdb-test")

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
@@ -82,6 +82,28 @@ class AuthDomainTest {
     }
 
     @Test
+    fun `session expiry boundary is future-admitted past-rejected`() {
+        // Coverage gap (P3-6): pin the expiry semantics. A clearly-future expiry is
+        // admitted; a clearly-past one is rejected. (The exact ==now edge isn't
+        // deterministically testable at ms resolution, so we bracket it.)
+        val userId = seedUser()
+        val future = SessionStore.create(userId, 3600)
+        transaction {
+            Sessions.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq future } }) {
+                it[Sessions.expiresAt] = Instant.now().plusSeconds(60).toString()
+            }
+        }
+        assertNotNull(SessionStore.lookup(future))
+        val past = SessionStore.create(userId, 3600)
+        transaction {
+            Sessions.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq past } }) {
+                it[Sessions.expiresAt] = Instant.now().minusSeconds(1).toString()
+            }
+        }
+        assertNull(SessionStore.lookup(past))
+    }
+
+    @Test
     fun `suspended user is rejected mid-session`() {
         // The DB-backed revocation invariant (spec §7): suspend → session immediately invalid.
         val userId = seedUser()

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
@@ -7,9 +7,14 @@ import dev.androidskills.db.Sessions
 import dev.androidskills.db.UserStatus
 import dev.androidskills.db.Users
 import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import java.time.Instant
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -32,6 +37,19 @@ class AuthDomainTest {
 
     private fun seedUser(githubId: Long = 1L, handle: String = "alice"): String =
         UsersRepo.upsertFromGitHub(GitHubUser(githubId, handle, "Alice", "https://av/$handle.png"), bootstrapAdminGithubId = null)
+
+    /** Plants a user row with an EXACT handle (bypassing uniqueHandle) to stage collisions. */
+    private fun plantUser(handle: String, githubId: Long): String = transaction {
+        val id = dev.androidskills.util.newId()
+        val now = dev.androidskills.util.nowIso()
+        Users.insert {
+            it[Users.id] = id; it[Users.githubId] = githubId; it[Users.handle] = handle
+            it[Users.name] = "planted"; it[Users.role] = Role.member.name
+            it[Users.status] = UserStatus.active.name
+            it[Users.createdAt] = now; it[Users.updatedAt] = now
+        }
+        id
+    }
 
     @Test
     fun `session create then lookup returns a member principal`() {
@@ -190,5 +208,45 @@ class AuthDomainTest {
         val a = newState(); val b = newState(); val c = newState()
         assertTrue(a.matches(Regex("^[0-9a-f]{64}$")), "got $a")
         assertEquals(setOf(a, b, c).size, 3, "state must not repeat")
+    }
+
+    @Test
+    fun `uniqueHandle falls back to a full uuid when the whole ladder is taken`() {
+        // Exhaust every candidate on the ladder for githubId=3 (handle "taken"):
+        // "taken", "taken-3", "taken-3-2".."taken-3-10" = 11 handles, all held by
+        // other users. firstOrNull must then be null and the full-UUID fallback is
+        // used — never a NoSuchElementException → 500 mid-login. (P2-2a.)
+        plantUser("taken", 10)
+        plantUser("taken-3", 11)
+        for (i in 2..10) plantUser("taken-3-$i", 20L + i)
+        val id = UsersRepo.upsertFromGitHub(GitHubUser(3, "taken", "C", null), null)
+        val handle = transaction { Users.selectAll().where { Users.id eq id }.single()[Users.handle] }
+        assertTrue(handle.startsWith("taken-3-"), "got $handle")
+        assertNotEquals("taken-3", handle)
+        // The uuid fallback is longer than any ladder rung.
+        assertTrue(handle.length > "taken-3-10".length, "expected uuid suffix, got $handle")
+    }
+
+    @Test
+    fun `concurrent logins with the same handle all succeed with distinct handles`() {
+        // P2-2b: the check-then-insert race under concurrency. Three identities
+        // claim "shared" at once; one wins the raw handle, the others trip
+        // uq_users_handle and must retry into {handle}-{githubId}. None should 500.
+        val handles = kotlinx.coroutines.runBlocking {
+            val gids = listOf(100L, 101L, 102L)
+            kotlinx.coroutines.coroutineScope {
+                gids.map { gid ->
+                    async(Dispatchers.IO) {
+                        UsersRepo.upsertFromGitHub(GitHubUser(gid, "shared", "S", null), null) to gid
+                    }
+                }.awaitAll()
+            }
+        }
+        assertEquals(3, handles.size)
+        val byHandle = transaction { Users.selectAll().where { Users.githubId inList listOf(100L, 101L, 102L) }
+            .associate { it[Users.githubId] to it[Users.handle] } }
+        assertEquals(3, byHandle.size, "all three logins must create a user")
+        assertEquals(3, byHandle.values.distinct().size, "handles must be distinct: $byHandle")
+        assertTrue(byHandle.values.all { it.startsWith("shared") }, "$byHandle")
     }
 }

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
@@ -74,7 +74,7 @@ class AuthDomainTest {
         val userId = seedUser()
         val token = SessionStore.create(userId, 3600)
         transaction {
-            Sessions.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq token } }) {
+            Sessions.update({ Sessions.id eq token }) {
                 it[Sessions.expiresAt] = Instant.now().minusSeconds(60).toString()
             }
         }
@@ -89,14 +89,14 @@ class AuthDomainTest {
         val userId = seedUser()
         val future = SessionStore.create(userId, 3600)
         transaction {
-            Sessions.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq future } }) {
+            Sessions.update({ Sessions.id eq future }) {
                 it[Sessions.expiresAt] = Instant.now().plusSeconds(60).toString()
             }
         }
         assertNotNull(SessionStore.lookup(future))
         val past = SessionStore.create(userId, 3600)
         transaction {
-            Sessions.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq past } }) {
+            Sessions.update({ Sessions.id eq past }) {
                 it[Sessions.expiresAt] = Instant.now().minusSeconds(1).toString()
             }
         }
@@ -110,7 +110,7 @@ class AuthDomainTest {
         val token = SessionStore.create(userId, 3600)
         assertNotNull(SessionStore.lookup(token))
         transaction {
-            Users.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Users.id eq userId } }) {
+            Users.update({ Users.id eq userId }) {
                 it[Users.status] = UserStatus.suspended.name
             }
         }
@@ -131,7 +131,7 @@ class AuthDomainTest {
         val live = SessionStore.create(userId, 3600)
         val expired = SessionStore.create(userId, 3600)
         transaction {
-            Sessions.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq expired } }) {
+            Sessions.update({ Sessions.id eq expired }) {
                 it[Sessions.expiresAt] = Instant.now().minusSeconds(60).toString()
             }
         }
@@ -174,7 +174,7 @@ class AuthDomainTest {
         assertEquals(Role.admin.name, transaction { Users.selectAll().where { Users.id eq id }.single()[Users.role] })
         // Admin queue demotes root to member.
         transaction {
-            Users.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Users.id eq id } }) {
+            Users.update({ Users.id eq id }) {
                 it[Users.role] = Role.member.name
             }
         }
@@ -218,7 +218,7 @@ class AuthDomainTest {
         val token = SessionStore.create(userId, 3600)
         assertNotNull(SessionStore.lookup(token))
         transaction {
-            Users.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Users.id eq userId } }) {
+            Users.update({ Users.id eq userId }) {
                 it[Users.role] = "superuser" // not a valid Role
             }
         }

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
@@ -133,4 +133,41 @@ class AuthDomainTest {
         assertNotEquals("recycled", handle)
         assertTrue(handle.startsWith("recycled-"), "expected a disambiguated handle, got $handle")
     }
+
+    @Test
+    fun `uniqueHandle never crashes even when raw and suffixed forms are taken`() {
+        // Both "taken" and "taken-3" are held by other users. The disambiguation
+        // ladder must walk past them (…-2, …-4, …) instead of throwing and 500-ing
+        // the login. (Bugbot finding: `first` on a 2-element sequence threw.)
+        seedUser(githubId = 1, handle = "taken")
+        seedUser(githubId = 2, handle = "taken-3")
+        val id = UsersRepo.upsertFromGitHub(GitHubUser(3, "taken", "C", null), null)
+        val handle = transaction { Users.selectAll().where { Users.id eq id }.single()[Users.handle] }
+        // New user (githubId 3) must still log in: not "taken", not "taken-3".
+        assertTrue(handle.startsWith("taken-3") || handle.startsWith("taken-"), "got $handle")
+        assertNotEquals("taken", handle)
+        assertNotEquals("taken-3", handle)
+    }
+
+    @Test
+    fun `session lookup rejects a corrupted role value`() {
+        // Asymmetric with status: a corrupted role used to fall back to `member`,
+        // handing a valid session to a row that shouldn't be trusted. Reject it.
+        val userId = seedUser()
+        val token = SessionStore.create(userId, 3600)
+        assertNotNull(SessionStore.lookup(token))
+        transaction {
+            Users.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Users.id eq userId } }) {
+                it[Users.role] = "superuser" // not a valid Role
+            }
+        }
+        assertNull(SessionStore.lookup(token), "a corrupted role must not yield a member session")
+    }
+
+    @Test
+    fun `newState is 64 hex chars and each is unique`() {
+        val a = newState(); val b = newState(); val c = newState()
+        assertTrue(a.matches(Regex("^[0-9a-f]{64}$")), "got $a")
+        assertEquals(setOf(a, b, c).size, 3, "state must not repeat")
+    }
 }

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
@@ -1,0 +1,136 @@
+package dev.androidskills.auth
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.Role
+import dev.androidskills.db.Sessions
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import java.time.Instant
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** DB-level auth: session lifecycle (incl. expiry + suspended revocation) and user upsert. */
+class AuthDomainTest {
+    private val dir = TestSupport.tempDir()
+
+    @BeforeTest
+    fun setup() = Database.init(TestSupport.newConfig(dir))
+
+    @AfterTest
+    fun teardown() { dir.toFile().deleteRecursively() }
+
+    private fun seedUser(githubId: Long = 1L, handle: String = "alice"): String =
+        UsersRepo.upsertFromGitHub(GitHubUser(githubId, handle, "Alice", "https://av/$handle.png"), bootstrapAdminGithubId = null)
+
+    @Test
+    fun `session create then lookup returns a member principal`() {
+        val userId = seedUser()
+        val token = SessionStore.create(userId, 3600)
+        assertEquals(64, token.length) // 32 bytes hex
+        val p = SessionStore.lookup(token)
+        assertNotNull(p)
+        assertEquals(userId, p.userId)
+        assertEquals("alice", p.handle)
+        assertEquals(Role.member, p.role)
+        assertEquals(UserStatus.active, p.status)
+    }
+
+    @Test
+    fun `lookup returns null for unknown token`() {
+        assertNull(SessionStore.lookup("deadbeef".repeat(8)))
+    }
+
+    @Test
+    fun `expired session is rejected`() {
+        val userId = seedUser()
+        val token = SessionStore.create(userId, 3600)
+        transaction {
+            Sessions.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq token } }) {
+                it[Sessions.expiresAt] = Instant.now().minusSeconds(60).toString()
+            }
+        }
+        assertNull(SessionStore.lookup(token))
+    }
+
+    @Test
+    fun `suspended user is rejected mid-session`() {
+        // The DB-backed revocation invariant (spec §7): suspend → session immediately invalid.
+        val userId = seedUser()
+        val token = SessionStore.create(userId, 3600)
+        assertNotNull(SessionStore.lookup(token))
+        transaction {
+            Users.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Users.id eq userId } }) {
+                it[Users.status] = UserStatus.suspended.name
+            }
+        }
+        assertNull(SessionStore.lookup(token), "a suspended user must not resolve to a principal")
+    }
+
+    @Test
+    fun `delete invalidates the session`() {
+        val userId = seedUser()
+        val token = SessionStore.create(userId, 3600)
+        SessionStore.delete(token)
+        assertNull(SessionStore.lookup(token))
+    }
+
+    @Test
+    fun `purgeExpired removes only expired rows`() {
+        val userId = seedUser()
+        val live = SessionStore.create(userId, 3600)
+        val expired = SessionStore.create(userId, 3600)
+        transaction {
+            Sessions.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.id eq expired } }) {
+                it[Sessions.expiresAt] = Instant.now().minusSeconds(60).toString()
+            }
+        }
+        val removed = SessionStore.purgeExpired()
+        assertEquals(1, removed)
+        assertNotNull(SessionStore.lookup(live))
+        assertNull(SessionStore.lookup(expired))
+    }
+
+    @Test
+    fun `upsert inserts new as member and updates existing`() {
+        val id1 = UsersRepo.upsertFromGitHub(GitHubUser(7, "bob", "Bob", null), null)
+        val row = transaction { Users.selectAll().where { Users.githubId eq 7L }.single() }
+        assertEquals(Role.member.name, row[Users.role])
+        // Re-upsert with changed name/handle → same id, updated fields.
+        val id2 = UsersRepo.upsertFromGitHub(GitHubUser(7, "bob", "Bobby", "https://av/bob.png"), null)
+        assertEquals(id1, id2)
+        val row2 = transaction { Users.selectAll().where { Users.githubId eq 7L }.single() }
+        assertEquals("Bobby", row2[Users.name])
+    }
+
+    @Test
+    fun `bootstrap admin github id is promoted on upsert`() {
+        val id = UsersRepo.upsertFromGitHub(GitHubUser(99, "root", "Root", null), bootstrapAdminGithubId = 99L)
+        val role = transaction { Users.selectAll().where { Users.id eq id }.single()[Users.role] }
+        assertEquals(Role.admin.name, role)
+        // A different user stays member.
+        val other = UsersRepo.upsertFromGitHub(GitHubUser(100, "other", "Other", null), bootstrapAdminGithubId = 99L)
+        val otherRole = transaction { Users.selectAll().where { Users.id eq other }.single()[Users.role] }
+        assertEquals(Role.member.name, otherRole)
+    }
+
+    @Test
+    fun `handle collision with a different github id is disambiguated not failed`() {
+        UsersRepo.upsertFromGitHub(GitHubUser(1, "recycled", "A", null), null)
+        // A second, different github id claims the same handle → must not crash the login.
+        val id2 = UsersRepo.upsertFromGitHub(GitHubUser(2, "recycled", "B", null), null)
+        val handle = transaction { Users.selectAll().where { Users.id eq id2 }.single()[Users.handle] }
+        assertNotEquals("recycled", handle)
+        assertTrue(handle.startsWith("recycled-"), "expected a disambiguated handle, got $handle")
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthDomainTest.kt
@@ -125,6 +125,27 @@ class AuthDomainTest {
     }
 
     @Test
+    fun `bootstrap admin is not re-promoted after being demoted (INSERT-only)`() {
+        // P1-1: the bootstrap id must promote only on FIRST insert. Once the
+        // admin queue (step 7) demotes the bootstrap account, a re-login must
+        // NOT re-promote it just because BOOTSTRAP_ADMIN_GITHUB_ID is still set
+        // (it's a Kamal secret nobody rotates).
+        val id = UsersRepo.upsertFromGitHub(GitHubUser(99, "root", "Root", null), bootstrapAdminGithubId = 99L)
+        assertEquals(Role.admin.name, transaction { Users.selectAll().where { Users.id eq id }.single()[Users.role] })
+        // Admin queue demotes root to member.
+        transaction {
+            Users.update({ org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Users.id eq id } }) {
+                it[Users.role] = Role.member.name
+            }
+        }
+        // Re-login (same bootstrap id still set) → stays member, NOT re-promoted.
+        val id2 = UsersRepo.upsertFromGitHub(GitHubUser(99, "root", "Root", null), bootstrapAdminGithubId = 99L)
+        assertEquals(id, id2)
+        assertEquals(Role.member.name, transaction { Users.selectAll().where { Users.id eq id2 }.single()[Users.role] },
+            "a demoted bootstrap user must not be re-promoted on re-login")
+    }
+
+    @Test
     fun `handle collision with a different github id is disambiguated not failed`() {
         UsersRepo.upsertFromGitHub(GitHubUser(1, "recycled", "A", null), null)
         // A second, different github id claims the same handle → must not crash the login.

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
@@ -113,6 +113,23 @@ class AuthRoutesTest {
     }
 
     @Test
+    fun callbackReturns400Not500WhenOAuthFails() = testApp(oauth = FakeOAuthClient()) { client ->
+        // A normal OAuth failure (bad/expired/revoked code → OAuthException from
+        // exchange/userInfo) is a client/auth error, NOT a server outage: must be a
+        // controlled 400, not the generic 500 from the global Throwable handler.
+        val start = client.get("/api/auth/github/start")
+        val state = cookieValue(start.headers.getAll("Set-Cookie"), STATE_COOKIE)!!
+        val res = client.get("/api/auth/github/callback?code=bad-or-revoked-code&state=$state")
+        assertEquals(HttpStatusCode.BadRequest, res.status)
+        val body = res.bodyAsText()
+        assertTrue(body.contains("\"code\":\"bad_request\""), body)
+        // No session cookie was set on failure (and the state cookie was cleared).
+        val setCookies = res.headers.getAll("Set-Cookie") ?: emptyList()
+        assertTrue(setCookies.none { it.startsWith("$SESSION_COOKIE=") && !it.contains("Max-Age=0") },
+            "no session cookie should be set on OAuth failure: $setCookies")
+    }
+
+    @Test
     fun suspendedUserIsLoggedOutMidSession() = testApp(oauth = FakeOAuthClient()) { client ->
         // Log Alice in.
         val start = client.get("/api/auth/github/start")

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
@@ -123,10 +123,13 @@ class AuthRoutesTest {
         assertEquals(HttpStatusCode.BadRequest, res.status)
         val body = res.bodyAsText()
         assertTrue(body.contains("\"code\":\"bad_request\""), body)
-        // No session cookie was set on failure (and the state cookie was cleared).
+        // No session cookie was set on failure …
         val setCookies = res.headers.getAll("Set-Cookie") ?: emptyList()
         assertTrue(setCookies.none { it.startsWith("$SESSION_COOKIE=") && !it.contains("Max-Age=0") },
             "no session cookie should be set on OAuth failure: $setCookies")
+        // … and the single-use state cookie WAS cleared (P1-2: no stale CSRF cookie left behind).
+        assertTrue(setCookies.any { it.startsWith("$STATE_COOKIE=") && it.contains("Max-Age=0") },
+            "state cookie must be cleared on OAuth failure: $setCookies")
     }
 
     @Test

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
@@ -133,6 +133,30 @@ class AuthRoutesTest {
     }
 
     @Test
+    fun stateCookieIsHostOnlyAndNamedByScheme() {
+        // P2-3: the CSRF state cookie must be host-only (no Domain) so a sibling
+        // subdomain / MITM can't plant it for login-CSRF, and __Host- prefixed
+        // over HTTPS (browser-enforced host-only + Secure + Path=/). Unit-level.
+        val insecure = TestSupport.newConfig(TestSupport.tempDir()).auth
+        val secure = insecure.copy(sessionCookieSecure = true)
+        assertEquals("as_oauth_state", stateCookieName(insecure))
+        assertEquals("__Host-as_oauth_state", stateCookieName(secure))
+    }
+
+    @Test
+    fun startSetsHostOnlyStateCookie() = testApp(oauth = FakeOAuthClient()) { client ->
+        val start = client.get("/api/auth/github/start")
+        val setCookies = start.headers.getAll("Set-Cookie") ?: emptyList()
+        val stateCookie = setCookies.first { it.startsWith("${STATE_COOKIE}=") }
+        assertTrue(stateCookie.contains("HttpOnly"), stateCookie)
+        assertTrue(stateCookie.contains("Path=/"), stateCookie)
+        assertTrue(stateCookie.contains("SameSite=Lax"), stateCookie)
+        // P2-3: the state cookie must NEVER carry a Domain (host-only).
+        assertTrue(!stateCookie.contains("Domain=", ignoreCase = true),
+            "state cookie must be host-only: $stateCookie")
+    }
+
+    @Test
     fun suspendedUserIsLoggedOutMidSession() = testApp(oauth = FakeOAuthClient()) { client ->
         // Log Alice in.
         val start = client.get("/api/auth/github/start")

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
@@ -1,0 +1,187 @@
+package dev.androidskills.auth
+
+import dev.androidskills.AppConfig
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.api.installApiErrorMapping
+import dev.androidskills.db.Role
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.module
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** A controllable OAuthClient: maps codes→tokens→users in-process (no network). */
+class FakeOAuthClient(
+    private val codeToToken: Map<String, String> = mapOf("code-OK" to "tok-OK"),
+    private val tokenToUser: Map<String, GitHubUser> = mapOf(
+        "tok-OK" to GitHubUser(42, "alice", "Alice", "https://av/alice.png"),
+    ),
+) : OAuthClient {
+    override val configured = true
+    override fun authorizeUrl(state: String, redirectUri: String) =
+        "https://github.com/login/oauth/authorize?client_id=test&state=$state&redirect_uri=$redirectUri"
+    override suspend fun exchange(code: String, redirectUri: String): OAuthTokens =
+        OAuthTokens(codeToToken[code] ?: throw OAuthException("unknown code $code"))
+    override suspend fun userInfo(accessToken: String): GitHubUser =
+        tokenToUser[accessToken] ?: throw OAuthException("unknown token $accessToken")
+}
+
+class AuthRoutesTest {
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() { dir.toFile().deleteRecursively() }
+
+    private fun cookieValue(setCookieHeaders: List<String>?, name: String): String? {
+        for (h in setCookieHeaders ?: return null) {
+            val first = h.substringBefore(";")
+            if (first.startsWith("$name=")) return first.substringAfter("$name=")
+        }
+        return null
+    }
+
+    @Test
+    fun meIs401WhenAnonymous() = testApp(oauth = null) { client ->
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/api/me").status)
+    }
+
+    @Test
+    fun startReportsDisabledWhenOAuthUnconfigured() = testApp(oauth = null) { client ->
+        val res = client.get("/api/auth/github/start")
+        assertEquals(HttpStatusCode.ServiceUnavailable, res.status)
+        assertTrue(res.bodyAsText().contains("auth_disabled"))
+    }
+
+    @Test
+    fun fullOAuthFlowLoginThenLogout() = testApp(oauth = FakeOAuthClient()) { client ->
+        // 1. start → 302 + state cookie set, redirect to GitHub authorize URL.
+        val start = client.get("/api/auth/github/start")
+        assertEquals(HttpStatusCode.Found, start.status)
+        val state = cookieValue(start.headers.getAll("Set-Cookie"), STATE_COOKIE)
+        assertTrue(state != null && state.length == 64, "state cookie missing: $state")
+        val location = start.headers["Location"] ?: error("missing Location")
+        assertTrue(location.startsWith("https://github.com/login/oauth/authorize"))
+        assertTrue(location.contains("state=$state"))
+
+        // 2. callback with matching state → upsert + session cookie + redirect to site root.
+        val cb = client.get("/api/auth/github/callback?code=code-OK&state=$state")
+        assertEquals(HttpStatusCode.Found, cb.status)
+        assertEquals("http://localhost:8080", cb.headers["Location"])
+
+        // 3. /api/me now resolves Alice (session cookie carried by HttpCookies).
+        val me = client.get("/api/me")
+        assertEquals(HttpStatusCode.OK, me.status)
+        val body = me.bodyAsText()
+        assertTrue(body.contains("\"handle\":\"alice\""), body)
+        assertTrue(body.contains("\"role\":\"member\""), body)
+        assertTrue(body.contains("\"status\":\"active\""), body)
+
+        // 4. logout deletes the session and clears the cookie.
+        assertEquals(HttpStatusCode.OK, client.post("/api/auth/logout").status)
+        // 5. /api/me is 401 again.
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/api/me").status)
+    }
+
+    @Test
+    fun callbackRejectsMismatchedState() = testApp(oauth = FakeOAuthClient()) { client ->
+        client.get("/api/auth/github/start") // establish a state cookie
+        val res = client.get("/api/auth/github/callback?code=code-OK&state=wrong-state")
+        assertEquals(HttpStatusCode.BadRequest, res.status)
+        assertTrue(res.bodyAsText().contains("bad_request"))
+    }
+
+    @Test
+    fun suspendedUserIsLoggedOutMidSession() = testApp(oauth = FakeOAuthClient()) { client ->
+        // Log Alice in.
+        val start = client.get("/api/auth/github/start")
+        val state = cookieValue(start.headers.getAll("Set-Cookie"), STATE_COOKIE)!!
+        client.get("/api/auth/github/callback?code=code-OK&state=$state")
+        assertEquals(HttpStatusCode.OK, client.get("/api/me").status)
+
+        // An admin suspends Alice out-of-band → her very next request must 401 (spec §7).
+        transaction {
+            Users.update({ Users.githubId eq 42L }) { it[Users.status] = UserStatus.suspended.name }
+        }
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/api/me").status)
+    }
+
+    // ---- admin → 404 invariant (spec §7: non-admins and anons never learn the route exists) ----
+
+    @Test
+    fun adminGateReturns404ForAnonMemberAndOkForAdmin() {
+        // Set up three identities up front (committed to the DB file).
+        val config = TestSupport.newConfig(dir)
+        Database.init(config)
+        val memberId = UsersRepo.upsertFromGitHub(GitHubUser(1, "mem", "Mem", null), null)
+        val adminId = UsersRepo.upsertFromGitHub(GitHubUser(2, "adm", "Adm", null), bootstrapAdminGithubId = 2L)
+        // Sanity: roles as expected.
+        transaction {
+            assertEquals(Role.member.name, Users.selectAll().where { Users.id eq memberId }.single()[Users.role])
+            assertEquals(Role.admin.name, Users.selectAll().where { Users.id eq adminId }.single()[Users.role])
+        }
+        val memberToken = SessionStore.create(memberId, 3600)
+        val adminToken = SessionStore.create(adminId, 3600)
+
+        testApplication {
+            application { adminGateApp() }
+            // Anonymous → 404 (NOT 401/403).
+            val anon = client.get("/api/admin/_gate")
+            assertEquals(HttpStatusCode.NotFound, anon.status)
+            assertFalse(anon.bodyAsText().contains("role"))
+            // Authenticated member → 404.
+            val mem = client.get("/api/admin/_gate") { header("Cookie", "$SESSION_COOKIE=$memberToken") }
+            assertEquals(HttpStatusCode.NotFound, mem.status)
+            // Admin → 200.
+            val adm = client.get("/api/admin/_gate") { header("Cookie", "$SESSION_COOKIE=$adminToken") }
+            assertEquals(HttpStatusCode.OK, adm.status)
+            assertTrue(adm.bodyAsText().contains("\"role\":\"admin\""))
+        }
+    }
+
+    private fun Application.adminGateApp() {
+        install(ContentNegotiation) { json() }
+        installApiErrorMapping()
+        routing {
+            get("api/admin/_gate") {
+                val p = call.requireAdmin()
+                call.respond(mapOf("role" to p.role.name))
+            }
+        }
+    }
+
+    /** Builds the real module() with an injected [oauth] and a cookie-persisting client. */
+    private fun testApp(oauth: OAuthClient?, block: suspend (client: HttpClient) -> Unit) {
+        val config = TestSupport.newConfig(dir)
+        Database.init(config)
+        testApplication {
+            application { module(config, oauth = oauth) }
+            val client = createClient {
+                followRedirects = false
+                install(HttpCookies)
+            }
+            block(client)
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
@@ -89,6 +89,11 @@ class AuthRoutesTest {
         val cb = client.get("/api/auth/github/callback?code=code-OK&state=$state")
         assertEquals(HttpStatusCode.Found, cb.status)
         assertEquals("http://localhost:8080", cb.headers["Location"])
+        // NEW-2: the success-path Set-Cookie for the single-use state cookie must
+        // actually emit (proves the clear isn't a no-op after respondRedirect).
+        val cbCookies = cb.headers.getAll("Set-Cookie") ?: emptyList()
+        assertTrue(cbCookies.any { it.startsWith("$STATE_COOKIE=") && it.contains("Max-Age=0") },
+            "success path must clear the state cookie: $cbCookies")
 
         // 3. /api/me now resolves Alice (session cookie carried by HttpCookies).
         val me = client.get("/api/me")

--- a/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/AuthRoutesTest.kt
@@ -157,6 +157,37 @@ class AuthRoutesTest {
     }
 
     @Test
+    fun disabledOAuthReturns503TypedEnvelopeOnStartAndCallback() = testApp(oauth = null) { client ->
+        // P3-5 + coverage gap: when OAuth is unconfigured, both routes return the
+        // typed ErrorResponse envelope (code=auth_disabled), not a hand-rolled map.
+        val start = client.get("/api/auth/github/start")
+        assertEquals(HttpStatusCode.ServiceUnavailable, start.status)
+        assertTrue(start.bodyAsText().contains("\"code\":\"auth_disabled\""), start.bodyAsText())
+        val cb = client.get("/api/auth/github/callback?code=x&state=y")
+        assertEquals(HttpStatusCode.ServiceUnavailable, cb.status)
+        assertTrue(cb.bodyAsText().contains("\"error\":"), cb.bodyAsText())
+    }
+
+    @Test
+    fun anonymousLogoutIs401() = testApp(oauth = FakeOAuthClient()) { client ->
+        // Coverage gap: logout with no session → 401, not 500.
+        assertEquals(HttpStatusCode.Unauthorized, client.post("/api/auth/logout").status)
+    }
+
+    @Test
+    fun callbackReturns400OnMissingCodeOrStateCookie() = testApp(oauth = FakeOAuthClient()) { client ->
+        client.get("/api/auth/github/start") // establish state cookie
+        // Missing code.
+        val noCode = client.get("/api/auth/github/callback?state=whatever")
+        assertEquals(HttpStatusCode.BadRequest, noCode.status)
+        // Missing state cookie: the state param can't match a cookie that isn't
+        // stored (HttpCookies jar is empty per-request unless set), so this hits
+        // the missing-state-cookie branch.
+        val noState = client.get("/api/auth/github/callback?code=code-OK&state=absent")
+        assertEquals(HttpStatusCode.BadRequest, noState.status)
+    }
+
+    @Test
     fun suspendedUserIsLoggedOutMidSession() = testApp(oauth = FakeOAuthClient()) { client ->
         // Log Alice in.
         val start = client.get("/api/auth/github/start")

--- a/api/src/test/kotlin/dev/androidskills/auth/GitHubOAuthClientTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/GitHubOAuthClientTest.kt
@@ -65,4 +65,20 @@ class GitHubOAuthClientTest {
         val ex = assertFailsWith<OAuthException> { gh.exchange("code", "https://app/cb") }
         assertTrue(ex.message!!.contains("bad_verification_code"))
     }
+
+    @Test
+    fun exchangeSucceedsWhenReadUserScopeIsGranted() = kotlinx.coroutines.runBlocking {
+        val gh = newClient(HttpStatusCode.OK, """{"access_token":"tok-OK","token_type":"bearer","scope":"read:user"}""")
+        val tokens = gh.exchange("code", "https://app/cb")
+        assertEquals("tok-OK", tokens.accessToken)
+    }
+
+    @Test
+    fun exchangeRefusesATokenMissingTheReadUserScope() = kotlinx.coroutines.runBlocking {
+        // P3-1: a downscoped/empty token can't call GET /user; refuse it now
+        // rather than letting the next request 401.
+        val gh = newClient(HttpStatusCode.OK, """{"access_token":"tok","token_type":"bearer","scope":""}""")
+        val ex = assertFailsWith<OAuthException> { gh.exchange("code", "https://app/cb") }
+        assertTrue(ex.message!!.contains("read:user"), ex.message!!)
+    }
 }

--- a/api/src/test/kotlin/dev/androidskills/auth/GitHubOAuthClientTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/GitHubOAuthClientTest.kt
@@ -1,0 +1,68 @@
+package dev.androidskills.auth
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * P1-2: the real client must translate every auth/network failure into
+ * [OAuthException] so the route can map it to a controlled 400. Uses a MockEngine
+ * (no network) to assert both the translation and the happy path.
+ */
+class GitHubOAuthClientTest {
+
+    private var client: HttpClient? = null
+
+    @AfterTest
+    fun teardown() { client?.close() }
+
+    private fun newClient(status: HttpStatusCode, body: String): GitHubOAuthClient {
+        val http = HttpClient(MockEngine { _ ->
+            respond(body, status, headersOf(HttpHeaders.ContentType, "application/json"))
+        }) {
+            install(ContentNegotiation) { json(dev.androidskills.util.appJson) }
+            expectSuccess = true
+        }
+        client = http
+        return GitHubOAuthClient(clientId = "cid", clientSecret = "secret", http = http)
+    }
+
+    @Test
+    fun `non-2xx response is translated to OAuthException`() = kotlinx.coroutines.runBlocking {
+        // expectSuccess throws ResponseException on 401; the client must catch and
+        // rethrow as OAuthException (not leak to the route as a 500).
+        val gh = newClient(HttpStatusCode.Unauthorized, """{"message":"Bad credentials"}""")
+        val ex = assertFailsWith<OAuthException> { gh.userInfo("tok") }
+        assertTrue(ex.message!!.contains("GitHub request failed"))
+    }
+
+    @Test
+    fun `successful user lookup returns the GitHub identity`() = kotlinx.coroutines.runBlocking {
+        val gh = newClient(
+            HttpStatusCode.OK,
+            """{"id":42,"login":"alice","name":"Alice","avatar_url":"https://av/alice.png"}""",
+        )
+        val user = gh.userInfo("tok")
+        assertEquals(42L, user.githubId)
+        assertEquals("alice", user.handle)
+        assertEquals("Alice", user.name)
+    }
+
+    @Test
+    fun `token endpoint error response surfaces as OAuthException`() = kotlinx.coroutines.runBlocking {
+        // GitHub returns 200 with an error body for a bad code.
+        val gh = newClient(HttpStatusCode.OK, """{"error":"bad_verification_code","error_description":"expired"}""")
+        val ex = assertFailsWith<OAuthException> { gh.exchange("code", "https://app/cb") }
+        assertTrue(ex.message!!.contains("bad_verification_code"))
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/auth/GitHubOAuthClientTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/auth/GitHubOAuthClientTest.kt
@@ -74,11 +74,20 @@ class GitHubOAuthClientTest {
     }
 
     @Test
-    fun exchangeRefusesATokenMissingTheReadUserScope() = kotlinx.coroutines.runBlocking {
-        // P3-1: a downscoped/empty token can't call GET /user; refuse it now
-        // rather than letting the next request 401.
-        val gh = newClient(HttpStatusCode.OK, """{"access_token":"tok","token_type":"bearer","scope":""}""")
+    fun exchangeRefusesAPresentScopeMissingReadUser() = kotlinx.coroutines.runBlocking {
+        // P3-1: a token downscoped to something else (not read:user) is refused.
+        val gh = newClient(HttpStatusCode.OK, """{"access_token":"tok","token_type":"bearer","scope":"gist"}""")
         val ex = assertFailsWith<OAuthException> { gh.exchange("code", "https://app/cb") }
         assertTrue(ex.message!!.contains("read:user"), ex.message!!)
+    }
+
+    @Test
+    fun exchangeAcceptsAnEmptyScopeForGithubAppCompatibility() = kotlinx.coroutines.runBlocking {
+        // NEW-1: GitHub App user-to-server tokens are SCOPELESS (empty `scope`).
+        // Hard-failing here would reject every login once the real App is wired
+        // (step 4). Empty/absent scope must be accepted; GET /user 401 is the guard.
+        val gh = newClient(HttpStatusCode.OK, """{"access_token":"tok","token_type":"bearer","scope":""}""")
+        val tokens = gh.exchange("code", "https://app/cb")
+        assertEquals("tok", tokens.accessToken)
     }
 }


### PR DESCRIPTION
## What this is

Step 3 of `docs/backend-spec.md` §14 — **Auth** (§7, §9 Auth, §13): GitHub OAuth web flow, DB-backed sessions, `/api/me`, and the role middleware with the **admin → 404** invariant. Built in an isolated worktree (`wt/step3-auth`) off `develop`.

## Endpoints

| Method | Path | Auth | Notes |
|---|---|---|---|
| GET | `/api/auth/github/start` | — | CSRF state cookie (10m), 302 to GitHub authorize (`scope=read:user`). **503 `auth_disabled`** when OAuth creds absent (§13). |
| GET | `/api/auth/github/callback` | — | constant-time state check, code→token, `GET /user`, upsert user, create session, set session cookie, 302 to site root. State mismatch → **400**. |
| POST | `/api/auth/logout` | S | delete session row + clear cookie. |
| GET | `/api/me` | S | `{id,handle,name,avatarUrl,role,status,createdAt}`; **401** if anon/expired/suspended. |

## Commit narrative

| Commit | Scope |
|---|---|
| `14bfb62` | config (`AuthConfig`), 400/401 typed errors, `SessionStore`, `UsersRepo`, `OAuthClient` + `GitHubOAuthClient` + `DisabledOAuthClient`, `Principal` + `principal()/requireSession()/requireAdmin()` + cookie helpers |
| `1f00dd4` | the four routes + `Application.module(config, oauth?)` wiring (builds the GitHub client from env creds, or `DisabledOAuthClient`; health reports `auth`) |
| `91d16c7` | tests (15) |

## Invariants honored

- **Manifest/source-of-truth, public visibility, etc.** from steps 1–2 are untouched.
- **Sessions are DB-backed**, not JWTs — so **suspend** (status change) and **logout** (row delete) revoke *immediately*. `SessionStore.lookup` returns null for unknown / expired / suspended, in one place (architecture.md).
- **Admin gating (critical, §7):** `requireAdmin()` returns **404** for *everyone* who isn't an admin — **including anonymous callers**. It does **not** chain `requireSession()` first, because a 401/403 would leak that the route exists. Proven over HTTP: anon→404, member→404, admin→200.
- **Cookie flags:** `httpOnly` + `Secure` + `SameSite=Lax`; opaque 256-bit token (no forgeable claims). `Secure` is relaxed for plain-HTTP localhost so a dev browser can actually log in (overridable via `SESSION_COOKIE_SECURE`).
- **External service behind an interface:** `OAuthClient` (fake in tests, `GitHubOAuthClient` in prod, `DisabledOAuthClient` when creds absent). The GitHub HTTP client is the only real network dependency in this step and is **not** exercised by unit tests — the flow is covered end-to-end via a fake.

## Assumptions (please confirm)

- **Admin bootstrap:** spec leaves admin promotion to the admin queue (step 7), but there's no way to *get* the first admin otherwise. Added `BOOTSTRAP_ADMIN_GITHUB_ID` — when set, that GitHub id is promoted to `admin` on upsert (explicit, not auto-promotion of the first user). Flip to a different bootstrap model if you prefer.
- **Suspended users get 401 on `/api/me`** (treated as "no valid session"). For admin routes they'd get 404 like any non-admin. If you'd rather suspended users see a dedicated "account suspended" page/status, that's a step-7 product decision.
- **OAuth scope is `read:user`** only — enough for identity. Repo access for contributing (step 6) will come via the GitHub App installation, not the user OAuth token.
- **State cookie is httpOnly+Secure+SameSite=Lax** (not `Strict`) so the GitHub→callback POST-less GET redirect works.
- **Handle recycling:** if a *different* github_id now owns a handle that exists for another user, the new login is disambiguated as `handle-{githubId}` rather than failing the login (documented edge case).

## Test status

- `api/gradlew -p api build` ✅ (also `clean build`)
- **79 tests**, all green (+15 auth): `AuthDomainTest` (9: session lifecycle incl. expiry + suspended revocation + purgeExpired; user upsert incl. bootstrap-admin + handle-collision disambig) and `AuthRoutesTest` (6: `/api/me` 401 anon; start 503 disabled; **full login→logout flow** via fake OAuthClient; state-mismatch 400; suspended-mid-session 401; the **admin→404 invariant** over a throwaway `/api/admin/_gate` route).
- The login flow test parses the CSRF state cookie from `Set-Cookie`, drives the callback with the matching `state`, and asserts the session cookie carries through to `/api/me` — all in-process (no network).

## Reviewer notes

- Three small commits intended to read in order (domain → routes → tests).
- `ktor-client-core/cio/content-negotiation` added (the real GitHub client); `ktor-client-mock` added as testImpl (unused for now, leaves the door open for HTTP-level client tests).
- No cloud credentials in the repo; auth runs disabled locally out of the box (steps 1–2 still build/run with zero setup). To exercise the real flow you'd set `GITHUB_OAUTH_CLIENT_ID`/`_SECRET` and `PUBLIC_BASE_URL`.
- Worktree used: `.worktrees/step3-auth` (now committed to be ignored in `develop`).

**Holding for review — not merging.**
