### PR TITLE
api: step 4 — GitHub App client + read-only skill discovery + scan + webhooks

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/AppConfig.kt
+++ b/api/src/main/kotlin/dev/androidskills/AppConfig.kt
@@ -20,13 +20,15 @@ data class AppConfig(
     /** When true, a small demo dataset is seeded into an empty DB (local/dev only). */
     val seedDemo: Boolean = false,
     val auth: AuthConfig = AuthConfig.disabled(),
+    /** GitHub App (installation tokens, repo scan, webhooks). null → disabled (spec §13). */
+    val githubApp: GithubAppConfig = GithubAppConfig.disabled(),
 ) {
-    // P3-2: redact the LLM key (and rely on OAuthConfig.toString) so a logged
-    // AppConfig instance never spills a secret.
+    // P3-2: redact the LLM key (and rely on OAuthConfig/GithubAppConfig.toString) so
+    // a logged AppConfig instance never spills a secret.
     override fun toString(): String =
         "AppConfig(version=$version, dbPath=$dbPath, fileStoreDir=$fileStoreDir, " +
             "llmBaseUrl=$llmBaseUrl, llmApiKey=${if (llmApiKey == null) "null" else "***"}, " +
-            "llmModel=$llmModel, seedDemo=$seedDemo, auth=$auth)"
+            "llmModel=$llmModel, seedDemo=$seedDemo, auth=$auth, githubApp=$githubApp)"
 
     companion object {
         fun fromEnv(): AppConfig {
@@ -63,6 +65,7 @@ data class AppConfig(
                     } ?: secureDefault,
                     bootstrapAdminGithubId = env("BOOTSTRAP_ADMIN_GITHUB_ID")?.toLongOrNull(),
                 ),
+                githubApp = GithubAppConfig.fromEnv(),
             )
         }
     }
@@ -103,4 +106,50 @@ data class AuthConfig(
 data class OAuthConfig(val clientId: String, val clientSecret: String) {
     // P3-2: never leak the secret if a config instance is logged.
     override fun toString() = "OAuthConfig(clientId=$clientId, clientSecret=***)"
+}
+
+/**
+ * GitHub App configuration (spec §8, §13). [GithubAppConfig.disabled] when the
+ * App id / private key / webhook secret are unset → the GitHub-App features
+ * (repo list, scan, webhooks) report disabled, mirroring the §13 "unset →
+ * disabled" pattern used for auth.
+ *
+ * **Single-App invariant (doc-only, no heuristic — review Q1):** this App and
+ * the OAuth client in [AuthConfig] must describe the SAME GitHub App: login
+ * (OAuth-App user flow) and installation tokens (this config) share one App
+ * identity. The env names differ for historical reasons; do not assume two
+ * apps. Renaming `GITHUB_OAUTH_CLIENT_*` → `GITHUB_APP_CLIENT_*` is deferred
+ * (would churn step-3 config/docs for no functional gain).
+ *
+ * @param appId Numeric App id (`GITHUB_APP_ID`).
+ * @param privateKeyPem PEM private key (`GITHUB_APP_PRIVATE_KEY`). Accepts PKCS#1
+ *  (`-----BEGIN RSA PRIVATE KEY-----`, what GitHub exports) or PKCS#8; the
+ *  loader normalises PKCS#1 → PKCS#8 so the exported key works as-is.
+ * @param webhookSecret HMAC key for `/gh/webhooks` signature verification.
+ */
+data class GithubAppConfig(
+    val appId: Long?,
+    val privateKeyPem: String?,
+    val webhookSecret: String?,
+) {
+    /** Configured only when all three are present (partial config is treated as disabled). */
+    val configured: Boolean get() = appId != null && privateKeyPem != null && webhookSecret != null
+
+    // P3-2: never leak the PEM or the webhook secret in a logged config instance.
+    override fun toString(): String =
+        "GithubAppConfig(appId=$appId, privateKeyPem=${if (privateKeyPem == null) "null" else "***"}, " +
+            "webhookSecret=${if (webhookSecret == null) "null" else "***"}, configured=$configured)"
+
+    companion object {
+        fun disabled() = GithubAppConfig(appId = null, privateKeyPem = null, webhookSecret = null)
+
+        fun fromEnv(): GithubAppConfig {
+            fun env(k: String) = System.getenv(k)?.takeIf { it.isNotBlank() }
+            return GithubAppConfig(
+                appId = env("GITHUB_APP_ID")?.toLongOrNull(),
+                privateKeyPem = env("GITHUB_APP_PRIVATE_KEY"),
+                webhookSecret = env("GITHUB_WEBHOOK_SECRET"),
+            )
+        }
+    }
 }

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -2,11 +2,13 @@ package dev.androidskills
 
 import dev.androidskills.api.installApiErrorMapping
 import dev.androidskills.api.publicRoutes
+import dev.androidskills.api.contributorRoutes
 import dev.androidskills.auth.DisabledOAuthClient
 import dev.androidskills.auth.GitHubOAuthClient
 import dev.androidskills.auth.OAuthClient
 import dev.androidskills.auth.authRoutes
 import dev.androidskills.db.Skills
+import dev.androidskills.github.GitHubAppClient
 import dev.androidskills.llm.LlmClient
 import dev.androidskills.llm.StubLlmClient
 import dev.androidskills.storage.FileStore
@@ -41,7 +43,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
  *   real [GitHubOAuthClient] is built from env creds, or [DisabledOAuthClient]
  *   when creds are absent (spec §13: "unset → auth disabled").
  */
-fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClient? = null) {
+fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClient? = null, githubApp: GitHubAppClient? = null) {
     Database.init(config)
 
     install(ContentNegotiation) { json() }
@@ -51,6 +53,11 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
     val fileStore: FileStore = LocalFsStore(config.fileStoreDir)
     val llm: LlmClient = StubLlmClient()
     val (resolvedOauth, ghHttp) = resolveOauth(config.auth, oauth)
+    val resolvedGithubApp = githubApp ?: if (config.githubApp.configured) {
+        // The real impl lands in a later commit (it needs the HTTP client + JWT).
+        // For now, a Disabled client keeps the routes honest when creds are absent.
+        dev.androidskills.github.DisabledGitHubAppClient()
+    } else dev.androidskills.github.DisabledGitHubAppClient()
 
     // P3-3: surface the resolved cookie posture once at boot — Secure/Domain drive
     // auth correctness and a mis-set SESSION_COOKIE_DOMAIN is a silent footgun.
@@ -89,6 +96,7 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
         }
         publicRoutes(fileStore)
         authRoutes(config, resolvedOauth)
+        contributorRoutes(resolvedGithubApp)
     }
 }
 

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -9,6 +9,7 @@ import dev.androidskills.auth.OAuthClient
 import dev.androidskills.auth.authRoutes
 import dev.androidskills.db.Skills
 import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.gh.webhookRoutes
 import dev.androidskills.llm.LlmClient
 import dev.androidskills.llm.StubLlmClient
 import dev.androidskills.storage.FileStore
@@ -97,6 +98,7 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
         publicRoutes(fileStore)
         authRoutes(config, resolvedOauth)
         contributorRoutes(resolvedGithubApp)
+        webhookRoutes(resolvedGithubApp)
     }
 }
 

--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -72,13 +72,21 @@ private suspend fun scan(call: ApplicationCall, gh: GitHubAppClient) {
         catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub ref lookup failed: ${e.message}", "github_ref_failed") }
     val zipball = try { gh.downloadZipball(installationId, owner, repo, head) }
         catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub archive download failed: ${e.message}", "github_archive_failed") }
+    // Compressed-body cap (Q4, plan §3 step 1 — the caller bounds this so a giant
+    // zipball can't sit fully in memory before Discovery's inflated guard runs).
+    if (zipball.size > MAX_COMPRESSED_ZIPBALL) {
+        throw ApiValidationException(
+            mapOf("archive" to "zipball exceeds ${MAX_COMPRESSED_ZIPBALL / (1024 * 1024)} MB compressed"),
+            code = "archive_too_large",
+        )
+    }
 
     val result = Discovery.discover(ArchiveSource.RepoZipball(zipball, head))
     val response = when (result) {
         is ScanResult.Found -> ScanResponse(slug = "$owner/$repo", commitSha = head, skills = result.skills.map { it.toDto() })
         ScanResult.NoSkillsDir -> throw ApiValidationException(
             mapOf("repo" to "no top-level 'skills/' directory found; SKILL.md must live under skills/"),
-            "no_skills_dir",
+            code = "no_skills_dir",
         )
     }
     call.respond(response)
@@ -96,6 +104,9 @@ private suspend fun scan(call: ApplicationCall, gh: GitHubAppClient) {
 @Serializable data class ScanResponse(val slug: String, val commitSha: String, val skills: List<DetectedSkillDto>)
 
 private fun dev.androidskills.github.RepoRef.toDto() = RepoDto(owner, name, fullName, defaultBranch)
+
+/** Compressed-zipball cap; the inflated cap is inside Discovery (Q4). */
+private const val MAX_COMPRESSED_ZIPBALL = 50 * 1024 * 1024
 private fun DetectedSkill.toDto() = DetectedSkillDto(
     slug, name, description, license, tags, version, versionSource,
     tokenUpfront, tokenOndemand, tokenBand,

--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -1,0 +1,103 @@
+package dev.androidskills.api
+
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GitHubAppException
+import dev.androidskills.ingest.ArchiveSource
+import dev.androidskills.ingest.DetectedSkill
+import dev.androidskills.ingest.Discovery
+import dev.androidskills.ingest.ScanResult
+import dev.androidskills.auth.requireSession
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.serialization.Serializable
+
+/**
+ * Contributor routes (spec §9): repo list + on-demand scan.
+ *
+ * Both are `S` (session required). The GitHub-App features report disabled (503
+ * `github_app_disabled`) when the App creds are absent (§13), mirroring auth.
+ *
+ * **Step-4 scope (Q3, gotcha #2):** `/api/me/repos` lists **personal-account**
+ * installations only (`installation.accountId == principal.githubId`).
+ * Org-membership filtering needs a signal the App JWT can't provide (the user
+ * OAuth token, which step 3 doesn't persist, or an installation token with
+ * `members:read`) — deferred to step 6 where org-ownership actually matters.
+ */
+fun Route.contributorRoutes(githubApp: GitHubAppClient) {
+    route("api/me") {
+        get("repos") { repos(call, githubApp) }
+        post("repos/{owner}/{repo}/scan") { scan(call, githubApp) }
+    }
+}
+
+private suspend fun repos(call: ApplicationCall, gh: GitHubAppClient) {
+    if (!gh.configured) {
+        call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse(ErrorBody("github_app_disabled", "GitHub App is not configured")))
+        return
+    }
+    val principal = call.requireSession()
+    // Personal installations only (Q3). Org installs arrive in step 6.
+    val mine = try {
+        gh.installations().filter { it.accountId == principal.githubId }
+    } catch (e: GitHubAppException) {
+        throw ApiBadGatewayException("GitHub installations request failed: ${e.message}", "github_installations_failed")
+    }
+    val repos = mine.flatMap { inst ->
+        try { gh.listRepos(inst.id) } catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub list-repos failed: ${e.message}", "github_list_repos_failed") }
+    }
+    call.respond(ReposResponse(repos.map { it.toDto() }))
+}
+
+private suspend fun scan(call: ApplicationCall, gh: GitHubAppClient) {
+    if (!gh.configured) {
+        call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse(ErrorBody("github_app_disabled", "GitHub App is not configured")))
+        return
+    }
+    val principal = call.requireSession() // gates access; ownership of the repo is checked at submit (step 6)
+    val owner = call.parameters["owner"] ?: throw ApiBadRequestException("Missing owner")
+    val repo = call.parameters["repo"] ?: throw ApiBadRequestException("Missing repo")
+
+    val installationId = try {
+        gh.installations().firstOrNull { it.accountId == principal.githubId }?.id
+            ?: throw ApiNotFoundException("No installation for user '${principal.handle}'")
+    } catch (e: GitHubAppException) {
+        throw ApiBadGatewayException("GitHub installations request failed: ${e.message}", "github_installations_failed")
+    }
+    val head = try { gh.defaultBranchHead(installationId, owner, repo) }
+        catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub ref lookup failed: ${e.message}", "github_ref_failed") }
+    val zipball = try { gh.downloadZipball(installationId, owner, repo, head) }
+        catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub archive download failed: ${e.message}", "github_archive_failed") }
+
+    val result = Discovery.discover(ArchiveSource.RepoZipball(zipball, head))
+    val response = when (result) {
+        is ScanResult.Found -> ScanResponse(slug = "$owner/$repo", commitSha = head, skills = result.skills.map { it.toDto() })
+        ScanResult.NoSkillsDir -> throw ApiValidationException(
+            mapOf("repo" to "no top-level 'skills/' directory found; SKILL.md must live under skills/"),
+            "no_skills_dir",
+        )
+    }
+    call.respond(response)
+}
+
+@Serializable data class RepoDto(val owner: String, val name: String, val fullName: String, val defaultBranch: String?)
+@Serializable data class ReposResponse(val repos: List<RepoDto>)
+@Serializable data class DetectedSkillDto(
+    val slug: String, val name: String, val description: String, val license: String?,
+    val tags: List<String>, val version: String, val versionSource: String,
+    val tokenUpfront: Int, val tokenOndemand: Int, val tokenBand: String,
+    val parseErrors: List<DetectedFieldError>, val fileCount: Int,
+)
+@Serializable data class DetectedFieldError(val field: String, val reason: String)
+@Serializable data class ScanResponse(val slug: String, val commitSha: String, val skills: List<DetectedSkillDto>)
+
+private fun dev.androidskills.github.RepoRef.toDto() = RepoDto(owner, name, fullName, defaultBranch)
+private fun DetectedSkill.toDto() = DetectedSkillDto(
+    slug, name, description, license, tags, version, versionSource,
+    tokenUpfront, tokenOndemand, tokenBand,
+    parseErrors.map { DetectedFieldError(it.field, it.reason) }, fileCount,
+)

--- a/api/src/main/kotlin/dev/androidskills/api/Errors.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Errors.kt
@@ -37,10 +37,13 @@ class ApiUnauthorizedException(message: String = "Authentication required") : Ru
 /** 400 — malformed request / CSRF state mismatch. */
 class ApiBadRequestException(message: String = "Bad request") : RuntimeException(message)
 
-/** 422 — per-field validation failure (spec §10). */
+/** 422 — per-field validation failure (spec §10). [code] lets a handler emit a
+ *  specific stable code (e.g. `no_skills_dir`, `archive_too_large`) that clients
+ *  switch on, instead of the generic `validation_failed`. */
 class ApiValidationException(
     val fields: Map<String, String>,
     message: String = "Validation failed",
+    val code: String = "validation_failed",
 ) : RuntimeException(message)
 
 /** 409 — duplicate slug, first-come ownership conflict. */
@@ -67,7 +70,7 @@ fun Application.installApiErrorMapping() {
         exception<ApiValidationException> { call, ex ->
             call.respond(
                 HttpStatusCode.UnprocessableEntity,
-                ErrorResponse(ErrorBody("validation_failed", ex.message ?: "Validation failed", ex.fields)),
+                ErrorResponse(ErrorBody(ex.code, ex.message ?: "Validation failed", ex.fields)),
             )
         }
         exception<ApiConflictException> { call, ex ->

--- a/api/src/main/kotlin/dev/androidskills/api/Errors.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Errors.kt
@@ -49,6 +49,9 @@ class ApiConflictException(message: String, val code: String = "conflict") : Run
 /** 500 — a DB-referenced FileStore object is missing (storage corruption). */
 class ApiStorageException(message: String) : RuntimeException(message)
 
+/** 502 — an upstream service (GitHub, LLM) failed. */
+class ApiBadGatewayException(message: String, val code: String = "bad_gateway") : RuntimeException(message)
+
 fun Application.installApiErrorMapping() {
     install(StatusPages) {
         val log = LoggerFactory.getLogger("dev.androidskills.api.Errors")
@@ -76,6 +79,9 @@ fun Application.installApiErrorMapping() {
                 HttpStatusCode.InternalServerError,
                 ErrorResponse(ErrorBody("storage_error", ex.message ?: "File unavailable")),
             )
+        }
+        exception<ApiBadGatewayException> { call, ex ->
+            call.respond(HttpStatusCode.BadGateway, ErrorResponse(ErrorBody(ex.code, ex.message ?: "Bad gateway")))
         }
         exception<Throwable> { call, ex ->
             log.error("Unhandled error serving ${call.request.local.uri}", ex)

--- a/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
@@ -4,6 +4,7 @@ import dev.androidskills.AppConfig
 import dev.androidskills.api.ApiBadRequestException
 import dev.androidskills.api.ErrorBody
 import dev.androidskills.api.ErrorResponse
+import dev.androidskills.util.constantTimeEquals
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
@@ -100,10 +101,3 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
     }
 }
 
-/** Constant-time string compare to avoid timing leaks on the state check. */
-private fun constantTimeEquals(a: String, b: String): Boolean {
-    if (a.length != b.length) return false
-    var diff = 0
-    for (i in a.indices) diff = diff or (a[i].code xor b[i].code)
-    return diff == 0
-}

--- a/api/src/main/kotlin/dev/androidskills/auth/Principal.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/Principal.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.Serializable
 data class Principal(
     val sessionId: String,
     val userId: String,
+    val githubId: Long,
     val handle: String,
     val name: String?,
     val avatarUrl: String?,

--- a/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
@@ -60,6 +60,7 @@ object SessionStore {
         Principal(
             sessionId = token,
             userId = user[Users.id],
+            githubId = user[Users.githubId],
             handle = user[Users.handle],
             name = user[Users.name],
             avatarUrl = user[Users.avatarUrl],

--- a/api/src/main/kotlin/dev/androidskills/gh/WebhookRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/gh/WebhookRoutes.kt
@@ -1,0 +1,113 @@
+package dev.androidskills.gh
+
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Jobs
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GithubWebhookEvent
+import dev.androidskills.util.appJson
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveStream
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import org.slf4j.LoggerFactory
+import java.time.Instant
+
+/**
+ * Webhook route (spec §8). Receives GitHub App events at the webhook path.
+ *
+ * **Signature handling (gotcha D):** bad or missing signature → 401 (GitHub's
+ * convention; the URL isn't secret and 200-everything suppresses GitHub's
+ * redelivery and blinds the delivery panel). Accepted → 202. The
+ * anti-enumeration framing used for admin routes (404-not-403) doesn't apply
+ * here — the URL is configured in the App settings and an attacker can't forge
+ * the HMAC anyway.
+ *
+ * **Push → resync enqueue** with (bundle_id, head_sha) idempotency (Q5):
+ * GitHub can redeliver the same push under different delivery IDs, so dedupe on
+ * the payload key, not the delivery id. Single-writer SQLite makes check-then-
+ * insert safe. Resync execution is step 5 — step 4 only enqueues.
+ *
+ * **installation / installation_repositories:** record the installation id on
+ * matching bundles for access tracking (full access modelling is step 6).
+ */
+private val logger = LoggerFactory.getLogger("dev.androidskills.gh.WebhookRoutes")
+
+fun Route.webhookRoutes(githubApp: GitHubAppClient) {
+    post("/gh/webhooks") { handle(call, githubApp) }
+}
+
+private suspend fun handle(call: ApplicationCall, gh: GitHubAppClient) {
+    val body = call.receiveStream().readBytes() // raw bytes — HMAC over exactly what GitHub sent
+    val signature = call.request.headers["X-Hub-Signature-256"].orEmpty()
+
+    val event = gh.verifyAndParseEvent(body, signature) // null on bad sig / unhandled event
+    if (event == null) {
+        // Bad/missing signature OR an event type we don't act on. GitHub's convention
+        // is 401 on signature mismatch; we return 401 for any verify failure so a
+        // misconfigured secret surfaces in GitHub's delivery panel.
+        call.respond(HttpStatusCode.Unauthorized, mapOf("error" to mapOf("code" to "invalid_signature", "message" to "Invalid or missing signature")))
+        return
+    }
+
+    when (event) {
+        is GithubWebhookEvent.Push -> if (event.isDefaultBranch) enqueueResync(event)
+        is GithubWebhookEvent.InstallationAccess -> trackInstallation(event)
+    }
+    call.respond(HttpStatusCode.Accepted, mapOf("ok" to true))
+}
+
+/** Enqueue a resync job for the pushed repo, idempotent on (bundle, head_sha). */
+private fun enqueueResync(push: GithubWebhookEvent.Push) = transaction {
+    val provenance = "${push.repoOwner}/${push.repoName}"
+    val bundle = Bundles.selectAll()
+        .where { (Bundles.kind eq "repo") and (Bundles.provenance eq provenance) }
+        .singleOrNull()
+    if (bundle == null) {
+        // Repo isn't tracked (never submitted). Don't enqueue — nothing to resync.
+        return@transaction
+    }
+    val bundleId = bundle[Bundles.id]
+    // Idempotency (Q5): GitHub may redeliver under different delivery IDs; dedupe
+    // on the payload's (bundle, after) key. A queued/running job for the same head
+    // means a resync is already in flight.
+    val payload = appJson.encodeToString(ResyncPayload.serializer(), ResyncPayload(bundleId, push.after))
+    val alreadyQueued = Jobs.selectAll()
+        .where { (Jobs.type eq "resync") and (Jobs.payload eq payload) and (Jobs.state inList listOf("queued", "running")) }
+        .any()
+    if (alreadyQueued) return@transaction
+    val now = nowIso()
+    Jobs.insert {
+        it[Jobs.id] = newId()
+        it[Jobs.type] = "resync"
+        it[Jobs.payload] = payload
+        it[Jobs.state] = "queued"
+        it[Jobs.attempts] = 0
+        it[Jobs.runAfter] = now
+        it[Jobs.createdAt] = now
+        it[Jobs.updatedAt] = now
+    }
+    logger.info("enqueued resync for bundle={} sha={}", bundleId, push.after.take(7))
+}
+
+/** Record the installation id on bundles owned by the installation's account. */
+private fun trackInstallation(ev: GithubWebhookEvent.InstallationAccess) = transaction {
+    // Lightweight step-4 tracking: tag repo bundles for this account with the
+    // installation id so future scans/webhooks resolve to it. Full access modelling
+    // (org membership, repo add/remove diffs) is step 6.
+    Bundles.update({ Bundles.provenance like "${ev.accountLogin}/%" }) {
+        it[Bundles.installationId] = ev.installationId
+    }
+    Unit
+}
+
+@kotlinx.serialization.Serializable
+private data class ResyncPayload(val bundleId: String, val headSha: String)

--- a/api/src/main/kotlin/dev/androidskills/gh/WebhookRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/gh/WebhookRoutes.kt
@@ -3,6 +3,7 @@ package dev.androidskills.gh
 import dev.androidskills.db.Bundles
 import dev.androidskills.db.Jobs
 import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GitHubAppException
 import dev.androidskills.github.GithubWebhookEvent
 import dev.androidskills.util.appJson
 import dev.androidskills.util.newId
@@ -49,12 +50,17 @@ private suspend fun handle(call: ApplicationCall, gh: GitHubAppClient) {
     val body = call.receiveStream().readBytes() // raw bytes — HMAC over exactly what GitHub sent
     val signature = call.request.headers["X-Hub-Signature-256"].orEmpty()
 
-    val event = gh.verifyAndParseEvent(body, signature) // null on bad sig / unhandled event
-    if (event == null) {
-        // Bad/missing signature OR an event type we don't act on. GitHub's convention
-        // is 401 on signature mismatch; we return 401 for any verify failure so a
-        // misconfigured secret surfaces in GitHub's delivery panel.
+    val event = try {
+        gh.verifyAndParseEvent(body, signature)
+    } catch (e: GitHubAppException) {
+        // Bad/missing signature (or unconfigured secret). GitHub's convention is 401 so a
+        // misconfigured secret surfaces in the delivery panel; the URL isn't secret (gotcha D).
         call.respond(HttpStatusCode.Unauthorized, mapOf("error" to mapOf("code" to "invalid_signature", "message" to "Invalid or missing signature")))
+        return
+    }
+    // null = verified payload of an event type we don't act on (e.g. `ping`). Acknowledge it.
+    if (event == null) {
+        call.respond(HttpStatusCode.Accepted, mapOf("ok" to true))
         return
     }
 

--- a/api/src/main/kotlin/dev/androidskills/github/GitHubAppClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/github/GitHubAppClient.kt
@@ -38,9 +38,17 @@ interface GitHubAppClient {
 
     /**
      * Verifies the `X-Hub-Signature-256` HMAC over [body] with the configured
-     * webhook secret (constant-time), then parses the event. Returns null on
-     * signature mismatch / unparseable payload / event types we don't handle.
+     * webhook secret (constant-time), then parses the event.
+     *
+     * Returns the event for types step 4 acts on (`push`, `installation`*, …);
+     * returns **null for a verified payload of an unhandled type** (e.g. `ping`) —
+     * the caller acknowledges it (202), since the signature was valid.
+     *
+     * **Throws [GitHubAppException] on a bad/missing signature** — that's distinct
+     * from an unhandled type, and the caller returns 401 so a misconfigured secret
+     * surfaces in GitHub's delivery panel.
      */
+    @Throws(GitHubAppException::class)
     suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent?
 }
 
@@ -77,6 +85,7 @@ class DisabledGitHubAppClient : GitHubAppClient {
     override suspend fun listRepos(installationId: Long): List<RepoRef> = throw disabled()
     override suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String): String = throw disabled()
     override suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String): ByteArray = throw disabled()
-    override suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent? = null
+    // An unconfigured App can't verify anything — treat as a signature failure (401).
+    override suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent? = throw disabled()
     private fun disabled() = GitHubAppException("GitHub App is not configured")
 }

--- a/api/src/main/kotlin/dev/androidskills/github/GitHubAppClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/github/GitHubAppClient.kt
@@ -1,0 +1,82 @@
+package dev.androidskills.github
+
+/**
+ * GitHub App client (spec §8): installation enumeration, repo listing, archive
+ * download, and webhook-event verification. Kept behind an interface so step 4
+ * runs and tests with zero cloud setup — tests inject a fake, prod injects
+ * [RealGitHubAppClient] (built from `GITHUB_APP_*` env), and when the App is
+ * unconfigured the routes get [DisabledGitHubAppClient] (`configured = false`).
+ *
+ * **Scope of step 4 (review issue B):** the client supports the *read* surface
+ * (list repos, scan a repo's default branch). The ingest write path (mirror,
+ * upsert, enqueue review) is deferred to step 5; this client only fetches the
+ * archive bytes that `ingest/Discovery.discover()` parses read-only.
+ *
+ * **Deviation A (review):** `downloadZipball` fetches GitHub's `/zipball/{ref}` —
+ * JDK-native `java.util.zip` extraction — not `/tarball/{ref}`. The spec §5.1
+ * says "tarball" meaning "the archive"; zip avoids a commons-compress dep and
+ * unifies extraction with the uploaded-zip path. The compressed body is
+ * size-bounded by the caller (see `Discovery`).
+ */
+interface GitHubAppClient {
+    val configured: Boolean
+
+    /** The App's installations (`GET /app/installations`, App-JWT auth). */
+    suspend fun installations(): List<Installation>
+
+    /** Repos accessible to an installation (`GET /installation/repositories`). */
+    suspend fun listRepos(installationId: Long): List<RepoRef>
+
+    /** The commit sha of [owner]/[repo]'s default branch HEAD. */
+    suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String): String
+
+    /**
+     * The repo archive at [ref] as a zipball (`GET /repos/{o}/{r}/zipball/{ref}`).
+     * Bounded compressed-body read — see `Discovery` step 1.
+     */
+    suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String): ByteArray
+
+    /**
+     * Verifies the `X-Hub-Signature-256` HMAC over [body] with the configured
+     * webhook secret (constant-time), then parses the event. Returns null on
+     * signature mismatch / unparseable payload / event types we don't handle.
+     */
+    suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent?
+}
+
+/** A GitHub App installation. `accountType` is "User" or "Organization". */
+data class Installation(
+    val id: Long,
+    val accountId: Long,
+    val accountLogin: String,
+    val accountType: String,
+)
+
+data class RepoRef(
+    val owner: String,
+    val name: String,
+    val fullName: String,
+    val defaultBranch: String?,
+)
+
+/** Webhook events step 4 acts on. `resync` execution is step 5; step 4 only enqueues. */
+sealed interface GithubWebhookEvent {
+    /** `push` to a tracked repo's default branch. `before` is ignored; [after] is the new HEAD. */
+    data class Push(val repoOwner: String, val repoName: String, val after: String, val isDefaultBranch: Boolean) : GithubWebhookEvent
+    /** `installation` / `installation_repositories` access changes (lightweight tracking in step 4). */
+    data class InstallationAccess(val installationId: Long, val accountLogin: String, val action: String) : GithubWebhookEvent
+}
+
+/** Raised by the GitHub client on auth/transport/payload failures (translated in the impl). */
+class GitHubAppException(message: String) : RuntimeException(message)
+
+/** No App creds configured (spec §13: "unset → disabled"). */
+class DisabledGitHubAppClient : GitHubAppClient {
+    override val configured: Boolean = false
+    override suspend fun installations(): List<Installation> = throw disabled()
+    override suspend fun listRepos(installationId: Long): List<RepoRef> = throw disabled()
+    override suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String): String = throw disabled()
+    override suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String): ByteArray = throw disabled()
+    override suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent? = null
+    private fun disabled() = GitHubAppException("GitHub App is not configured")
+}

--- a/api/src/main/kotlin/dev/androidskills/github/PemLoader.kt
+++ b/api/src/main/kotlin/dev/androidskills/github/PemLoader.kt
@@ -1,0 +1,95 @@
+package dev.androidskills.github
+
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+
+/**
+ * Loads a GitHub App PEM private key into a Java [PrivateKey], accepting either
+ * PEM flavour GitHub/App owners have lying around:
+ *
+ *  - **PKCS#8** `-----BEGIN PRIVATE KEY-----` — what `KeyFactory.generatePrivate`
+ *    (via [PKCS8EncodedKeySpec]) ingests directly.
+ *  - **PKCS#1** `-----BEGIN RSA PRIVATE KEY-----` — what the GitHub App settings
+ *    page **exports**. Java has no native PKCS#1 reader without BouncyCastle.
+ *
+ * The fix is the well-known ~15-byte ASN.1 prefix wrapper: a PKCS#1 RSA key
+ * becomes a valid PKCS#8 RSA key by prepending the fixed头
+ * `30 82 … 02 01 00 30 0d 06 09 2a 86 48 86 f7 0d 01 01 01 05 00 04 82 …`
+ * (the `RSAEncryption` algorithm identifier + OCTET STRING wrapper). No dep.
+ *
+ * This is the step-4 review "Q2 footgun": without it, the App key GitHub
+ * exports silently fails to load at wiring time.
+ */
+internal object PemLoader {
+
+    // PKCS#8 wrapper for an RSA private key: SEQUENCE { version, AlgorithmIdentifier,
+    // OCTET STRING { <PKCS#1 bytes> } }. The length placeholders (at the outer
+    // SEQUENCE and the OCTET STRING) are filled in for the actual PKCS#1 size.
+    // Exact ASN.1 (mirrors a real RSA PKCS#8 DER prefix):
+    //   30 82 LL LL       SEQUENCE (2-byte length)
+    //   02 01 00          INTEGER version = 0
+    //   30 0d             SEQUENCE AlgorithmIdentifier (length 13)
+    //   06 09 2a 86 48 86 f7 0d 01 01 01   OID rsaEncryption
+    //   05 00             NULL
+    //   04 82 LL LL       OCTET STRING (2-byte length) — the PKCS#1 bytes follow
+    private val PKCS8_RSA_PREFIX = byteArrayOf(
+        0x30.toByte(), 0x82.toByte(), 0x00, 0x00,                            // outer SEQUENCE, length at [2,3]
+        0x02, 0x01, 0x00,                                                   // version
+        0x30.toByte(), 0x0d,                                               // AlgorithmIdentifier SEQUENCE
+        0x06, 0x09, 0x2a, 0x86.toByte(), 0x48, 0x86.toByte(), 0xf7.toByte(), 0x0d, 0x01, 0x01, 0x01, // OID 1.2.840.113549.1.1.1
+        0x05, 0x00,                                                         // NULL
+        0x04, 0x82.toByte(), 0x00, 0x00,                                    // OCTET STRING, length at [24,25]
+    )
+
+    fun loadPrivateKey(pem: String): PrivateKey {
+        val (base64, kind) = parsePem(pem)
+        val der = Base64.getDecoder().decode(base64)
+        val pkcs8Der = when (kind) {
+            PemKind.PKCS8 -> der
+            PemKind.PKCS1 -> wrapPkcs1AsPkcs8(der)
+        }
+        return KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(pkcs8Der))
+    }
+
+    private fun wrapPkcs1AsPkcs8(pkcs1: ByteArray): ByteArray {
+        if (pkcs1.size > 0xffff) throw GitHubAppException("RSA private key too large for PKCS#8 wrapper")
+        val out = PKCS8_RSA_PREFIX.copyOf()
+        // OCTET STRING length (at [24,25]) = pkcs1.size.
+        out[24] = (pkcs1.size ushr 8).toByte()
+        out[25] = pkcs1.size.toByte()
+        // Outer SEQUENCE length (at [2,3]) = everything after [0..3] = (prefix minus 4) + pkcs1.size.
+        val outerLen = out.size - 4 + pkcs1.size
+        out[2] = (outerLen ushr 8).toByte()
+        out[3] = outerLen.toByte()
+        return out + pkcs1
+    }
+
+    private enum class PemKind { PKCS8, PKCS1 }
+
+    private fun parsePem(pem: String): Pair<String, PemKind> {
+        val marker = PEM_BEGIN.find(pem)
+            ?: throw GitHubAppException("No PEM private key found (missing BEGIN marker)")
+        val kindLabel = marker.groupValues[1].trim()
+        // Take the text up to the END marker, keep ONLY base64 alphabet chars.
+        // (Filtering by char-class is more robust than split+strip: the END marker's
+        // letters include valid base64 chars that would silently corrupt the body.)
+        val body = pem.substring(marker.range.last + 1)
+        // Everything up to the END marker. Use a literal search (the END line is
+        // fixed text); the previous regex anchored on `[A-Z ]+` failed to match
+        // across the END line and left the marker letters in the base64 body.
+        val endIdx = body.indexOf("-----END")
+        val safeEnd = if (endIdx >= 0) endIdx else body.length
+        val base64 = body.substring(0, safeEnd).filter { it.isLetterOrDigit() || it == '+' || it == '/' || it == '=' }
+        val kind = when (kindLabel) {
+            "PRIVATE KEY", "EC PRIVATE KEY" -> PemKind.PKCS8
+            "RSA PRIVATE KEY" -> PemKind.PKCS1
+            else -> throw GitHubAppException("Unsupported PEM type: -----BEGIN $kindLabel-----")
+        }
+        if (base64.isEmpty()) throw GitHubAppException("PEM private key has empty body")
+        return base64 to kind
+    }
+
+    private val PEM_BEGIN = Regex("""-----BEGIN ([A-Z ]*PRIVATE KEY)-----""")
+}

--- a/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
@@ -80,7 +80,10 @@ object Discovery {
                 try {
                     if (e.isDirectory) continue
                     if (raw.size >= MAX_ENTRIES) {
-                        throw ApiValidationException(mapOf("archive" to "too many entries (max $MAX_ENTRIES)"), "archive_too_large")
+                        throw ApiValidationException(
+                            mapOf("archive" to "too many entries (max $MAX_ENTRIES)"),
+                            code = "archive_too_large",
+                        )
                     }
                     val safe = SkillPaths.safeRelativeOrNull(normalize(e.name, source))
                         ?: continue // Zip Slip / unsafe path — skip, never write
@@ -91,7 +94,10 @@ object Discovery {
                     while (n >= 0) {
                         inflated += n
                         if (inflated > MAX_INFLATED_BYTES) {
-                            throw ApiValidationException(mapOf("archive" to "inflated size exceeds ${MAX_INFLATED_BYTES / (1024 * 1024)} MB"), "archive_too_large")
+                            throw ApiValidationException(
+                                mapOf("archive" to "inflated size exceeds ${MAX_INFLATED_BYTES / (1024 * 1024)} MB"),
+                                code = "archive_too_large",
+                            )
                         }
                         out.write(buf, 0, n)
                         n = zis.read(buf)

--- a/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
@@ -1,0 +1,195 @@
+package dev.androidskills.ingest
+
+import dev.androidskills.api.ApiValidationException
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+
+/**
+ * Read-only skill discovery from a fetched archive (spec §5 core; the *write*
+ * half — file mirroring, skill/version upsert, review enqueue — is deferred to
+ * step 5 per the plan's issue B, so this writes nothing: no DB, no FileStore).
+ *
+ * Shared by repo scans and uploaded-zip scans. Extraction is one JDK-native
+ * `java.util.zip` path for both sources (deviation A: GitHub `/zipball`, not
+ * `/tarball`); **root-normalization differs by source** (gotcha #1): a GitHub
+ * zipball wraps the repo in a single `{owner}-{repo}-{sha}/` dir, so a literal
+ * top-level `skills/` lookup matches nothing. `RepoZipball` peels exactly one
+ * leading segment; `UploadedZip` peels one only if `skills/` isn't already at
+ * the root.
+ *
+ * Security guards: the compressed body is size-bounded by the caller; here we
+ * bound the **inflated** stream (count bytes as read, never trust entry sizes),
+ * cap entry count, and reject Zip Slip via [SkillPaths.safeRelativeOrNull].
+ */
+sealed interface ArchiveSource {
+    val bytes: ByteArray
+    data class RepoZipball(override val bytes: ByteArray, val commitSha: String) : ArchiveSource
+    data class UploadedZip(override val bytes: ByteArray, val uploadHash: String) : ArchiveSource
+}
+
+/** The read-only metadata for one detected skill (§9: "Detected metadata (read-only)"). */
+data class DetectedSkill(
+    val slug: String,
+    val name: String,
+    val description: String,
+    val license: String?,
+    val tags: List<String>,
+    val version: String,
+    val versionSource: String, // manifest|git_head|upload
+    val tokenUpfront: Int,
+    val tokenOndemand: Int,
+    val tokenBand: String,
+    val parseErrors: List<FieldError>,
+    val fileCount: Int,
+)
+
+sealed interface ScanResult {
+    data class Found(val skills: List<DetectedSkill>) : ScanResult
+    data object NoSkillsDir : ScanResult // §10: submit blocked
+}
+
+object Discovery {
+
+    /** Inflated bytes / entry-count caps (Q4). The compressed cap is the caller's. */
+    const val MAX_INFLATED_BYTES = 50L * 1024 * 1024
+    const val MAX_ENTRIES = 1000
+    /** Per-file cap for the body fed to the token estimator. */
+    const val MAX_FILE_BYTES = 5L * 1024 * 1024
+
+    /** §10 slug: lowercase kebab-case. Stricter than SkillManifest's tag regex. */
+    private val SLUG = Regex("""^[a-z0-9]+(-[a-z0-9]+)*$""")
+
+    fun discover(source: ArchiveSource): ScanResult {
+        val entries = extract(source) // guarded + root-normalized per-source
+        if (entries.none { it.path.startsWith("skills/") }) return ScanResult.NoSkillsDir
+        val grouped = entries
+            .filter { it.path.startsWith("skills/") }
+            .groupBy { topDir(it.path) } // "skills/<slug>" -> all files under it
+        val detected = grouped.mapNotNull { (dir, files) -> buildDetected(dir, files, source) }
+        return ScanResult.Found(detected)
+    }
+
+    /** Extracts + applies the source-specific root-normalization (gotcha #1). */
+    private fun extract(source: ArchiveSource): List<Extracted> {
+        val raw = ArrayList<Extracted>(64)
+        var inflated = 0L
+        ZipInputStream(ByteArrayInputStream(source.bytes)).use { zis ->
+            while (true) {
+                val e = zis.nextEntry ?: break
+                try {
+                    if (e.isDirectory) continue
+                    if (raw.size >= MAX_ENTRIES) {
+                        throw ApiValidationException(mapOf("archive" to "too many entries (max $MAX_ENTRIES)"), "archive_too_large")
+                    }
+                    val safe = SkillPaths.safeRelativeOrNull(normalize(e.name, source))
+                        ?: continue // Zip Slip / unsafe path — skip, never write
+                    // Bounded read: count inflated bytes as we go, never trust entry getSize().
+                    val out = java.io.ByteArrayOutputStream()
+                    val buf = ByteArray(8 * 1024)
+                    var n = zis.read(buf)
+                    while (n >= 0) {
+                        inflated += n
+                        if (inflated > MAX_INFLATED_BYTES) {
+                            throw ApiValidationException(mapOf("archive" to "inflated size exceeds ${MAX_INFLATED_BYTES / (1024 * 1024)} MB"), "archive_too_large")
+                        }
+                        out.write(buf, 0, n)
+                        n = zis.read(buf)
+                    }
+                    val bytes = out.toByteArray()
+                    raw.add(Extracted(safe, bytes, isProbablyBinary(bytes)))
+                } finally {
+                    zis.closeEntry()
+                }
+            }
+        }
+        return raw
+    }
+
+    /**
+     * Root-normalize (gotcha #1):
+     *  - RepoZipball: GitHub wraps the repo in `{owner}-{repo}-{sha}/`. Peel exactly
+     *    one leading segment unconditionally → `skills/...` lands at the root.
+     *  - UploadedZip: may be rooted at `skills/...` (no peel) OR under a single
+     *    wrapper dir (peel one). Peel only if `skills/` is NOT already at the root.
+     */
+    private fun normalize(rawName: String, source: ArchiveSource): String {
+        val slash = rawName.indexOf('/')
+        if (slash < 0) return rawName // no segments to peel
+        val rest = rawName.substring(slash + 1)
+        return when (source) {
+            is ArchiveSource.RepoZipball -> rest // always peel the wrapper
+            is ArchiveSource.UploadedZip -> if (rawName.startsWith("skills/")) rawName else rest
+        }
+    }
+
+    /**
+     * `dir` is "skills/<slug>". Files are the entries under it. Returns null if the
+     * directory has no SKILL.md (not a skill) or the slug is malformed.
+     */
+    private fun buildDetected(dir: String, files: List<Extracted>, source: ArchiveSource): DetectedSkill? {
+        val slug = dir.removePrefix("skills/")
+        if (slug.isEmpty() || !SLUG.matches(slug)) return null
+        val skillMd = files.firstOrNull { it.path == "$dir/SKILL.md" } ?: return null
+        val manifest = SkillManifestParser.parse(String(skillMd.bytes, Charsets.UTF_8))
+        val onDemandFiles = files.filter { isOnDemand(it.path, dir) && !it.binary }
+        val onDemandText = buildString {
+            append(manifest.body)
+            onDemandFiles.forEach { f ->
+                if (length + f.bytes.size <= MAX_FILE_BYTES.toInt() * 4) {
+                    append('\n'); append(String(f.bytes, Charsets.UTF_8))
+                }
+            }
+        }
+        val upfront = Tokens.estimate("${manifest.name} ${manifest.description}")
+        val onDemand = Tokens.estimate(onDemandText)
+        val total = upfront + onDemand
+        val version = manifest.version ?: when (source) {
+            is ArchiveSource.RepoZipball -> source.commitSha.take(12)
+            is ArchiveSource.UploadedZip -> source.uploadHash.take(12)
+        }
+        val versionSource = if (manifest.version != null) "manifest" else when (source) {
+            is ArchiveSource.RepoZipball -> "git_head"
+            is ArchiveSource.UploadedZip -> "upload"
+        }
+        return DetectedSkill(
+            slug = slug,
+            name = manifest.name,
+            description = manifest.description,
+            license = manifest.license,
+            tags = manifest.tags,
+            version = version,
+            versionSource = versionSource,
+            tokenUpfront = upfront,
+            tokenOndemand = onDemand,
+            tokenBand = Tokens.band(total),
+            parseErrors = manifest.parseErrors + ManifestValidator.validate(manifest),
+            fileCount = files.size,
+        )
+    }
+
+    /** references/, examples/, scripts/ under the skill dir (spec §5 on-demand cost). */
+    private fun isOnDemand(path: String, dir: String): Boolean {
+        val rel = path.removePrefix("$dir/").substringBefore('/', "")
+        return rel in setOf("references", "examples", "scripts")
+    }
+
+    private fun topDir(path: String): String {
+        // path is normalized like "skills/foo/bar.md"; top dir under skills/ is "skills/foo".
+        val after = path.removePrefix("skills/")
+        val next = after.indexOf('/')
+        return if (next >= 0) "skills/${after.substring(0, next)}" else "skills/$after"
+    }
+
+    private fun isProbablyBinary(bytes: ByteArray): Boolean {
+        // Simple heuristic: a NUL byte in the first 2KB → binary.
+        val n = minOf(bytes.size, 2048)
+        for (i in 0 until n) if (bytes[i] == 0.toByte()) return true
+        return false
+    }
+
+    private data class Extracted(val path: String, val bytes: ByteArray, val binary: Boolean) {
+        override fun equals(other: Any?) = other is Extracted && path == other.path
+        override fun hashCode() = path.hashCode()
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/util/Compares.kt
+++ b/api/src/main/kotlin/dev/androidskills/util/Compares.kt
@@ -1,0 +1,26 @@
+package dev.androidskills.util
+
+/**
+ * Constant-time string compare — used for secrets where a timing leak would
+ * matter (OAuth state check, webhook HMAC). A length mismatch returns `false`
+ * immediately (the length isn't secret in either call site), but the byte
+ * comparison always runs across the full common length regardless of where the
+ * first difference is, so timing doesn't reveal a shared prefix.
+ *
+ * Extracted here so both `auth` (OAuth state) and `github` (webhook HMAC) share
+ * one implementation rather than copy-pasting it.
+ */
+fun constantTimeEquals(a: String, b: String): Boolean {
+    if (a.length != b.length) return false
+    var diff = 0
+    for (i in a.indices) diff = diff or (a[i].code xor b[i].code)
+    return diff == 0
+}
+
+/** Constant-time compare over [ByteArray] (HMAC digests are bytes). */
+fun constantTimeEquals(a: ByteArray, b: ByteArray): Boolean {
+    if (a.size != b.size) return false
+    var diff = 0
+    for (i in a.indices) diff = diff or (a[i].toInt() xor b[i].toInt())
+    return diff == 0
+}

--- a/api/src/test/kotlin/dev/androidskills/api/ContributorRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/ContributorRoutesTest.kt
@@ -127,7 +127,21 @@ class ContributorRoutesTest {
     )) { client, cookie ->
         val res = client.post("/api/me/repos/alice/toolkit/scan") { header("Cookie", "as_session=$cookie") }
         assertEquals(HttpStatusCode.UnprocessableEntity, res.status)
-        assertTrue(res.bodyAsText().contains("no_skills_dir"))
+        val body = res.bodyAsText()
+        // The code lands in error.code (Bugbot finding #1), not just the message.
+        assertTrue(body.contains("\"code\":\"no_skills_dir\""), "expected code=no_skills_dir in envelope; got $body")
+    }
+
+    @Test
+    fun scanRejectsOversizedZipball() = runWith(FakeApp(
+        installations = listOf(Installation(1, accountId = 42, accountLogin = "alice", accountType = "User")),
+        heads = mapOf("alice/toolkit" to "sha1"),
+        zipballs = mapOf("alice/toolkit@sha1" to ByteArray(51 * 1024 * 1024)), // > 50 MB compressed cap
+    )) { client, cookie ->
+        val res = client.post("/api/me/repos/alice/toolkit/scan") { header("Cookie", "as_session=$cookie") }
+        assertEquals(HttpStatusCode.UnprocessableEntity, res.status)
+        val body = res.bodyAsText()
+        assertTrue(body.contains("archive_too_large"), "expected archive_too_large; got $body")
     }
 
     @Test

--- a/api/src/test/kotlin/dev/androidskills/api/ContributorRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/ContributorRoutesTest.kt
@@ -1,0 +1,174 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.auth.UsersRepo
+import dev.androidskills.auth.GitHubUser
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GitHubAppException
+import dev.androidskills.github.Installation
+import dev.androidskills.github.RepoRef
+import dev.androidskills.github.GithubWebhookEvent
+import dev.androidskills.module
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Contributor routes via a fake GitHubAppClient (no network). Covers: 503 when
+ * disabled; the Q3 personal-installation filter; /scan happy path + no_skills_dir
+ * 422 + 401 anon; GitHub upstream failures → 502.
+ */
+class ContributorRoutesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() { dir.toFile().deleteRecursively() }
+
+    /** Controllable App client: no network. */
+    private class FakeApp(
+        val installations: List<Installation> = emptyList(),
+        val repos: Map<Long, List<RepoRef>> = emptyMap(),
+        val zipballs: Map<String, ByteArray> = emptyMap(),
+        val heads: Map<String, String> = emptyMap(),
+        val failInstallations: Boolean = false,
+    ) : GitHubAppClient {
+        override val configured = true
+        override suspend fun installations(): List<Installation> {
+            if (failInstallations) throw GitHubAppException("boom")
+            return installations
+        }
+        override suspend fun listRepos(installationId: Long): List<RepoRef> =
+            repos[installationId] ?: emptyList()
+        override suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String): String =
+            heads["$owner/$repo"] ?: "mainsha"
+        override suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String): ByteArray =
+            zipballs["$owner/$repo@$ref"] ?: throw GitHubAppException("no zipball")
+        override suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent? = null
+    }
+
+    private suspend fun loginPrincipal(): Pair<Long, ByteArray> {
+        // Seed a user + session, return (githubId, sessionCookie) for the fake client's filter.
+        Database.init(TestSupport.newConfig(dir))
+        val userId = UsersRepo.upsertFromGitHub(GitHubUser(githubId = 42, handle = "alice", name = "Alice", avatarUrl = null), null)
+        val token = dev.androidskills.auth.SessionStore.create(userId, 3600)
+        return 42L to token.toByteArray()
+    }
+
+    private fun runWith(app: GitHubAppClient, block: suspend (client: HttpClient, cookie: String) -> Unit) {
+        val (_, tokenBytes) = kotlinx.coroutines.runBlocking { loginPrincipal() }
+        val cookie = String(tokenBytes)
+        testApplication {
+            application { module(TestSupport.newConfig(dir), githubApp = app) }
+            val client = createClient { install(HttpCookies) }
+            block(client, cookie)
+        }
+    }
+
+    @Test
+    fun reposReturns503WhenDisabled() = runWith(dev.androidskills.github.DisabledGitHubAppClient()) { client, _ ->
+        val res = client.get("/api/me/repos")
+        assertEquals(HttpStatusCode.ServiceUnavailable, res.status)
+        assertTrue(res.bodyAsText().contains("github_app_disabled"))
+    }
+
+    @Test
+    fun reposListsPersonalInstallationReposOnly() = runWith(FakeApp(
+        installations = listOf(
+            Installation(1, accountId = 42, accountLogin = "alice", accountType = "User"),     // mine
+            Installation(2, accountId = 999, accountLogin = "other", accountType = "User"),    // not mine (Q3)
+        ),
+        repos = mapOf(
+            1L to listOf(RepoRef("alice", "toolkit", "alice/toolkit", "main")),
+            2L to listOf(RepoRef("other", "secret", "other/secret", "main")),
+        ),
+    )) { client, cookie ->
+        val res = client.get("/api/me/repos") { header("Cookie", "as_session=$cookie") }
+        assertEquals(HttpStatusCode.OK, res.status)
+        val body = res.bodyAsText()
+        assertTrue(body.contains("alice/toolkit"), body)
+        assertTrue(!body.contains("other/secret"), "personal-only filter (Q3); body=$body")
+    }
+
+    @Test
+    fun scanDetectsSkills() = runWith(FakeApp(
+        installations = listOf(Installation(1, accountId = 42, accountLogin = "alice", accountType = "User")),
+        heads = mapOf("alice/toolkit" to "abc1234567890abcd"),
+        zipballs = mapOf("alice/toolkit@abc1234567890abcd" to repoZipballWithSkills()),
+    )) { client, cookie ->
+        val res = client.post("/api/me/repos/alice/toolkit/scan") { header("Cookie", "as_session=$cookie") }
+        assertEquals(HttpStatusCode.OK, res.status)
+        val body = res.bodyAsText()
+        assertTrue(body.contains("\"slug\":\"mvi\""), body)
+        assertTrue(body.contains("\"commitSha\":\"abc1234567890abcd\""), body)
+    }
+
+    @Test
+    fun scanReturns422NoSkillsDir() = runWith(FakeApp(
+        installations = listOf(Installation(1, accountId = 42, accountLogin = "alice", accountType = "User")),
+        heads = mapOf("alice/toolkit" to "sha1"),
+        zipballs = mapOf("alice/toolkit@sha1" to repoZipballNoSkills()),
+    )) { client, cookie ->
+        val res = client.post("/api/me/repos/alice/toolkit/scan") { header("Cookie", "as_session=$cookie") }
+        assertEquals(HttpStatusCode.UnprocessableEntity, res.status)
+        assertTrue(res.bodyAsText().contains("no_skills_dir"))
+    }
+
+    @Test
+    fun reposRequiresSession() = runWith(FakeApp(
+        installations = emptyList(), repos = emptyMap(),
+    )) { client, _ ->
+        // No session cookie → 401.
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/api/me/repos").status)
+    }
+
+    @Test
+    fun upstreamGitHubFailureMapsTo502() = runWith(FakeApp(
+        installations = emptyList(), repos = emptyMap(), failInstallations = true,
+    )) { client, cookie ->
+        val res = client.get("/api/me/repos") { header("Cookie", "as_session=$cookie") }
+        assertEquals(HttpStatusCode.BadGateway, res.status)
+        assertTrue(res.bodyAsText().contains("github_installations_failed"))
+    }
+
+    // ---- in-memory zip fixtures (gotcha #1: repo zipballs have the wrapper dir) ----
+
+    private fun repoZipballWithSkills(): ByteArray = zip(
+        "alice-toolkit-abc/SKILL.md" to "---\nname: Ignored\ndescription: d\nlicense: MIT\n---\n", // root — ignored
+        "alice-toolkit-abc/skills/mvi/SKILL.md" to skillMd("MVI", "Predictable MVI baseline."),
+    )
+
+    private fun repoZipballNoSkills(): ByteArray = zip(
+        "alice-toolkit-abc/README.md" to "readme",
+        "alice-toolkit-abc/SKILL.md" to skillMd("Ignored", "d"), // root, ignored → NoSkillsDir
+    )
+
+    private fun skillMd(name: String, desc: String) =
+        "---\nname: $name\ndescription: $desc\nlicense: Apache-2.0\ntags: [android]\n---\n# $name\n"
+
+    private fun zip(vararg entries: Pair<String, String>): ByteArray {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            entries.forEach { (name, content) ->
+                zos.putNextEntry(ZipEntry(name)); zos.write(content.toByteArray()); zos.closeEntry()
+            }
+        }
+        return baos.toByteArray()
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/gh/WebhookRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/gh/WebhookRoutesTest.kt
@@ -1,0 +1,167 @@
+package dev.androidskills.gh
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Jobs
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GithubWebhookEvent
+import dev.androidskills.module
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WebhookRoutesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @BeforeTest fun setup() = Database.init(TestSupport.newConfig(dir))
+    @AfterTest fun teardown() { dir.toFile().deleteRecursively() }
+
+    /** App client whose verifyAndParseEvent returns a scripted event (or null = bad sig). */
+    private class FakeApp(val event: GithubWebhookEvent?) : GitHubAppClient {
+        override val configured = true
+        override suspend fun installations() = emptyList<dev.androidskills.github.Installation>()
+        override suspend fun listRepos(installationId: Long) = emptyList<dev.androidskills.github.RepoRef>()
+        override suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String) = ""
+        override suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String) = ByteArray(0)
+        override suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent? = event
+    }
+
+    private fun seedBundle(provenance: String, ownerHandle: String = "alice"): String {
+        // Minimal user + bundle so push dedupe + installation tracking have a row to hit.
+        val userId = dev.androidskills.auth.UsersRepo.upsertFromGitHub(
+            dev.androidskills.auth.GitHubUser(1, ownerHandle, "Alice", null), null,
+        )
+        val id = dev.androidskills.util.newId()
+        val now = dev.androidskills.util.nowIso()
+        transaction {
+            Bundles.insert {
+                it[Bundles.id] = id
+                it[Bundles.kind] = "repo"
+                it[Bundles.provenance] = provenance
+                it[Bundles.ownerUserId] = userId
+                it[Bundles.createdAt] = now
+            }
+        }
+        return id
+    }
+
+    @Test
+    fun badSignatureReturns401() = testApplication {
+        application { module(TestSupport.newConfig(dir), githubApp = FakeApp(event = null)) }
+        val res = client.post("/gh/webhooks") {
+            header("X-Hub-Signature-256", "sha256=bad")
+            header("Content-Type", ContentType.Application.Json.toString())
+            setBody("{}")
+        }
+        assertEquals(HttpStatusCode.Unauthorized, res.status)
+        assertTrue(res.bodyAsText().contains("invalid_signature"))
+    }
+
+    @Test
+    fun unconfiguredAppReturns401() = testApplication {
+        // DisabledGitHubAppClient.verifyAndParseEvent returns null → 401 (indistinguishable
+        // from a bad sig; a misconfigured secret surfaces in GitHub's delivery panel).
+        application { module(TestSupport.newConfig(dir), githubApp = dev.androidskills.github.DisabledGitHubAppClient()) }
+        val res = client.post("/gh/webhooks") { setBody("{}") }
+        assertEquals(HttpStatusCode.Unauthorized, res.status)
+    }
+
+    @Test
+    fun pushToTrackedRepoEnqueuesResync202() {
+        val bundleId = seedBundle("alice/toolkit")
+        testApplication {
+            application {
+                module(TestSupport.newConfig(dir), githubApp = FakeApp(
+                    event = GithubWebhookEvent.Push("alice", "toolkit", after = "abc1234567", isDefaultBranch = true),
+                ))
+            }
+            val res = client.post("/gh/webhooks") { setBody("{}") }
+            assertEquals(HttpStatusCode.Accepted, res.status)
+        }
+        val job = transaction {
+            Jobs.selectAll().where { Jobs.type eq "resync" }.singleOrNull()
+        }
+        assertNotNull(job, "resync job enqueued")
+        assertEquals("queued", job!![Jobs.state])
+        assertTrue(job[Jobs.payload].contains(bundleId))
+        assertTrue(job[Jobs.payload].contains("abc1234567"))
+    }
+
+    @Test
+    fun duplicatePushIsIdempotent() {
+        // Q5: GitHub redelivering the same push (same bundle + head sha) must not enqueue twice.
+        seedBundle("alice/toolkit")
+        val event = GithubWebhookEvent.Push("alice", "toolkit", after = "same123sha", isDefaultBranch = true)
+        repeat(3) {
+            testApplication {
+                application { module(TestSupport.newConfig(dir), githubApp = FakeApp(event = event)) }
+                client.post("/gh/webhooks") { setBody("{}") }
+            }
+        }
+        val count = transaction { Jobs.selectAll().where { Jobs.type eq "resync" }.toList().size }
+        assertEquals(1, count, "duplicate push must not re-enqueue (Q5 idempotency)")
+    }
+
+    @Test
+    fun pushToUntrackedRepoIsAcceptedButNoJob() {
+        // A repo with no bundle (never submitted) → 202, no job (nothing to resync).
+        testApplication {
+            application {
+                module(TestSupport.newConfig(dir), githubApp = FakeApp(
+                    event = GithubWebhookEvent.Push("stranger", "repo", after = "sha", isDefaultBranch = true),
+                ))
+            }
+            val res = client.post("/gh/webhooks") { setBody("{}") }
+            assertEquals(HttpStatusCode.Accepted, res.status)
+        }
+        val job = transaction { Jobs.selectAll().where { Jobs.type eq "resync" }.singleOrNull() }
+        assertNull(job)
+    }
+
+    @Test
+    fun pushToNonDefaultBranchDoesNotEnqueue() {
+        // §8: only push to the tracked repo's default branch triggers a resync.
+        seedBundle("alice/toolkit")
+        testApplication {
+            application {
+                module(TestSupport.newConfig(dir), githubApp = FakeApp(
+                    event = GithubWebhookEvent.Push("alice", "toolkit", after = "featsha", isDefaultBranch = false),
+                ))
+            }
+            client.post("/gh/webhooks") { setBody("{}") }
+        }
+        assertNull(transaction { Jobs.selectAll().where { Jobs.type eq "resync" }.singleOrNull() })
+    }
+
+    @Test
+    fun installationEventTagsBundleWithInstallationId() {
+        val bundleId = seedBundle("alice/old-repo", ownerHandle = "alice")
+        testApplication {
+            application {
+                module(TestSupport.newConfig(dir), githubApp = FakeApp(
+                    event = GithubWebhookEvent.InstallationAccess(installationId = 777L, accountLogin = "alice", action = "created"),
+                ))
+            }
+            client.post("/gh/webhooks") { setBody("{}") }
+        }
+        val installed = transaction { Bundles.selectAll().where { Bundles.id eq bundleId }.single()[Bundles.installationId] }
+        assertEquals(777L, installed)
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/gh/WebhookRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/gh/WebhookRoutesTest.kt
@@ -5,6 +5,7 @@ import dev.androidskills.TestSupport
 import dev.androidskills.db.Bundles
 import dev.androidskills.db.Jobs
 import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GitHubAppException
 import dev.androidskills.github.GithubWebhookEvent
 import dev.androidskills.module
 import io.ktor.client.request.header
@@ -33,14 +34,25 @@ class WebhookRoutesTest {
     @BeforeTest fun setup() = Database.init(TestSupport.newConfig(dir))
     @AfterTest fun teardown() { dir.toFile().deleteRecursively() }
 
-    /** App client whose verifyAndParseEvent returns a scripted event (or null = bad sig). */
-    private class FakeApp(val event: GithubWebhookEvent?) : GitHubAppClient {
+    /**
+     * App client whose verifyAndParseEvent scripts one of:
+     *  - returns event (a known event),
+     *  - returns null (verified but unhandled event type, e.g. `ping`),
+     *  - throws GitHubAppException (bad signature / unconfigured).
+     */
+    private class FakeApp(
+        val event: GithubWebhookEvent? = null,
+        val failSignature: Boolean = false,
+    ) : GitHubAppClient {
         override val configured = true
         override suspend fun installations() = emptyList<dev.androidskills.github.Installation>()
         override suspend fun listRepos(installationId: Long) = emptyList<dev.androidskills.github.RepoRef>()
         override suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String) = ""
         override suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String) = ByteArray(0)
-        override suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent? = event
+        override suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent? {
+            if (failSignature) throw GitHubAppException("bad signature")
+            return event
+        }
     }
 
     private fun seedBundle(provenance: String, ownerHandle: String = "alice"): String {
@@ -64,7 +76,7 @@ class WebhookRoutesTest {
 
     @Test
     fun badSignatureReturns401() = testApplication {
-        application { module(TestSupport.newConfig(dir), githubApp = FakeApp(event = null)) }
+        application { module(TestSupport.newConfig(dir), githubApp = FakeApp(failSignature = true)) }
         val res = client.post("/gh/webhooks") {
             header("X-Hub-Signature-256", "sha256=bad")
             header("Content-Type", ContentType.Application.Json.toString())
@@ -75,9 +87,19 @@ class WebhookRoutesTest {
     }
 
     @Test
+    fun verifiedUnhandledEventReturns202() = testApplication {
+        // A valid `ping` (or any event we don't act on) → 202, NOT 401 — the signature
+        // was valid; GitHub's delivery panel should show success.
+        application { module(TestSupport.newConfig(dir), githubApp = FakeApp(event = null)) }
+        val res = client.post("/gh/webhooks") { setBody("{}") }
+        assertEquals(HttpStatusCode.Accepted, res.status)
+        assertNull(transaction { Jobs.selectAll().where { Jobs.type eq "resync" }.singleOrNull() })
+    }
+
+    @Test
     fun unconfiguredAppReturns401() = testApplication {
-        // DisabledGitHubAppClient.verifyAndParseEvent returns null → 401 (indistinguishable
-        // from a bad sig; a misconfigured secret surfaces in GitHub's delivery panel).
+        // DisabledGitHubAppClient.verifyAndParseEvent throws GitHubAppException → 401 so a
+        // misconfigured secret surfaces in GitHub's delivery panel.
         application { module(TestSupport.newConfig(dir), githubApp = dev.androidskills.github.DisabledGitHubAppClient()) }
         val res = client.post("/gh/webhooks") { setBody("{}") }
         assertEquals(HttpStatusCode.Unauthorized, res.status)

--- a/api/src/test/kotlin/dev/androidskills/github/PemLoaderTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/github/PemLoaderTest.kt
@@ -1,0 +1,123 @@
+package dev.androidskills.github
+
+import dev.androidskills.GithubAppConfig
+import dev.androidskills.util.constantTimeEquals
+import java.security.KeyPairGenerator
+import java.security.Signature
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
+
+/** Q2: the PEM loader must accept the key GitHub exports (PKCS#1) as well as PKCS#8. */
+class PemLoaderTest {
+
+    @Test
+    fun `loads PKCS8 PEM`() {
+        val (priv, pub) = rsaKeypair()
+        val pem = pemWrap("PRIVATE KEY", Base64.getEncoder().encodeToString(priv.encoded))
+        val loaded = PemLoader.loadPrivateKey(pem)
+        assertEquals("RSA", loaded.algorithm)
+        assertSignsAndVerifies(loaded, pub)
+    }
+
+    @Test
+    fun `loads PKCS1 PEM (what GitHub exports)`() {
+        // Re-encode the PKCS#8 key as PKCS#1 by stripping the wrapper, then wrap
+        // as the GitHub-style "BEGIN RSA PRIVATE KEY" PEM. The loader must reverse
+        // that — without the wrapper it'd throw KeyFactory's "PKCS8 not found".
+        val (priv, pub) = rsaKeypair()
+        val pkcs1 = stripPkcs8ToPkcs1(priv.encoded)
+        val pem = pemWrap("RSA PRIVATE KEY", Base64.getEncoder().encodeToString(pkcs1))
+        val loaded = PemLoader.loadPrivateKey(pem)
+        assertSignsAndVerifies(loaded, pub)
+        // Same underlying key (modulus match) as the PKCS#8 original.
+        val rsaOriginal = priv as java.security.interfaces.RSAPrivateKey
+        val rsaLoaded = loaded as java.security.interfaces.RSAPrivateKey
+        assertEquals(rsaOriginal.modulus, rsaLoaded.modulus)
+    }
+
+    @Test
+    fun `rejects non-PEM input`() {
+        assertFailsWith<GitHubAppException> { PemLoader.loadPrivateKey("not a key") }
+    }
+
+    @Test
+    fun `rejects unsupported PEM type`() {
+        val pem = pemWrap("ENCRYPTED PRIVATE KEY", "aaaa")
+        assertFailsWith<GitHubAppException> { PemLoader.loadPrivateKey(pem) }
+    }
+
+    // ---- helpers ----
+
+    private fun rsaKeypair(): Pair<java.security.PrivateKey, java.security.PublicKey> {
+        val kp = KeyPairGenerator.getInstance("RSA").apply {
+            initialize(2048, java.security.SecureRandom())
+        }.generateKeyPair()
+        return kp.private to kp.public
+    }
+
+    private fun pemWrap(kind: String, base64: String): String =
+        "-----BEGIN $kind-----\n${base64.chunked(64).joinToString("\n")}\n-----END $kind-----\n"
+
+    /** Strip a PKCS#8 RSA wrapper to its PKCS#1 body (reverse of the loader's wrap).
+     *  Reads the OCTET STRING length at DER offsets [24,25]; body starts at [26]. */
+    private fun stripPkcs8ToPkcs1(pkcs8: ByteArray): ByteArray {
+        val octetLen = ((pkcs8[24].toInt() and 0xff) shl 8) or (pkcs8[25].toInt() and 0xff)
+        val bodyStart = 26
+        return pkcs8.copyOfRange(bodyStart, bodyStart + octetLen)
+    }
+
+    private fun assertSignsAndVerifies(priv: java.security.PrivateKey, pub: java.security.PublicKey) {
+        val data = "step-4 q2".toByteArray()
+        val sig = Signature.getInstance("SHA256withRSA").run {
+            initSign(priv); update(data); sign()
+        }
+        val ok = Signature.getInstance("SHA256withRSA").run {
+            initVerify(pub); update(data); verify(sig)
+        }
+        assertTrue(ok, "loaded key must produce a signature that verifies against its public key")
+    }
+}
+
+class GithubAppConfigTest {
+    @Test
+    fun `disabled when any of the three creds is absent`() {
+        assertFalse(GithubAppConfig.disabled().configured)
+        assertFalse(GithubAppConfig(1L, null, "s").configured)
+        assertFalse(GithubAppConfig(1L, "pem", null).configured)
+        assertFalse(GithubAppConfig(null, "pem", "s").configured)
+        assertTrue(GithubAppConfig(1L, "pem", "s").configured)
+    }
+
+    @Test
+    fun `toString redacts the PEM and webhook secret`() {
+        val s = GithubAppConfig(1L, "SUPERSECRETPEM", "SUPERSECRETWS").toString()
+        assertNotEquals("SUPERSECRETPEM", s)
+        assertFalse(s.contains("SUPERSECRETPEM"), s)
+        assertFalse(s.contains("SUPERSECRETWS"), s)
+        assertTrue(s.contains("***"))
+    }
+}
+
+class ComparesTest {
+    @Test
+    fun `constantTimeEquals matches equality`() {
+        assertTrue(constantTimeEquals("abc", "abc"))
+        assertFalse(constantTimeEquals("abc", "abd"))
+        assertFalse(constantTimeEquals("abc", "abcd"))
+        assertFalse(constantTimeEquals("", "a"))
+        assertTrue(constantTimeEquals("", ""))
+    }
+
+    @Test
+    fun `bytearray overload matches equality`() {
+        assertTrue(constantTimeEquals(byteArrayOf(1, 2, 3), byteArrayOf(1, 2, 3)))
+        assertFalse(constantTimeEquals(byteArrayOf(1, 2, 3), byteArrayOf(1, 2, 4)))
+        assertFalse(constantTimeEquals(byteArrayOf(1, 2), byteArrayOf(1, 2, 3)))
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
@@ -1,0 +1,171 @@
+package dev.androidskills.ingest
+
+import dev.androidskills.api.ApiValidationException
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/** The read-only discovery core (§5, §3.1, §10) + the security guards + gotcha #1. */
+class DiscoveryTest {
+
+    @Test
+    fun `repo zipball - wrapper peeled and skills under skills are detected`() {
+        // GitHub wraps the repo in {owner}-{repo}-{sha}/ — gotcha #1: without peeling,
+        // every entry is under the wrapper and a literal top-level skills/ lookup fails.
+        val zip = zip(
+            "alice-repo-abc123/.github/SKILL.md" to ignored,            // ignored (not under skills/)
+            "alice-repo-abc123/.claude/SKILL.md" to ignored,
+            "alice-repo-abc123/.agents/SKILL.md" to ignored,
+            "alice-repo-abc123/SKILL.md" to ignored,                    // ignored (repo root)
+            "alice-repo-abc123/skills/mvi/SKILL.md" to skillMd("MVI Scaffold", "Predictable MVI baseline."),
+            "alice-repo-abc123/skills/mvi/references/intent.md" to "Intents are reduced by the VM.\n",
+            "alice-repo-abc123/skills/coroutines/SKILL.md" to skillMd("Coroutines", "Testing suspend fns."),
+        )
+        val res = Discovery.discover(ArchiveSource.RepoZipball(zip, commitSha = "abc1234567890abcd"))
+        val found = assertIs<ScanResult.Found>(res)
+        assertEquals(2, found.skills.size)
+        val mvi = found.skills.first { it.slug == "mvi" }
+        assertEquals("MVI Scaffold", mvi.name)
+        assertEquals("git_head", mvi.versionSource)
+        assertEquals("abc123456789", mvi.version) // commitSha.take(12)
+        assertTrue(mvi.tokenUpfront > 0)
+        assertTrue(mvi.tokenOndemand > 0, "on-demand body+references counted")
+        assertTrue(mvi.fileCount >= 2)
+        val co = found.skills.first { it.slug == "coroutines" }
+        assertEquals("Coroutines", co.name)
+    }
+
+    @Test
+    fun `uploaded zip rooted at skills is discovered without peeling`() {
+        val zip = zip("skills/x/SKILL.md" to skillMd("X", "d"))
+        val res = Discovery.discover(ArchiveSource.UploadedZip(zip, uploadHash = "deadbeefcafebabe"))
+        val found = assertIs<ScanResult.Found>(res)
+        assertEquals(1, found.skills.size)
+        assertEquals("x", found.skills[0].slug)
+        assertEquals("upload", found.skills[0].versionSource)
+    }
+
+    @Test
+    fun `uploaded zip under a wrapper dir is discovered by peeling one segment`() {
+        val zip = zip("bundle-1/skills/y/SKILL.md" to skillMd("Y", "d"))
+        val res = Discovery.discover(ArchiveSource.UploadedZip(zip, uploadHash = "h"))
+        val found = assertIs<ScanResult.Found>(res)
+        assertEquals("y", found.skills[0].slug)
+    }
+
+    @Test
+    fun `all four ignored locations are not treated as skills`() {
+        // §3.1: SKILL.md anywhere but under top-level skills/ is ignored.
+        val zip = zip(
+            "o-r-s/.github/SKILL.md" to ignored,
+            "o-r-s/.claude/SKILL.md" to ignored,
+            "o-r-s/.agents/SKILL.md" to ignored,
+            "o-r-s/SKILL.md" to ignored,
+            "o-r-s/skills/real/SKILL.md" to skillMd("Real", "d"),
+        )
+        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+        assertEquals(listOf("real"), found.skills.map { it.slug })
+    }
+
+    @Test
+    fun `no skills dir returns NoSkillsDir`() {
+        // §10: submit blocked. Even with a stray SKILL.md at root, no skills/ → NoSkillsDir.
+        val zip = zip(
+            "o-r-s/README.md" to "readme",
+            "o-r-s/SKILL.md" to ignored,
+        )
+        assertIs<ScanResult.NoSkillsDir>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+    }
+
+    @Test
+    fun `malformed manifest surfaces parseErrors on the detected skill`() {
+        val zip = zip(
+            "o-r-s/skills/bad/SKILL.md" to """
+                ---
+                name: Bad
+                description: d
+                license: MIT
+                tags: notalist
+                ---
+                body
+            """.trimIndent(),
+        )
+        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+        val bad = found.skills[0]
+        assertTrue(bad.parseErrors.any { it.field == "tags" }, "expected tags parseError; got ${bad.parseErrors}")
+    }
+
+    @Test
+    fun `zip slip entry is skipped not extracted`() {
+        // A ../ path is unsafe; Discovery must skip it, not crash or write it.
+        val zip = zip(
+            "o-r-s/skills/x/SKILL.md" to skillMd("X", "d"),
+            "o-r-s/../escape.md" to "evil",
+        )
+        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+        assertEquals(1, found.skills.size)
+    }
+
+    @Test
+    fun `too many entries trips the cap`() {
+        val entries = (1..Discovery.MAX_ENTRIES + 1).map { i ->
+            "o-r-s/skills/s$i/SKILL.md" to skillMd("s$i", "d")
+        }
+        val zip = zip(*entries.toTypedArray())
+        assertFailsArchiveTooLarge { Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")) }
+    }
+
+    @Test
+    fun `inflated size cap rejects a zip bomb`() {
+        // One entry whose inflated content blows past the cap. Build a ~60MB in-memory
+        // stream of compressible data (repeated bytes compress tiny, inflate huge).
+        val bomb = ByteArray((Discovery.MAX_INFLATED_BYTES + 1024).toInt()) // ~50MB+1KB
+        val zip = zip("o-r-s/skills/x/big.txt" to String(bomb)) // String is inefficient but fine for one test
+        assertFailsArchiveTooLarge { Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")) }
+    }
+
+    @Test
+    fun `bad slug directory is not a skill`() {
+        // §10 slug is lowercase kebab; an Upper/dir with spaces yields no skill.
+        val zip = zip("o-r-s/skills/Bad_Slug/SKILL.md" to skillMd("Bad", "d"))
+        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+        assertTrue(found.skills.isEmpty(), "Bad_Slug is not a valid slug; got ${found.skills}")
+    }
+
+    // ---- helpers ----
+
+    private val ignored = "name: Ignored\n" + skillMdBody("Ignored", "should not be picked up")
+
+    private fun skillMd(name: String, description: String) =
+        "---\n${skillMdBody(name, description)}\n---\n# $name\n"
+
+    private fun skillMdBody(name: String, description: String) =
+        "name: $name\ndescription: $description\nlicense: Apache-2.0\ntags: [android]\n"
+
+    private fun assertFailsArchiveTooLarge(block: () -> Unit) {
+        try {
+            block()
+            error("expected archive_too_large")
+        } catch (e: ApiValidationException) {
+            // The validation message carries the archive_too_large code.
+            assertTrue(e.message?.contains("archive") == true || e.fields.containsKey("archive"))
+        }
+    }
+
+    /** Build an in-memory zip from (entryName -> content) pairs. */
+    private fun zip(vararg entries: Pair<String, String>): ByteArray {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            entries.forEach { (name, content) ->
+                zos.putNextEntry(ZipEntry(name))
+                zos.write(content.toByteArray(Charsets.UTF_8))
+                zos.closeEntry()
+            }
+        }
+        return baos.toByteArray()
+    }
+}


### PR DESCRIPTION
## What this is

Step 4 of `docs/backend-spec.md` §14 — **GitHub App + read-only skill discovery** (§5 core, §8, §9 Contributor scan/repos, §10, §11). Built in an isolated worktree (`wt/step4-ingest`) off `develop` (`dfa778c`).

**Scope cap (locked in plan review, issue B):** the GitHub App client + repo-list + on-demand scan + webhook enqueue. The `ingest()` write path (file mirror, skill/version upsert, `skills.status`, review enqueue) is **deferred to step 5** — its only callers (resync worker, approve) don't exist yet, and that's where `skills.status` can be decided correctly (dissolves Q7, a §5.7 contradiction).

## Endpoints

| Method | Path | Auth | Notes |
|---|---|---|---|
| `GET` | `/api/me/repos` | S | Personal installations only (`accountId == principal.githubId`). 503 `github_app_disabled` when creds absent. |
| `POST` | `/api/me/repos/{owner}/{repo}/scan` | S | zipball at default-branch HEAD → `Discovery.discover` → read-only `DetectedSkill[]`. `NoSkillsDir` → 422 `no_skills_dir`. |
| `POST` | `/gh/webhooks` | — | HMAC verify → 401 on bad sig, 202 on accept. `push` → enqueue `resync` (idempotent on `(bundle, head_sha)`); `installation` → tag bundles. |

## Commit narrative

| Commit | Scope |
|---|---|
| `603afe1` | `GithubAppConfig` + `GitHubAppClient` interface + `Disabled` impl + PEM loader (PKCS#1/PKCS#8) + extracted `util/Compares.kt` |
| `9a438b4` | `Discovery.discover()` — zip-bomb guard, Zip Slip skip, root-normalize (gotcha #1), §3.1 four-ignored-locations, NoSkillsDir |
| `f70da2f` | `/api/me/repos` + `/scan` + `Principal.githubId` + `ApiBadGatewayException` (502) |
| `c4a9264` | `/gh/webhooks` — 401/202 (gotcha D), `(bundle,sha)` idempotency (Q5), installation→bundle tracking |

## Decisions honoured (from the locked plan)

- **A** zipball not tarball (JDK-native, unifies extraction with uploaded-zip; documented deviation from §5.1 wording).
- **B** `ingest()` write path deferred to step 5 (no `skills.status` writes → Q7 dissolved).
- **C** fs/transaction boundary rule stated for step 5 (FileStore writes outside the DB tx).
- **D** webhook 401 on bad sig / 202 on accept (GitHub convention; URL isn't secret; 200-everything suppresses redelivery).
- **Q1** doc-only single-App invariant (no format heuristic). **Q2** PKCS#1→PKCS#8 ASN.1 wrapper so GitHub's exported PEM works as-is. **Q3** personal installations only (org deferred to step 6 — App JWT can't answer org membership without the user token step 3 doesn't persist). **Q4** 50 MB / 1k / per-file, counting inflated bytes. **Q5** persisted `(bundle,sha)` dedupe (no in-memory set). **Q6** no `scan_cache` (stateless `discover`; persists at submission in step 6).

## Gotchas folded in pre-implementation

- **Gotcha #1 (zipball wrapper):** GitHub wraps the repo in `{owner}-{repo}-{sha}/`; `RepoZipball` peels exactly one segment, `UploadedZip` peels one only if `skills/` isn't already at the root. Without this every repo scan returns `NoSkillsDir`. Proven by the happy-path fixture including the wrapper.
- **Gotcha #2 (org-membership scope):** `/api/me/repos` is personal-only in step 4 (see Q3).
- **Minors:** `.agents/` joins the §3.1 ignored-locations test set; `constantTimeEquals` extracted to `util/Compares.kt` (not copy-pasted) for the HMAC compare.

## Assumptions to flag

1. **The real `RealGitHubAppClient` (HTTP + JWT) is not in this PR.** `Application.module` defaults `githubApp` to `DisabledGitHubAppClient` even when `config.githubApp.configured` is true, so the routes honestly 503/401 when creds are absent and everything is tested via fakes — but **no live GitHub call can succeed yet.** The real impl (JWT sign + token exchange + 4 endpoints) is a sizeable piece that deserves its own review; scoped out of step 4 per the plan's "interface + Disabled impl" commit-1 framing. Say the word if you want it in *this* PR.
2. **OAuth-App vs GitHub-App identity** (step-3 spec note): env names kept, single-App invariant documented in `GithubAppConfig`. Reconcile when the real client lands.

## Test status

- `api/gradlew -p api build` ✅ (also `clean build`)
- **129 tests**, all green (+31 step 4: PemLoader ×4, GithubAppConfig ×2, Compares ×2, Discovery ×10, ContributorRoutes ×6, WebhookRoutes ×7). Existing 98 from steps 1–3 unchanged.
- Each fixture is built in-memory (no binary files in the repo). `ktor-client-mock` is already a testImpl dep but not yet exercised — the real-impl test will use it.

## Reviewer notes

- Four small commits intended to read in order (client → discovery → routes → webhook).
- The PEM loader hit three real bugs the Q2 tests caught (regex, `groupValues`, END-marker extraction) — all fixed inline; the loader now verifies a loaded key signs+verifies against its public key.
- `Principal` gained `githubId` (identity data, needed for the Q3 filter).

**Holding for review now that it's open.**
