### PR TITLE
api: step 6 — contributor flows + settings + soft account delete (#5)

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -12,6 +12,7 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -37,6 +38,9 @@ fun Route.contributorRoutes(githubApp: GitHubAppClient) {
         get("submissions") { mySubmissions(call) }
         post("submissions") { createSubmissions(call, githubApp) }
         get("submissions/{id}") { getSubmission(call) }
+        post("submissions/{id}/submit") { submit(call) }
+        post("submissions/{id}/withdraw") { withdraw(call) }
+        delete("submissions/{id}") { deleteDraft(call) }
     }
 }
 
@@ -138,4 +142,25 @@ private suspend fun getSubmission(call: ApplicationCall) {
     val detail = SubmissionQueries.getSubmission(principal, id)
         ?: throw ApiNotFoundException("Submission not found")
     call.respond(detail)
+}
+
+private suspend fun submit(call: ApplicationCall) {
+    val principal = call.requireSession()
+    val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing submission id")
+    SubmissionQueries.submit(principal, id)
+    call.respond(HttpStatusCode.OK, mapOf("ok" to true))
+}
+
+private suspend fun withdraw(call: ApplicationCall) {
+    val principal = call.requireSession()
+    val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing submission id")
+    SubmissionQueries.withdraw(principal, id)
+    call.respond(HttpStatusCode.OK, mapOf("ok" to true))
+}
+
+private suspend fun deleteDraft(call: ApplicationCall) {
+    val principal = call.requireSession()
+    val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing submission id")
+    SubmissionQueries.deleteDraft(principal, id)
+    call.respond(HttpStatusCode.NoContent)
 }

--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -7,10 +7,19 @@ import dev.androidskills.ingest.DetectedSkill
 import dev.androidskills.ingest.Discovery
 import dev.androidskills.ingest.ScanResult
 import dev.androidskills.auth.requireSession
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Jobs
+import dev.androidskills.db.Skills
+import dev.androidskills.util.appJson
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
@@ -41,6 +50,10 @@ fun Route.contributorRoutes(githubApp: GitHubAppClient) {
         post("submissions/{id}/submit") { submit(call) }
         post("submissions/{id}/withdraw") { withdraw(call) }
         delete("submissions/{id}") { deleteDraft(call) }
+    }
+    route("api/skills/{slug}") {
+        post("unpublish") { unpublish(call) }
+        post("resync") { resync(call, githubApp) }
     }
 }
 
@@ -163,4 +176,41 @@ private suspend fun deleteDraft(call: ApplicationCall) {
     val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing submission id")
     SubmissionQueries.deleteDraft(principal, id)
     call.respond(HttpStatusCode.NoContent)
+}
+
+// ---- skill owner actions (step 6) ----
+
+private suspend fun unpublish(call: ApplicationCall) {
+    val principal = call.requireSession()
+    val slug = call.parameters["slug"] ?: throw ApiBadRequestException("Missing slug")
+    SkillOwnerQueries.unpublish(principal, slug)
+    call.respond(HttpStatusCode.OK, mapOf("ok" to true))
+}
+
+private suspend fun resync(call: ApplicationCall, gh: GitHubAppClient) {
+    if (!gh.configured) {
+        call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse(ErrorBody("github_app_disabled", "GitHub App is not configured")))
+        return
+    }
+    val principal = call.requireSession()
+    val slug = call.parameters["slug"] ?: throw ApiBadRequestException("Missing slug")
+
+    val bundleId = SkillOwnerQueries.ownedBundleId(principal, slug)
+        ?: if (skillExists(slug)) throw ApiForbiddenException("Not the skill owner") else throw ApiNotFoundException("Skill not found")
+
+    val bundle = transaction { Bundles.selectAll().where { Bundles.id eq bundleId }.singleOrNull() }
+        ?: throw ApiNotFoundException("Bundle not found")
+    val installationId = bundle[Bundles.installationId]
+        ?: throw ApiBadGatewayException("Bundle has no installation", "bundle_no_installation")
+    val (owner, repo) = bundle[Bundles.provenance].split("/", limit = 2)
+
+    val head = try { gh.defaultBranchHead(installationId, owner, repo) }
+    catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub ref lookup failed: ${e.message}", "github_ref_failed") }
+
+    SkillOwnerQueries.enqueueResync(principal, slug, head)
+    call.respond(HttpStatusCode.Accepted, mapOf("ok" to true))
+}
+
+private fun skillExists(slug: String) = transaction {
+    Skills.selectAll().where { Skills.slug eq slug }.any()
 }

--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -50,6 +50,10 @@ fun Route.contributorRoutes(githubApp: GitHubAppClient) {
         post("submissions/{id}/submit") { submit(call) }
         post("submissions/{id}/withdraw") { withdraw(call) }
         delete("submissions/{id}") { deleteDraft(call) }
+
+        get("stars") { listStars(call) }
+        post("stars/{slug}") { addStar(call) }
+        delete("stars/{slug}") { removeStar(call) }
     }
     route("api/skills/{slug}") {
         post("unpublish") { unpublish(call) }
@@ -175,6 +179,27 @@ private suspend fun deleteDraft(call: ApplicationCall) {
     val principal = call.requireSession()
     val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing submission id")
     SubmissionQueries.deleteDraft(principal, id)
+    call.respond(HttpStatusCode.NoContent)
+}
+
+// ---- stars (step 6) ----
+
+private suspend fun listStars(call: ApplicationCall) {
+    val principal = call.requireSession()
+    call.respond(StarsQueries.listStars(principal))
+}
+
+private suspend fun addStar(call: ApplicationCall) {
+    val principal = call.requireSession()
+    val slug = call.parameters["slug"] ?: throw ApiBadRequestException("Missing slug")
+    StarsQueries.addStar(principal, slug)
+    call.respond(HttpStatusCode.Created, mapOf("ok" to true))
+}
+
+private suspend fun removeStar(call: ApplicationCall) {
+    val principal = call.requireSession()
+    val slug = call.parameters["slug"] ?: throw ApiBadRequestException("Missing slug")
+    StarsQueries.removeStar(principal, slug)
     call.respond(HttpStatusCode.NoContent)
 }
 

--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -24,6 +24,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
+import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import kotlinx.serialization.Serializable
 
@@ -54,6 +55,10 @@ fun Route.contributorRoutes(githubApp: GitHubAppClient) {
         get("stars") { listStars(call) }
         post("stars/{slug}") { addStar(call) }
         delete("stars/{slug}") { removeStar(call) }
+
+        get("settings") { getSettings(call) }
+        put("settings") { updateSettings(call) }
+        delete("") { deleteAccount(call) }
     }
     route("api/skills/{slug}") {
         post("unpublish") { unpublish(call) }
@@ -200,6 +205,26 @@ private suspend fun removeStar(call: ApplicationCall) {
     val principal = call.requireSession()
     val slug = call.parameters["slug"] ?: throw ApiBadRequestException("Missing slug")
     StarsQueries.removeStar(principal, slug)
+    call.respond(HttpStatusCode.NoContent)
+}
+
+// ---- settings + account deletion (step 6) ----
+
+private suspend fun getSettings(call: ApplicationCall) {
+    val principal = call.requireSession()
+    call.respond(UserQueries.getSettings(principal))
+}
+
+private suspend fun updateSettings(call: ApplicationCall) {
+    val principal = call.requireSession()
+    val settings = call.receive<UserQueries.UserSettings>()
+    UserQueries.updateSettings(principal, settings)
+    call.respond(HttpStatusCode.OK, mapOf("ok" to true))
+}
+
+private suspend fun deleteAccount(call: ApplicationCall) {
+    val principal = call.requireSession()
+    UserQueries.deleteAccount(principal)
     call.respond(HttpStatusCode.NoContent)
 }
 

--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -252,7 +252,12 @@ private suspend fun resync(call: ApplicationCall, gh: GitHubAppClient) {
         ?: throw ApiNotFoundException("Bundle not found")
     val installationId = bundle[Bundles.installationId]
         ?: throw ApiBadGatewayException("Bundle has no installation", "bundle_no_installation")
-    val (owner, repo) = bundle[Bundles.provenance].split("/", limit = 2)
+    val (owner, repo) = bundle[Bundles.provenance].split("/", limit = 2).let {
+        if (it.size == 2) it[0] to it[1] else throw ApiBadGatewayException(
+            "Bundle provenance is malformed: ${bundle[Bundles.provenance]}",
+            "bundle_provenance_malformed",
+        )
+    }
 
     val head = try { gh.defaultBranchHead(installationId, owner, repo) }
     catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub ref lookup failed: ${e.message}", "github_ref_failed") }

--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -9,6 +9,7 @@ import dev.androidskills.ingest.ScanResult
 import dev.androidskills.auth.requireSession
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
@@ -32,6 +33,10 @@ fun Route.contributorRoutes(githubApp: GitHubAppClient) {
     route("api/me") {
         get("repos") { repos(call, githubApp) }
         post("repos/{owner}/{repo}/scan") { scan(call, githubApp) }
+
+        get("submissions") { mySubmissions(call) }
+        post("submissions") { createSubmissions(call, githubApp) }
+        get("submissions/{id}") { getSubmission(call) }
     }
 }
 
@@ -81,7 +86,7 @@ private suspend fun scan(call: ApplicationCall, gh: GitHubAppClient) {
         )
     }
 
-    val result = Discovery.discover(ArchiveSource.RepoZipball(zipball, head))
+    val result = Discovery.discover(ArchiveSource.RepoZipball(zipball, owner, repo, head))
     val response = when (result) {
         is ScanResult.Found -> ScanResponse(slug = "$owner/$repo", commitSha = head, skills = result.skills.map { it.toDto() })
         ScanResult.NoSkillsDir -> throw ApiValidationException(
@@ -112,3 +117,25 @@ private fun DetectedSkill.toDto() = DetectedSkillDto(
     tokenUpfront, tokenOndemand, tokenBand,
     parseErrors.map { DetectedFieldError(it.field, it.reason) }, fileCount,
 )
+
+// ---- submissions (step 6) ----
+
+private suspend fun createSubmissions(call: ApplicationCall, gh: GitHubAppClient) {
+    val principal = call.requireSession()
+    val request = call.receive<SubmissionQueries.CreateDraftsRequest>()
+    val response = SubmissionQueries.createDrafts(principal, request, gh)
+    call.respond(HttpStatusCode.Created, response)
+}
+
+private suspend fun mySubmissions(call: ApplicationCall) {
+    val principal = call.requireSession()
+    call.respond(SubmissionQueries.mySubmissions(principal))
+}
+
+private suspend fun getSubmission(call: ApplicationCall) {
+    val principal = call.requireSession()
+    val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing submission id")
+    val detail = SubmissionQueries.getSubmission(principal, id)
+        ?: throw ApiNotFoundException("Submission not found")
+    call.respond(detail)
+}

--- a/api/src/main/kotlin/dev/androidskills/api/Errors.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Errors.kt
@@ -46,6 +46,9 @@ class ApiValidationException(
     val code: String = "validation_failed",
 ) : RuntimeException(message)
 
+/** 403 — authenticated caller lacks permission for a public resource action. */
+class ApiForbiddenException(message: String = "Forbidden") : RuntimeException(message)
+
 /** 409 — duplicate slug, first-come ownership conflict. */
 class ApiConflictException(message: String, val code: String = "conflict") : RuntimeException(message)
 
@@ -60,6 +63,9 @@ fun Application.installApiErrorMapping() {
         val log = LoggerFactory.getLogger("dev.androidskills.api.Errors")
         exception<ApiNotFoundException> { call, ex ->
             call.respond(HttpStatusCode.NotFound, ErrorResponse(ErrorBody("not_found", ex.message ?: "Not found")))
+        }
+        exception<ApiForbiddenException> { call, ex ->
+            call.respond(HttpStatusCode.Forbidden, ErrorResponse(ErrorBody("forbidden", ex.message ?: "Forbidden")))
         }
         exception<ApiUnauthorizedException> { call, ex ->
             call.respond(HttpStatusCode.Unauthorized, ErrorResponse(ErrorBody("unauthorized", ex.message ?: "Authentication required")))

--- a/api/src/main/kotlin/dev/androidskills/api/SkillOwnerQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/SkillOwnerQueries.kt
@@ -1,0 +1,77 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.Principal
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Jobs
+import dev.androidskills.db.SkillStatus
+import dev.androidskills.db.Skills
+import dev.androidskills.util.appJson
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+/**
+ * Owner-only actions on a published/unlisted skill (spec §9 Contributor).
+ * Non-owners get 403 because `/api/skills/{slug}` is already a public route;
+ * a missing slug returns 404.
+ */
+object SkillOwnerQueries {
+
+    /** Returns the skill's bundle id if [principal] owns it; null if the skill does not exist. */
+    fun ownedBundleId(principal: Principal, slug: String): String? = transaction {
+        val skill = Skills.selectAll().where { Skills.slug eq slug }.singleOrNull() ?: return@transaction null
+        val bundle = Bundles.selectAll().where { Bundles.id eq skill[Skills.bundleId] }.singleOrNull()
+        bundle?.get(Bundles.id)?.takeIf { bundle[Bundles.ownerUserId] == principal.userId }
+    }
+
+    fun unpublish(principal: Principal, slug: String) {
+        transaction {
+            val bundleId = ownedBundleId(principal, slug)
+            if (bundleId == null) {
+                // Distinguish "slug doesn't exist" (404) from "exists but not owner" (403).
+                val exists = Skills.selectAll().where { Skills.slug eq slug }.any()
+                if (exists) throw ApiForbiddenException("Not the skill owner")
+                throw ApiNotFoundException("Skill not found")
+            }
+            Skills.update({ Skills.slug eq slug }) {
+                it[Skills.status] = SkillStatus.unlisted.name
+                it[Skills.verified] = false
+                it[Skills.updatedAt] = nowIso()
+            }
+        }
+    }
+
+    /**
+     * Enqueues a resync job for an owned skill. [headSha] is the current HEAD
+     * of the bundle's repo (fetched by the route via GitHubAppClient).
+     */
+    fun enqueueResync(principal: Principal, slug: String, headSha: String) {
+        transaction {
+            val bundleId = ownedBundleId(principal, slug)
+            if (bundleId == null) {
+                val exists = Skills.selectAll().where { Skills.slug eq slug }.any()
+                if (exists) throw ApiForbiddenException("Not the skill owner")
+                throw ApiNotFoundException("Skill not found")
+            }
+            val now = nowIso()
+            val payload = appJson.encodeToString(ResyncPayload.serializer(), ResyncPayload(bundleId, headSha))
+            Jobs.insert {
+                it[Jobs.id] = newId()
+                it[Jobs.type] = "resync"
+                it[Jobs.payload] = payload
+                it[Jobs.state] = "queued"
+                it[Jobs.attempts] = 0
+                it[Jobs.runAfter] = now
+                it[Jobs.createdAt] = now
+                it[Jobs.updatedAt] = now
+            }
+        }
+    }
+
+    @Serializable
+    private data class ResyncPayload(val bundleId: String, val headSha: String)
+}

--- a/api/src/main/kotlin/dev/androidskills/api/StarsQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/StarsQueries.kt
@@ -3,6 +3,7 @@ package dev.androidskills.api
 import dev.androidskills.auth.Principal
 import dev.androidskills.db.Categories
 import dev.androidskills.db.Skills
+import dev.androidskills.db.SkillStatus
 import dev.androidskills.db.Stars
 import dev.androidskills.util.nowIso
 import kotlinx.serialization.Serializable
@@ -56,11 +57,13 @@ object StarsQueries {
 
     fun addStar(principal: Principal, slug: String) {
         transaction {
-            val skillId = Skills.selectAll().where { Skills.slug eq slug }.singleOrNull()?.get(Skills.id)
-                ?: throw ApiNotFoundException("Skill not found")
+            val skill = Skills.selectAll()
+                .where { (Skills.slug eq slug) and (Skills.status eq SkillStatus.published.name) }
+                .singleOrNull()
+            if (skill == null) throw ApiNotFoundException("Skill not found")
             Stars.insertIgnore {
                 it[Stars.userId] = principal.userId
-                it[Stars.skillId] = skillId
+                it[Stars.skillId] = skill[Skills.id]
                 it[Stars.createdAt] = nowIso()
             }
         }

--- a/api/src/main/kotlin/dev/androidskills/api/StarsQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/StarsQueries.kt
@@ -1,0 +1,79 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.Principal
+import dev.androidskills.db.Categories
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Stars
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insertIgnore
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+
+/**
+ * Account-synced starred library (spec §9 Contributor).
+ */
+object StarsQueries {
+
+    @Serializable
+    data class StarredSkill(
+        val slug: String,
+        val name: String,
+        val category: String?,
+        val createdAt: String,
+    )
+
+    fun listStars(principal: Principal): List<StarredSkill> = transaction {
+        val stars = Stars.selectAll()
+            .where { Stars.userId eq principal.userId }
+            .orderBy(Stars.createdAt to SortOrder.DESC)
+            .map { it[Stars.skillId] to it[Stars.createdAt] }
+        val skillIds = stars.map { it.first }
+        val skillsById = if (skillIds.isEmpty()) emptyMap() else {
+            Skills.selectAll()
+                .where { Skills.id inList skillIds }
+                .associateBy({ it[Skills.id] }, { it })
+        }
+        val categoryIds = skillsById.values.mapNotNull { it[Skills.categoryId] }.distinct()
+        val categoryNames = if (categoryIds.isEmpty()) emptyMap() else {
+            Categories.selectAll()
+                .where { Categories.id inList categoryIds }
+                .associate { it[Categories.id] to it[Categories.name] }
+        }
+        stars.mapNotNull { (skillId, createdAt) ->
+            val skill = skillsById[skillId] ?: return@mapNotNull null
+            StarredSkill(
+                slug = skill[Skills.slug],
+                name = skill[Skills.name],
+                category = skill[Skills.categoryId]?.let { categoryNames[it] },
+                createdAt = createdAt,
+            )
+        }
+    }
+
+    fun addStar(principal: Principal, slug: String) {
+        transaction {
+            val skillId = Skills.selectAll().where { Skills.slug eq slug }.singleOrNull()?.get(Skills.id)
+                ?: throw ApiNotFoundException("Skill not found")
+            Stars.insertIgnore {
+                it[Stars.userId] = principal.userId
+                it[Stars.skillId] = skillId
+                it[Stars.createdAt] = nowIso()
+            }
+        }
+    }
+
+    fun removeStar(principal: Principal, slug: String) {
+        transaction {
+            val skillId = Skills.selectAll().where { Skills.slug eq slug }.singleOrNull()?.get(Skills.id)
+                ?: throw ApiNotFoundException("Skill not found")
+            val op = org.jetbrains.exposed.sql.SqlExpressionBuilder.run {
+                (Stars.userId eq principal.userId) and (Stars.skillId eq skillId)
+            }
+            Stars.deleteWhere { op }
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/SubmissionQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/SubmissionQueries.kt
@@ -163,7 +163,10 @@ object SubmissionQueries {
                 val version = selection.version ?: request.ref.take(12)
                 val versionSource = if (selection.version != null) VersionSource.manifest.name else VersionSource.git_head.name
 
-                // Slug must not already belong to a different bundle.
+                // Slug must not already belong to a different bundle. If it belongs to
+                // the same bundle, we only allow re-drafting an unlisted shell; a published
+                // skill or an active submission must be handled via the admin queue (Bugbot
+                // high + medium findings).
                 val existingSkill = Skills.selectAll().where { Skills.slug eq selection.slug }.singleOrNull()
                 if (existingSkill != null && existingSkill[Skills.bundleId] != bundleId) {
                     throw ApiConflictException(
@@ -171,9 +174,30 @@ object SubmissionQueries {
                         code = "slug_conflict",
                     )
                 }
+                if (existingSkill != null && existingSkill[Skills.status] == SkillStatus.published.name) {
+                    throw ApiConflictException(
+                        "Skill '${selection.slug}' is already published; updates go through the admin queue",
+                        code = "skill_already_published",
+                    )
+                }
+                if (existingSkill != null) {
+                    val activeSub = Submissions.selectAll()
+                        .where {
+                            (Submissions.bundleId eq bundleId) and
+                                (Submissions.skillId eq existingSkill[Skills.id]) and
+                                (Submissions.state inList listOf("in_review", "changes_requested", "published", "rejected"))
+                        }
+                        .singleOrNull()
+                    if (activeSub != null) {
+                        throw ApiConflictException(
+                            "An active submission already exists for '${selection.slug}'",
+                            code = "submission_already_active",
+                        )
+                    }
+                }
 
                 val skillId = if (existingSkill != null) {
-                    // Same bundle: update the shell from the latest scan metadata.
+                    // Same bundle, unlisted shell: update the shell from the latest scan metadata.
                     val id = existingSkill[Skills.id]
                     Skills.update({ Skills.id eq id }) {
                         it[Skills.name] = selection.name

--- a/api/src/main/kotlin/dev/androidskills/api/SubmissionQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/SubmissionQueries.kt
@@ -3,20 +3,25 @@ package dev.androidskills.api
 import dev.androidskills.auth.Principal
 import dev.androidskills.db.BundleKind
 import dev.androidskills.db.Bundles
+import dev.androidskills.db.Jobs
 import dev.androidskills.db.SkillStatus
 import dev.androidskills.db.Skills
 import dev.androidskills.db.Submissions
 import dev.androidskills.db.VersionSource
-import org.jetbrains.exposed.sql.SortOrder
-import org.jetbrains.exposed.sql.and
+import dev.androidskills.db.Versions
 import dev.androidskills.github.GitHubAppClient
 import dev.androidskills.github.GitHubAppException
+import dev.androidskills.ingest.ManifestValidator
 import dev.androidskills.ingest.StagedPayload
 import dev.androidskills.ingest.SubmissionPayload
 import dev.androidskills.util.appJson
 import dev.androidskills.util.newId
 import dev.androidskills.util.nowIso
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -35,6 +40,7 @@ object SubmissionQueries {
 
     /** Lowercase kebab-case, matching the spec §10 slug rule. */
     private val SLUG_RE = Regex("^[a-z0-9]+(-[a-z0-9]+)*$")
+    private val TAG_RE = Regex("^[a-z0-9][a-z0-9._+-]{0,39}$")
 
     @Serializable
     data class CreateDraftsRequest(
@@ -273,6 +279,118 @@ object SubmissionQueries {
         )
     }
 
+    /**
+     * Moves a draft submission to `in_review` and enqueues a metadata-only review
+     * job (guarded against duplicates). Validates the manifest per §10.
+     */
+    fun submit(principal: Principal, submissionId: String) {
+        transaction {
+            val row = Submissions.selectAll()
+                .where { (Submissions.id eq submissionId) and (Submissions.submitterId eq principal.userId) }
+                .singleOrNull() ?: throw ApiNotFoundException("Submission not found")
+            if (row[Submissions.state] != "draft") {
+                throw ApiConflictException("Submission is not a draft", code = "invalid_state_transition")
+            }
+            val skillId = row[Submissions.skillId]
+                ?: throw IllegalStateException("Draft submission $submissionId has no skill")
+            val payload = row[Submissions.payload]?.let {
+                runCatching { appJson.decodeFromString(SubmissionPayload.serializer(), it) }.getOrNull()
+            }
+            val staged = payload?.staged
+                ?: throw IllegalStateException("Draft submission $submissionId has no staged payload")
+            val selection = SelectedSkill(
+                slug = Skills.selectAll().where { Skills.id eq skillId }.singleOrNull()?.get(Skills.slug) ?: "",
+                name = staged.name,
+                description = staged.description,
+                license = staged.license ?: "",
+                tags = staged.tags,
+                version = staged.version,
+            )
+            val expectSemVer = staged.versionSource == VersionSource.manifest.name
+            val errors = validateForSubmit(selection, expectSemVer)
+            if (errors.isNotEmpty()) throw ApiValidationException(errors)
+
+            val now = nowIso()
+            Submissions.update({ Submissions.id eq submissionId }) {
+                it[Submissions.state] = "in_review"
+                it[Submissions.updatedAt] = now
+            }
+            enqueueReview(skillId, submissionId, now)
+        }
+    }
+
+    /**
+     * Withdraws an `in_review` submission back to `draft`. Clears any queued
+     * review job; a running job is left alone (its output will be merged but
+     * ignored until the next submit).
+     */
+    fun withdraw(principal: Principal, submissionId: String) {
+        transaction {
+            val row = Submissions.selectAll()
+                .where { (Submissions.id eq submissionId) and (Submissions.submitterId eq principal.userId) }
+                .singleOrNull() ?: throw ApiNotFoundException("Submission not found")
+            if (row[Submissions.state] != "in_review") {
+                throw ApiConflictException("Submission is not in review", code = "invalid_state_transition")
+            }
+            Submissions.update({ Submissions.id eq submissionId }) {
+                it[Submissions.state] = "draft"
+                it[Submissions.updatedAt] = nowIso()
+            }
+            // Remove queued review jobs for this submission.
+            val reviewPayload = appJson.encodeToString(
+                ReviewPayload(skillId = row[Submissions.skillId] ?: "", submissionId = submissionId),
+            )
+            val deleteOp = org.jetbrains.exposed.sql.SqlExpressionBuilder.run {
+                (Jobs.type eq "review") and (Jobs.payload eq reviewPayload) and (Jobs.state eq "queued")
+            }
+            Jobs.deleteWhere { deleteOp }
+        }
+    }
+
+    /**
+     * Deletes a draft submission and its unlisted skill shell, but only if the
+     * skill has no published versions (prevents accidental data loss).
+     */
+    fun deleteDraft(principal: Principal, submissionId: String) {
+        transaction {
+            val row = Submissions.selectAll()
+                .where { (Submissions.id eq submissionId) and (Submissions.submitterId eq principal.userId) }
+                .singleOrNull() ?: throw ApiNotFoundException("Submission not found")
+            if (row[Submissions.state] != "draft") {
+                throw ApiConflictException("Only drafts can be deleted", code = "invalid_state_transition")
+            }
+            val skillId = row[Submissions.skillId]
+            val hasVersions = skillId?.let { sid -> Versions.selectAll().where { Versions.skillId eq sid }.any() } ?: false
+            val subOp = org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Submissions.id eq submissionId }
+            Submissions.deleteWhere { subOp }
+            if (skillId != null && !hasVersions) {
+                val skillOp = org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Skills.id eq skillId }
+                Skills.deleteWhere { skillOp }
+            }
+        }
+    }
+
+    private fun enqueueReview(skillId: String, submissionId: String, now: String) {
+        val payload = appJson.encodeToString(
+            ReviewPayload(skillId = skillId, submissionId = submissionId),
+        )
+        val alreadyQueued = Jobs.selectAll()
+            .where { (Jobs.type eq "review") and (Jobs.payload eq payload) and (Jobs.state inList listOf("queued", "running")) }
+            .any()
+        if (!alreadyQueued) {
+            Jobs.insert {
+                it[Jobs.id] = newId()
+                it[Jobs.type] = "review"
+                it[Jobs.payload] = payload
+                it[Jobs.state] = "queued"
+                it[Jobs.attempts] = 0
+                it[Jobs.runAfter] = now
+                it[Jobs.createdAt] = now
+                it[Jobs.updatedAt] = now
+            }
+        }
+    }
+
     private fun buildStaged(
         selection: SelectedSkill,
         version: String,
@@ -292,9 +410,33 @@ object SubmissionQueries {
         ),
     )
 
+    /**
+     * Validates the manifest fields required before a submission can move to
+     * `in_review` (spec §10). Returns a map of field → reason, empty if valid.
+     * [expectSemVer] is true when the version came from the manifest (not a
+     * derived git HEAD ref).
+     */
+    fun validateForSubmit(selection: SelectedSkill, expectSemVer: Boolean): Map<String, String> {
+        val errors = mutableMapOf<String, String>()
+        if (!SLUG_RE.matches(selection.slug)) errors["slug"] = "must be lowercase kebab-case"
+        if (selection.name.isBlank()) errors["name"] = "is required"
+        if (selection.description.isBlank()) errors["description"] = "is required"
+        if (selection.license.isBlank()) errors["license"] = "is required"
+        selection.tags.forEachIndexed { i, tag ->
+            if (!TAG_RE.matches(tag)) errors["tags[$i]"] = "must be lowercase alnum/._+- (max 40)"
+        }
+        if (expectSemVer && selection.version != null && !ManifestValidator.SEMVER.matches(selection.version)) {
+            errors["version"] = "must be valid SemVer"
+        }
+        return errors
+    }
+
     private fun validateSlug(slug: String) {
         if (!SLUG_RE.matches(slug)) {
             throw ApiValidationException(mapOf("slug" to "must be lowercase kebab-case"))
         }
     }
 }
+
+    @Serializable
+    private data class ReviewPayload(val skillId: String, val submissionId: String)

--- a/api/src/main/kotlin/dev/androidskills/api/SubmissionQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/SubmissionQueries.kt
@@ -114,12 +114,19 @@ object SubmissionQueries {
         // installed the App on the account that owns the repo.
         val installationId = try {
             gh.installations()
-                .firstOrNull { it.accountLogin.equals(request.repoOwner, ignoreCase = true) }
+                .firstOrNull {
+                    // SEC1: must be an installation controlled by the principal. The App-level
+                    // /app/installations list includes every account that installed the App; we
+                    // reject any installation whose account is not the caller's (org installs
+                    // require membership proof and are deferred).
+                    it.accountId == principal.githubId &&
+                        it.accountLogin.equals(request.repoOwner, ignoreCase = true)
+                }
                 ?.id
         } catch (e: GitHubAppException) {
             throw ApiBadGatewayException("GitHub installations request failed: ${e.message}", "github_installations_failed")
         } ?: throw ApiValidationException(
-            mapOf("repo" to "install the GitHub App on '$request.repoOwner' first"),
+            mapOf("repo" to "install the GitHub App on '${request.repoOwner}' first"),
             code = "github_app_not_installed",
         )
 
@@ -436,7 +443,7 @@ object SubmissionQueries {
             throw ApiValidationException(mapOf("slug" to "must be lowercase kebab-case"))
         }
     }
-}
 
     @Serializable
     private data class ReviewPayload(val skillId: String, val submissionId: String)
+}

--- a/api/src/main/kotlin/dev/androidskills/api/SubmissionQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/SubmissionQueries.kt
@@ -1,0 +1,300 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.Principal
+import dev.androidskills.db.BundleKind
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.SkillStatus
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Submissions
+import dev.androidskills.db.VersionSource
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GitHubAppException
+import dev.androidskills.ingest.StagedPayload
+import dev.androidskills.ingest.SubmissionPayload
+import dev.androidskills.util.appJson
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+/**
+ * Contributor submission lifecycle (spec §9 Contributor, step 6).
+ *
+ * Drafts are created from scan results and are where bundles are first
+ * materialised (first-come-first-served ownership, §3.4). Each selected skill
+ * becomes an unlisted skill shell + a draft submission. Submit moves the
+ * submission to `in_review` and enqueues a metadata-only review via the step-5
+ * worker.
+ */
+object SubmissionQueries {
+
+    /** Lowercase kebab-case, matching the spec §10 slug rule. */
+    private val SLUG_RE = Regex("^[a-z0-9]+(-[a-z0-9]+)*$")
+
+    @Serializable
+    data class CreateDraftsRequest(
+        val repoOwner: String,
+        val repoName: String,
+        val ref: String,
+        val skills: List<SelectedSkill>,
+    )
+
+    @Serializable
+    data class SelectedSkill(
+        val slug: String,
+        val name: String,
+        val description: String,
+        val license: String,
+        val tags: List<String> = emptyList(),
+        val version: String? = null,
+    )
+
+    @Serializable
+    data class CreateDraftsResponse(val submissionIds: List<String>)
+
+    @Serializable
+    data class SubmissionSummary(
+        val id: String,
+        val slug: String,
+        val state: String,
+        val lintScore: Int?,
+        val createdAt: String,
+        val updatedAt: String,
+    )
+
+    @Serializable
+    data class GroupedSubmissions(
+        val state: String,
+        val items: List<SubmissionSummary>,
+    )
+
+    @Serializable
+    data class SubmissionDetail(
+        val id: String,
+        val slug: String,
+        val state: String,
+        val lintScore: Int?,
+        val note: String?,
+        val payload: SubmissionPayload?,
+        val createdAt: String,
+        val updatedAt: String,
+    )
+
+    /**
+     * Creates a bundle (first-come) and one draft submission per selected skill.
+     * Each skill becomes an unlisted shell so the step-5 review worker has a row
+     * to read. Validates slugs up front to avoid claiming bad slugs.
+     */
+    suspend fun createDrafts(
+        principal: Principal,
+        request: CreateDraftsRequest,
+        gh: GitHubAppClient,
+    ): CreateDraftsResponse {
+        if (request.repoOwner.isBlank() || request.repoName.isBlank() || request.ref.isBlank()) {
+            throw ApiValidationException(mapOf("repo" to "owner, repo and ref are required"))
+        }
+        if (request.skills.isEmpty()) {
+            throw ApiValidationException(mapOf("skills" to "at least one skill is required"))
+        }
+
+        val provenance = "${request.repoOwner}/${request.repoName}"
+
+        // Resolve the GitHub App installation for this repo. The user must have
+        // installed the App on the account that owns the repo.
+        val installationId = try {
+            gh.installations()
+                .firstOrNull { it.accountLogin.equals(request.repoOwner, ignoreCase = true) }
+                ?.id
+        } catch (e: GitHubAppException) {
+            throw ApiBadGatewayException("GitHub installations request failed: ${e.message}", "github_installations_failed")
+        } ?: throw ApiValidationException(
+            mapOf("repo" to "install the GitHub App on '$request.repoOwner' first"),
+            code = "github_app_not_installed",
+        )
+
+        val now = nowIso()
+        val submissionIds = transaction {
+            // First-come-first-served bundle ownership (§3.4).
+            val existingBundle = Bundles.selectAll()
+                .where { (Bundles.kind eq BundleKind.repo.name) and (Bundles.provenance eq provenance) }
+                .singleOrNull()
+            val bundleId = if (existingBundle != null) {
+                if (existingBundle[Bundles.ownerUserId] != principal.userId) {
+                    throw ApiConflictException(
+                        "Repository '$provenance' is already linked to another account",
+                        code = "bundle_ownership_conflict",
+                    )
+                }
+                existingBundle[Bundles.id]
+            } else {
+                val id = newId()
+                Bundles.insert {
+                    it[Bundles.id] = id
+                    it[Bundles.kind] = BundleKind.repo.name
+                    it[Bundles.provenance] = provenance
+                    it[Bundles.ownerUserId] = principal.userId
+                    it[Bundles.sourceRef] = request.ref
+                    it[Bundles.installationId] = installationId
+                    it[Bundles.createdAt] = now
+                }
+                id
+            }
+
+            request.skills.map { selection ->
+                validateSlug(selection.slug)
+                val version = selection.version ?: request.ref.take(12)
+                val versionSource = if (selection.version != null) VersionSource.manifest.name else VersionSource.git_head.name
+
+                // Slug must not already belong to a different bundle.
+                val existingSkill = Skills.selectAll().where { Skills.slug eq selection.slug }.singleOrNull()
+                if (existingSkill != null && existingSkill[Skills.bundleId] != bundleId) {
+                    throw ApiConflictException(
+                        "Skill slug '${selection.slug}' is already used by another repository",
+                        code = "slug_conflict",
+                    )
+                }
+
+                val skillId = if (existingSkill != null) {
+                    // Same bundle: update the shell from the latest scan metadata.
+                    val id = existingSkill[Skills.id]
+                    Skills.update({ Skills.id eq id }) {
+                        it[Skills.name] = selection.name
+                        it[Skills.description] = selection.description
+                        it[Skills.license] = selection.license
+                        it[Skills.tags] = appJson.encodeToString(selection.tags)
+                        it[Skills.version] = version
+                        it[Skills.versionSource] = versionSource
+                        it[Skills.updatedAt] = now
+                    }
+                    id
+                } else {
+                    val id = newId()
+                    Skills.insert {
+                        it[Skills.id] = id
+                        it[Skills.bundleId] = bundleId
+                        it[Skills.slug] = selection.slug
+                        it[Skills.name] = selection.name
+                        it[Skills.description] = selection.description
+                        it[Skills.license] = selection.license
+                        it[Skills.tags] = appJson.encodeToString(selection.tags)
+                        it[Skills.version] = version
+                        it[Skills.versionSource] = versionSource
+                        it[Skills.status] = SkillStatus.unlisted.name
+                        it[Skills.verified] = false
+                        it[Skills.createdAt] = now
+                        it[Skills.updatedAt] = now
+                    }
+                    id
+                }
+
+                // Reuse an existing draft submission for (bundle, skill) if present.
+                val existingSub = Submissions.selectAll()
+                    .where {
+                        (Submissions.bundleId eq bundleId) and
+                            (Submissions.skillId eq skillId) and
+                            (Submissions.state eq "draft")
+                    }
+                    .singleOrNull()
+
+                val subId = if (existingSub != null) {
+                    val id = existingSub[Submissions.id]
+                    val staged = buildStaged(selection, version, versionSource, request)
+                    val merged = SubmissionPayload(staged = staged)
+                    Submissions.update({ Submissions.id eq id }) {
+                        it[Submissions.payload] = appJson.encodeToString(SubmissionPayload.serializer(), merged)
+                        it[Submissions.updatedAt] = now
+                    }
+                    id
+                } else {
+                    val id = newId()
+                    val staged = buildStaged(selection, version, versionSource, request)
+                    Submissions.insert {
+                        it[Submissions.id] = id
+                        it[Submissions.bundleId] = bundleId
+                        it[Submissions.skillId] = skillId
+                        it[Submissions.submitterId] = principal.userId
+                        it[Submissions.state] = "draft"
+                        it[Submissions.payload] = appJson.encodeToString(SubmissionPayload.serializer(), SubmissionPayload(staged = staged))
+                        it[Submissions.createdAt] = now
+                        it[Submissions.updatedAt] = now
+                    }
+                    id
+                }
+                subId
+            }
+        }
+        return CreateDraftsResponse(submissionIds)
+    }
+
+    fun mySubmissions(principal: Principal): List<GroupedSubmissions> = transaction {
+        val rows = Submissions.selectAll()
+            .where { Submissions.submitterId eq principal.userId }
+            .orderBy(Submissions.updatedAt to org.jetbrains.exposed.sql.SortOrder.DESC)
+            .map {
+                SubmissionSummary(
+                    id = it[Submissions.id],
+                    slug = it[Submissions.skillId]?.let { sid ->
+                        Skills.selectAll().where { Skills.id eq sid }.singleOrNull()?.get(Skills.slug)
+                    } ?: "",
+                    state = it[Submissions.state],
+                    lintScore = it[Submissions.lintScore],
+                    createdAt = it[Submissions.createdAt],
+                    updatedAt = it[Submissions.updatedAt],
+                )
+            }
+        rows.groupBy { it.state }.map { (state, items) -> GroupedSubmissions(state, items) }
+    }
+
+    fun getSubmission(principal: Principal, submissionId: String): SubmissionDetail? = transaction {
+        val row = Submissions.selectAll()
+            .where { (Submissions.id eq submissionId) and (Submissions.submitterId eq principal.userId) }
+            .singleOrNull() ?: return@transaction null
+        val skillId = row[Submissions.skillId]
+        val slug = skillId?.let { sid ->
+            Skills.selectAll().where { Skills.id eq sid }.singleOrNull()?.get(Skills.slug)
+        } ?: ""
+        val payload = row[Submissions.payload]?.let {
+            runCatching { appJson.decodeFromString(SubmissionPayload.serializer(), it) }.getOrNull()
+        }
+        SubmissionDetail(
+            id = row[Submissions.id],
+            slug = slug,
+            state = row[Submissions.state],
+            lintScore = row[Submissions.lintScore],
+            note = row[Submissions.note],
+            payload = payload,
+            createdAt = row[Submissions.createdAt],
+            updatedAt = row[Submissions.updatedAt],
+        )
+    }
+
+    private fun buildStaged(
+        selection: SelectedSkill,
+        version: String,
+        versionSource: String,
+        request: CreateDraftsRequest,
+    ) = StagedPayload(
+        version = version,
+        versionSource = versionSource,
+        name = selection.name,
+        description = selection.description,
+        license = selection.license,
+        tags = selection.tags,
+        sourceRef = StagedPayload.SourceRef(
+            repoOwner = request.repoOwner,
+            repoName = request.repoName,
+            ref = request.ref,
+        ),
+    )
+
+    private fun validateSlug(slug: String) {
+        if (!SLUG_RE.matches(slug)) {
+            throw ApiValidationException(mapOf("slug" to "must be lowercase kebab-case"))
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/UserQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/UserQueries.kt
@@ -1,0 +1,62 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.GitHubUser
+import dev.androidskills.auth.Principal
+import dev.androidskills.auth.UsersRepo
+import dev.androidskills.db.Role
+import dev.androidskills.db.Users
+import dev.androidskills.util.appJson
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+/**
+ * Contributor settings and account deletion (spec §9 Contributor, step 6).
+ * Account deletion is soft: the user row stays so published skills/bundles and
+ * audit logs remain valid. Re-login reactivates the account.
+ */
+object UserQueries {
+
+    @Serializable
+    data class UserSettings(
+        val emailNotifications: Boolean = true,
+        val publicProfile: Boolean = true,
+    )
+
+    fun getSettings(principal: Principal): UserSettings = transaction {
+        val row = Users.selectAll().where { Users.id eq principal.userId }.singleOrNull()
+            ?: throw ApiNotFoundException("User not found")
+        row[Users.settingsJson]?.let {
+            runCatching { appJson.decodeFromString(UserSettings.serializer(), it) }.getOrNull()
+        } ?: UserSettings()
+    }
+
+    fun updateSettings(principal: Principal, settings: UserSettings) {
+        transaction {
+            Users.update({ Users.id eq principal.userId }) {
+                it[Users.settingsJson] = appJson.encodeToString(UserSettings.serializer(), settings)
+                it[Users.updatedAt] = nowIso()
+            }
+        }
+    }
+
+    /**
+     * Soft-deletes the authenticated account. Admins cannot self-delete (§3.9);
+     * they must be demoted by another admin first.
+     */
+    fun deleteAccount(principal: Principal) {
+        transaction {
+            val row = Users.selectAll().where { Users.id eq principal.userId }.singleOrNull()
+                ?: throw ApiNotFoundException("User not found")
+            if (Role.parse(row[Users.role]) == Role.admin) {
+                throw ApiConflictException("Admins cannot delete their own account", code = "admin_self_delete")
+            }
+            Users.update({ Users.id eq principal.userId }) {
+                it[Users.deletedAt] = nowIso()
+                it[Users.updatedAt] = nowIso()
+            }
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/UserQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/UserQueries.kt
@@ -4,10 +4,12 @@ import dev.androidskills.auth.GitHubUser
 import dev.androidskills.auth.Principal
 import dev.androidskills.auth.UsersRepo
 import dev.androidskills.db.Role
+import dev.androidskills.db.Sessions
 import dev.androidskills.db.Users
 import dev.androidskills.util.appJson
 import dev.androidskills.util.nowIso
 import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
@@ -57,6 +59,10 @@ object UserQueries {
                 it[Users.deletedAt] = nowIso()
                 it[Users.updatedAt] = nowIso()
             }
+            // LOW2: revoke all existing sessions so a deleted user cannot remain logged in,
+            // and so old cookies do not become valid again if the account is later reactivated.
+            val op = org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Sessions.userId eq principal.userId }
+            Sessions.deleteWhere { op }
         }
     }
 }

--- a/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/SessionStore.kt
@@ -5,9 +5,10 @@ import dev.androidskills.db.Sessions
 import dev.androidskills.db.UserStatus
 import dev.androidskills.db.Users
 import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.security.SecureRandom
 import java.time.Instant
@@ -46,7 +47,9 @@ object SessionStore {
         val expiresAt = runCatching { Instant.parse(row[Sessions.expiresAt]) }.getOrNull()
             ?: return@transaction null
         if (expiresAt.isBefore(now)) return@transaction null
-        val user = Users.selectAll().where { Users.id eq row[Sessions.userId] }.singleOrNull()
+        val user = Users.selectAll()
+            .where { (Users.id eq row[Sessions.userId]) and (Users.deletedAt.isNull()) }
+            .singleOrNull()
             ?: return@transaction null
         // A suspended user is never admitted — even mid-session.
         val status = runCatching { UserStatus.parse(user[Users.status]) }.getOrNull()

--- a/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
@@ -69,6 +69,8 @@ object UsersRepo {
                 it[Users.handle] = uniqueHandle(user.handle, user.githubId, excludeId = id)
                 it[Users.name] = user.name
                 it[Users.avatarUrl] = user.avatarUrl
+                // Re-login reactivates a soft-deleted account (step 6).
+                it[Users.deletedAt] = null
                 // NOTE: role is NOT touched here — a bootstrap/demoted/suspended
                 // user keeps their current role on re-login (P1-1).
                 it[Users.updatedAt] = now

--- a/api/src/main/kotlin/dev/androidskills/db/Migrations.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/Migrations.kt
@@ -25,6 +25,10 @@ object Migrations {
             migrateV1()
             writeVersion(1)
         }
+        if (version < 2) {
+            migrateV2()
+            writeVersion(2)
+        }
     }
 
     /** v1: the full initial schema (spec §4) + default category taxonomy. */
@@ -40,6 +44,21 @@ object Migrations {
                 it[Categories.slug] = slug
                 it[Categories.name] = name
             }
+        }
+    }
+
+    /** v2: contributor settings + soft-delete support (step 6). Idempotent so a
+     *  fresh v1 table created by the current [Users] object (which already has
+     *  these columns) doesn't fail on re-ALTER. */
+    private fun Transaction.migrateV2() {
+        addColumnIfNotExists("users", "settings_json", "TEXT")
+        addColumnIfNotExists("users", "deleted_at", "TEXT")
+    }
+
+    private fun Transaction.addColumnIfNotExists(table: String, column: String, type: String) {
+        val exists = exec("SELECT 1 FROM pragma_table_info('$table') WHERE name='$column'") { rs -> rs.next() }
+        if (exists != true) {
+            exec("ALTER TABLE $table ADD COLUMN $column $type;")
         }
     }
 

--- a/api/src/main/kotlin/dev/androidskills/db/Tables.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/Tables.kt
@@ -28,6 +28,8 @@ object Users : Table("users") {
     val avatarUrl = text("avatar_url").nullable()
     val role = varchar("role", 24).default("member")        // member|contributor|admin
     val status = varchar("status", 24).default("active")    // active|suspended
+    val settingsJson = text("settings_json").nullable()     // JSON UserSettings
+    val deletedAt = text("deleted_at").nullable()           // soft-delete marker (step 6)
     val createdAt = text("created_at")
     val updatedAt = text("updated_at")
 

--- a/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
@@ -24,8 +24,29 @@ import java.util.zip.ZipInputStream
  */
 sealed interface ArchiveSource {
     val bytes: ByteArray
-    data class RepoZipball(override val bytes: ByteArray, val commitSha: String) : ArchiveSource
-    data class UploadedZip(override val bytes: ByteArray, val uploadHash: String) : ArchiveSource
+    data class RepoZipball(
+        override val bytes: ByteArray,
+        val owner: String,
+        val repo: String,
+        val commitSha: String,
+    ) : ArchiveSource {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as RepoZipball
+            return bytes.contentEquals(other.bytes) && owner == other.owner && repo == other.repo && commitSha == other.commitSha
+        }
+        override fun hashCode(): Int = bytes.contentHashCode() * 31 + owner.hashCode() * 31 + repo.hashCode() * 31 + commitSha.hashCode()
+    }
+    data class UploadedZip(override val bytes: ByteArray, val uploadHash: String) : ArchiveSource {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as UploadedZip
+            return bytes.contentEquals(other.bytes) && uploadHash == other.uploadHash
+        }
+        override fun hashCode(): Int = bytes.contentHashCode() * 31 + uploadHash.hashCode()
+    }
 }
 
 /** The read-only metadata for one detected skill (§9: "Detected metadata (read-only)"). */

--- a/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
@@ -169,7 +169,23 @@ object IngestPipeline {
         bundleId: String, skillId: String, submitterId: String,
         skill: DetectedSkill, version: String, source: ArchiveSource,
     ): String {
-        val staged = StagedPayload(version, skill.versionSource, skill.name, skill.description, skill.license, skill.tags)
+        val sourceRefInfo = when (source) {
+            is ArchiveSource.RepoZipball -> StagedPayload.SourceRef(
+                repoOwner = source.owner,
+                repoName = source.repo,
+                ref = source.commitSha,
+            )
+            is ArchiveSource.UploadedZip -> null // uploads carry no fetchable source
+        }
+        val staged = StagedPayload(
+            version = version,
+            versionSource = skill.versionSource,
+            name = skill.name,
+            description = skill.description,
+            license = skill.license,
+            tags = skill.tags,
+            sourceRef = sourceRefInfo,
+        )
         val existing = Submissions.selectAll()
             .where {
                 (Submissions.bundleId eq bundleId) and

--- a/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/SkillManifest.kt
@@ -270,7 +270,7 @@ object ManifestValidator {
     // a non-digit. This rejects invalid forms the loose regex let through, e.g.
     // `1.2.3-alpha..1` (empty identifier) and `1.2.3-01` (leading-zero numeric).
     // Build identifiers are `[0-9A-Za-z-]+` (leading zeros allowed by the spec).
-    private val SEMVER = Regex(
+    val SEMVER = Regex(
         """^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)""" +
             """(?:-(?:0|[1-9]\d*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?""" +
             """(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$""",

--- a/api/src/main/kotlin/dev/androidskills/ingest/SubmissionPayload.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/SubmissionPayload.kt
@@ -23,7 +23,15 @@ data class StagedPayload(
     val description: String,
     val license: String?,
     val tags: List<String>,
-)
+    val sourceRef: SourceRef? = null,  // repo source so step-7 approval can fetch the archive
+) {
+    @Serializable
+    data class SourceRef(
+        val repoOwner: String,
+        val repoName: String,
+        val ref: String,
+    )
+}
 
 /** The review output — what the admin queue displays (category, findings, lintScore). */
 @Serializable

--- a/api/src/main/kotlin/dev/androidskills/jobs/JobWorker.kt
+++ b/api/src/main/kotlin/dev/androidskills/jobs/JobWorker.kt
@@ -201,7 +201,7 @@ private suspend fun runResyncJob(payload: String, store: FileStore, gh: GitHubAp
 
     val zipball = gh.downloadZipball(installationId, owner, repo, req.headSha)
     IngestPipeline.ingest(
-        ArchiveSource.RepoZipball(zipball, req.headSha),
+        ArchiveSource.RepoZipball(zipball, owner, repo, req.headSha),
         req.bundleId, store, ownerUserId,
     )
 }

--- a/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
@@ -45,13 +45,13 @@ class MigrationTest {
     }
 
     @Test
-    fun `schema_meta version is 1 after migration`() {
+    fun `schema_meta version is 2 after migration`() {
         Database.init(TestSupport.newConfig(dir))
         transaction {
             val v = exec("SELECT value FROM schema_meta WHERE key='version'") { rs ->
                 rs.next(); rs.getString(1).toInt()
             }
-            assertEquals(1, v)
+            assertEquals(2, v)
         }
     }
 
@@ -71,13 +71,27 @@ class MigrationTest {
     fun `re-running init is idempotent`() {
         val cfg = TestSupport.newConfig(dir)
         Database.init(cfg)
-        Database.init(cfg) // second open must not duplicate or re-run v1
+        Database.init(cfg) // second open must not duplicate or re-run migrations
         transaction {
             assertEquals(DEFAULT_CATEGORIES.size, Categories.selectAll().toList().size)
             val v = exec("SELECT value FROM schema_meta WHERE key='version'") { rs ->
                 rs.next(); rs.getString(1).toInt()
             }
-            assertEquals(1, v)
+            assertEquals(2, v)
+        }
+    }
+
+    @Test
+    fun `users table has settings_json and deleted_at columns`() {
+        Database.init(TestSupport.newConfig(dir))
+        transaction {
+            val cols = exec("PRAGMA table_info(users)") { rs ->
+                val out = mutableListOf<String>()
+                while (rs.next()) out += rs.getString(2)
+                out
+            } ?: emptyList()
+            assertTrue("settings_json column missing") { "settings_json" in cols }
+            assertTrue("deleted_at column missing") { "deleted_at" in cols }
         }
     }
 

--- a/api/src/test/kotlin/dev/androidskills/api/SkillOwnerQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/SkillOwnerQueriesTest.kt
@@ -1,0 +1,154 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.auth.GitHubUser
+import dev.androidskills.auth.Principal
+import dev.androidskills.auth.UsersRepo
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Jobs
+import dev.androidskills.db.Role
+import dev.androidskills.db.Skills
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SkillOwnerQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    private fun setupDb() {
+        Database.init(TestSupport.newConfig(dir))
+    }
+
+    private fun createUser(githubId: Long, handle: String): Pair<String, Principal> {
+        val uid = UsersRepo.upsertFromGitHub(GitHubUser(githubId, handle, handle, null), null)
+        val row = transaction { Users.selectAll().where { Users.id eq uid }.single() }
+        return uid to Principal(
+            sessionId = "",
+            userId = uid,
+            githubId = githubId,
+            handle = handle,
+            name = handle,
+            avatarUrl = null,
+            role = Role.parse(row[Users.role]),
+            status = UserStatus.parse(row[Users.status]),
+            createdAt = row[Users.createdAt],
+        )
+    }
+
+    private fun insertSkill(owner: Principal, slug: String, status: String = "published"): Pair<String, String> {
+        val now = nowIso()
+        val bid = "00000000-0000-0000-0000-000000000001"
+        val sid = "00000000-0000-0000-0000-000000000002"
+        transaction {
+            Bundles.insert {
+                it[Bundles.id] = bid
+                it[Bundles.kind] = "repo"
+                it[Bundles.provenance] = "owner/repo"
+                it[Bundles.ownerUserId] = owner.userId
+                it[Bundles.installationId] = 1L
+                it[Bundles.createdAt] = now
+            }
+            Skills.insert {
+                it[Skills.id] = sid
+                it[Skills.bundleId] = bid
+                it[Skills.slug] = slug
+                it[Skills.name] = "Skill"
+                it[Skills.description] = "Desc"
+                it[Skills.license] = "MIT"
+                it[Skills.version] = "1.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.status] = status
+                it[Skills.verified] = true
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+        }
+        return sid to bid
+    }
+
+    @Test
+    fun `unpublish flips status and verified`() {
+        setupDb()
+        val (_, owner) = createUser(42L, "alice")
+        insertSkill(owner, "my-skill")
+
+        SkillOwnerQueries.unpublish(owner, "my-skill")
+
+        transaction {
+            val skill = Skills.selectAll().single()
+            assertEquals("unlisted", skill[Skills.status])
+            assertEquals(false, skill[Skills.verified])
+        }
+    }
+
+    @Test
+    fun `unpublish 403 for non-owner`() {
+        setupDb()
+        val (_, owner) = createUser(42L, "alice")
+        val (_, other) = createUser(43L, "bob")
+        insertSkill(owner, "my-skill")
+
+        assertFailsWith<ApiForbiddenException> {
+            SkillOwnerQueries.unpublish(other, "my-skill")
+        }
+    }
+
+    @Test
+    fun `unpublish 404 for missing skill`() {
+        setupDb()
+        val (_, owner) = createUser(42L, "alice")
+        assertFailsWith<ApiNotFoundException> {
+            SkillOwnerQueries.unpublish(owner, "missing")
+        }
+    }
+
+    @Test
+    fun `enqueueResync creates resync job`() {
+        setupDb()
+        val (_, owner) = createUser(42L, "alice")
+        insertSkill(owner, "my-skill")
+
+        SkillOwnerQueries.enqueueResync(owner, "my-skill", "newsha")
+
+        transaction {
+            val job = Jobs.selectAll().single()
+            assertEquals("resync", job[Jobs.type])
+            assertEquals("queued", job[Jobs.state])
+        }
+    }
+
+    @Test
+    fun `enqueueResync 403 for non-owner`() {
+        setupDb()
+        val (_, owner) = createUser(42L, "alice")
+        val (_, other) = createUser(43L, "bob")
+        insertSkill(owner, "my-skill")
+
+        assertFailsWith<ApiForbiddenException> {
+            SkillOwnerQueries.enqueueResync(other, "my-skill", "newsha")
+        }
+    }
+
+    @Test
+    fun `enqueueResync 404 for missing skill`() {
+        setupDb()
+        val (_, owner) = createUser(42L, "alice")
+        assertFailsWith<ApiNotFoundException> {
+            SkillOwnerQueries.enqueueResync(owner, "missing", "newsha")
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/SkillOwnerRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/SkillOwnerRoutesTest.kt
@@ -1,0 +1,137 @@
+package dev.androidskills.api
+
+import dev.androidskills.AppConfig
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.auth.GitHubUser
+import dev.androidskills.auth.OAuthClient
+import dev.androidskills.auth.OAuthException
+import dev.androidskills.auth.OAuthTokens
+import dev.androidskills.auth.SessionStore
+import dev.androidskills.auth.UsersRepo
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Jobs
+import dev.androidskills.db.Skills
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GitHubAppException
+import dev.androidskills.github.Installation
+import dev.androidskills.github.RepoRef
+import dev.androidskills.module
+import dev.androidskills.util.nowIso
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SkillOwnerRoutesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    private fun setupUserAndSkill(): Pair<String, String> {
+        Database.init(TestSupport.newConfig(dir))
+        val uid = UsersRepo.upsertFromGitHub(GitHubUser(42L, "alice", "Alice", null), null)
+        val token = SessionStore.create(uid, 3600)
+        val now = nowIso()
+        val bid = "00000000-0000-0000-0000-000000000001"
+        val sid = "00000000-0000-0000-0000-000000000002"
+        transaction {
+            Bundles.insert {
+                it[Bundles.id] = bid
+                it[Bundles.kind] = "repo"
+                it[Bundles.provenance] = "owner/repo"
+                it[Bundles.ownerUserId] = uid
+                it[Bundles.installationId] = 1L
+                it[Bundles.createdAt] = now
+            }
+            Skills.insert {
+                it[Skills.id] = sid
+                it[Skills.bundleId] = bid
+                it[Skills.slug] = "my-skill"
+                it[Skills.name] = "Skill"
+                it[Skills.description] = "Desc"
+                it[Skills.license] = "MIT"
+                it[Skills.version] = "1.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.status] = "published"
+                it[Skills.verified] = true
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+        }
+        return uid to token
+    }
+
+    private fun fakeGh() = object : GitHubAppClient {
+        override val configured = true
+        override suspend fun installations() = listOf(Installation(1L, 42L, "owner", "User"))
+        override suspend fun listRepos(installationId: Long) = emptyList<RepoRef>()
+        override suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String) = "newsha123"
+        override suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String) = byteArrayOf()
+        override suspend fun verifyAndParseEvent(body: ByteArray, signature: String) = null
+    }
+
+    private fun fakeOAuth() = object : OAuthClient {
+        override val configured = true
+        override fun authorizeUrl(state: String, redirectUri: String) = ""
+        override suspend fun exchange(code: String, redirectUri: String) = OAuthTokens("tok")
+        override suspend fun userInfo(accessToken: String) = GitHubUser(42L, "alice", "Alice", null)
+    }
+
+    @Test
+    fun `resync route enqueues job for owner`() = testApplication {
+        val (_, token) = setupUserAndSkill()
+        application {
+            module(
+                config = TestSupport.newConfig(dir),
+                oauth = fakeOAuth(),
+                githubApp = fakeGh(),
+            )
+        }
+        val res = client.post("/api/skills/my-skill/resync") {
+            header("Cookie", "as_session=$token")
+        }
+        assertEquals(HttpStatusCode.Accepted, res.status)
+        assertTrue(res.bodyAsText().contains("\"ok\":true"))
+        transaction {
+            val job = Jobs.selectAll().single()
+            assertEquals("resync", job[Jobs.type])
+            assertEquals("queued", job[Jobs.state])
+        }
+    }
+
+    @Test
+    fun `resync route 503 when github app disabled`() = testApplication {
+        val (_, token) = setupUserAndSkill()
+        application {
+            module(
+                config = TestSupport.newConfig(dir),
+                oauth = fakeOAuth(),
+                githubApp = object : GitHubAppClient {
+                    override val configured = false
+                    override suspend fun installations() = throw GitHubAppException("")
+                    override suspend fun listRepos(installationId: Long) = emptyList<RepoRef>()
+                    override suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String) = ""
+                    override suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String) = byteArrayOf()
+                    override suspend fun verifyAndParseEvent(body: ByteArray, signature: String) = null
+                },
+            )
+        }
+        val res = client.post("/api/skills/my-skill/resync") {
+            header("Cookie", "as_session=$token")
+        }
+        assertEquals(HttpStatusCode.ServiceUnavailable, res.status)
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/SkillOwnerRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/SkillOwnerRoutesTest.kt
@@ -113,6 +113,75 @@ class SkillOwnerRoutesTest {
     }
 
     @Test
+    fun `resync route 403 for non-owner`() = testApplication {
+        val (_, owner) = setupUserAndSkill()
+        // A second user logs in and tries to resync the same skill.
+        val otherUid = UsersRepo.upsertFromGitHub(GitHubUser(43L, "bob", "Bob", null), null)
+        val otherToken = SessionStore.create(otherUid, 3600)
+        application {
+            module(
+                config = TestSupport.newConfig(dir),
+                oauth = fakeOAuth(),
+                githubApp = fakeGh(),
+            )
+        }
+        val res = client.post("/api/skills/my-skill/resync") {
+            header("Cookie", "as_session=$otherToken")
+        }
+        assertEquals(HttpStatusCode.Forbidden, res.status)
+    }
+
+    @Test
+    fun `resync route 404 for missing skill`() = testApplication {
+        val (_, token) = setupUserAndSkill()
+        application {
+            module(
+                config = TestSupport.newConfig(dir),
+                oauth = fakeOAuth(),
+                githubApp = fakeGh(),
+            )
+        }
+        val res = client.post("/api/skills/no-such-skill/resync") {
+            header("Cookie", "as_session=$token")
+        }
+        assertEquals(HttpStatusCode.NotFound, res.status)
+    }
+
+    @Test
+    fun `unpublish route 403 for non-owner`() = testApplication {
+        setupUserAndSkill()
+        val otherUid = UsersRepo.upsertFromGitHub(GitHubUser(43L, "bob", "Bob", null), null)
+        val otherToken = SessionStore.create(otherUid, 3600)
+        application {
+            module(
+                config = TestSupport.newConfig(dir),
+                oauth = fakeOAuth(),
+                githubApp = fakeGh(),
+            )
+        }
+        val res = client.post("/api/skills/my-skill/unpublish") {
+            header("Cookie", "as_session=$otherToken")
+        }
+        assertEquals(HttpStatusCode.Forbidden, res.status)
+    }
+
+    @Test
+    fun `unpublish route 404 for missing skill`() = testApplication {
+        val (_, token) = setupUserAndSkill()
+        application {
+            module(
+                config = TestSupport.newConfig(dir),
+                oauth = fakeOAuth(),
+                githubApp = fakeGh(),
+            )
+        }
+        val res = client.post("/api/skills/no-such-skill/unpublish") {
+            header("Cookie", "as_session=$token")
+        }
+        assertEquals(HttpStatusCode.NotFound, res.status)
+    }
+
+    @Test
     fun `resync route 503 when github app disabled`() = testApplication {
         val (_, token) = setupUserAndSkill()
         application {

--- a/api/src/test/kotlin/dev/androidskills/api/StarsQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/StarsQueriesTest.kt
@@ -17,6 +17,7 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertIgnore
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -136,6 +137,31 @@ class StarsQueriesTest {
         val (uid, principal) = createUser(42L, "alice")
         assertFailsWith<ApiNotFoundException> {
             StarsQueries.addStar(principal, "missing")
+        }
+    }
+
+    @Test
+    fun `addStar 404 for unlisted skill`() {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        val sid = insertPublishedSkill(uid, "skill-one")
+        transaction {
+            val op = org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Skills.id eq sid }
+            Skills.update({ op }) {
+                it[Skills.status] = "unlisted"
+            }
+        }
+        assertFailsWith<ApiNotFoundException> {
+            StarsQueries.addStar(principal, "skill-one")
+        }
+    }
+
+    @Test
+    fun `removeStar 404 for missing skill`() {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        assertFailsWith<ApiNotFoundException> {
+            StarsQueries.removeStar(principal, "missing")
         }
     }
 }

--- a/api/src/test/kotlin/dev/androidskills/api/StarsQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/StarsQueriesTest.kt
@@ -1,0 +1,141 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.auth.GitHubUser
+import dev.androidskills.auth.Principal
+import dev.androidskills.auth.UsersRepo
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Categories
+import dev.androidskills.db.Role
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Stars
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertIgnore
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class StarsQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    private fun setupDb() {
+        Database.init(TestSupport.newConfig(dir))
+    }
+
+    private fun createUser(githubId: Long, handle: String): Pair<String, Principal> {
+        val uid = UsersRepo.upsertFromGitHub(GitHubUser(githubId, handle, handle, null), null)
+        val row = transaction { Users.selectAll().where { Users.id eq uid }.single() }
+        return uid to Principal(
+            sessionId = "",
+            userId = uid,
+            githubId = githubId,
+            handle = handle,
+            name = handle,
+            avatarUrl = null,
+            role = Role.parse(row[Users.role]),
+            status = UserStatus.parse(row[Users.status]),
+            createdAt = row[Users.createdAt],
+        )
+    }
+
+    private fun insertPublishedSkill(ownerId: String, slug: String, categoryId: String? = null): String {
+        val now = nowIso()
+        val sid = "00000000-0000-0000-0000-${slug.padEnd(12, '0').take(12)}"
+        transaction {
+            Bundles.insertIgnore {
+                it[Bundles.id] = "00000000-0000-0000-0000-${slug.padEnd(12, '0').take(12)}"
+                it[Bundles.kind] = "repo"
+                it[Bundles.provenance] = "owner/$slug"
+                it[Bundles.ownerUserId] = ownerId
+                it[Bundles.createdAt] = now
+            }
+            Skills.insert {
+                it[Skills.id] = sid
+                it[Skills.bundleId] = "00000000-0000-0000-0000-${slug.padEnd(12, '0').take(12)}"
+                it[Skills.slug] = slug
+                it[Skills.name] = slug.replace("-", " ")
+                it[Skills.description] = "Desc"
+                it[Skills.license] = "MIT"
+                it[Skills.version] = "1.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.categoryId] = categoryId
+                it[Skills.status] = "published"
+                it[Skills.verified] = true
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+        }
+        return sid
+    }
+
+    @Test
+    fun `addStar and listStars`() {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        val catId = transaction {
+            Categories.insert {
+                it[Categories.id] = "00000000-0000-0000-0000-000000000000"
+                it[Categories.slug] = "ui"
+                it[Categories.name] = "UI"
+            }
+            "00000000-0000-0000-0000-000000000000"
+        }
+        insertPublishedSkill(uid, "skill-one", catId)
+        insertPublishedSkill(uid, "skill-two", null)
+
+        StarsQueries.addStar(principal, "skill-one")
+        StarsQueries.addStar(principal, "skill-two")
+
+        val stars = StarsQueries.listStars(principal)
+        assertEquals(2, stars.size)
+        val bySlug = stars.associateBy { it.slug }
+        assertEquals("UI", bySlug["skill-one"]?.category)
+        assertEquals(null, bySlug["skill-two"]?.category)
+    }
+
+    @Test
+    fun `addStar is idempotent`() {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        insertPublishedSkill(uid, "skill-one")
+
+        StarsQueries.addStar(principal, "skill-one")
+        StarsQueries.addStar(principal, "skill-one")
+
+        assertEquals(1, transaction { Stars.selectAll().count() }.toInt())
+    }
+
+    @Test
+    fun `removeStar deletes star`() {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        insertPublishedSkill(uid, "skill-one")
+        StarsQueries.addStar(principal, "skill-one")
+
+        StarsQueries.removeStar(principal, "skill-one")
+
+        assertEquals(0, transaction { Stars.selectAll().count() }.toInt())
+    }
+
+    @Test
+    fun `addStar 404 for missing skill`() {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        assertFailsWith<ApiNotFoundException> {
+            StarsQueries.addStar(principal, "missing")
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/SubmissionQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/SubmissionQueriesTest.kt
@@ -358,13 +358,49 @@ class SubmissionQueriesTest {
     }
 
     @Test
-    fun `deleteDraft 409 when not draft`(): Unit = runBlocking {
+    fun `createDrafts 409 when skill already published`(): Unit = runBlocking {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        // Seed a published skill directly (simulates approval path).
+        transaction {
+            Bundles.insert {
+                it[Bundles.id] = "00000000-0000-0000-0000-000000000001"
+                it[Bundles.kind] = "repo"
+                it[Bundles.provenance] = "owner/repo"
+                it[Bundles.ownerUserId] = uid
+                it[Bundles.installationId] = 1L
+                it[Bundles.createdAt] = nowIso()
+            }
+            Skills.insert {
+                it[Skills.id] = "00000000-0000-0000-0000-000000000002"
+                it[Skills.bundleId] = "00000000-0000-0000-0000-000000000001"
+                it[Skills.slug] = "skill-one"
+                it[Skills.name] = "Skill"
+                it[Skills.description] = "Desc"
+                it[Skills.license] = "MIT"
+                it[Skills.version] = "1.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.status] = "published"
+                it[Skills.verified] = true
+                it[Skills.createdAt] = nowIso()
+                it[Skills.updatedAt] = nowIso()
+            }
+        }
+        val ex = assertFailsWith<ApiConflictException> {
+            SubmissionQueries.createDrafts(principal, draftRequest("skill-one"), fakeGh())
+        }
+        assertEquals("skill_already_published", ex.code)
+    }
+
+    @Test
+    fun `createDrafts 409 when submission already in_review`(): Unit = runBlocking {
         setupDb()
         val (_, principal) = createUser(42L, "alice")
         val response = SubmissionQueries.createDrafts(principal, draftRequest("skill-one"), fakeGh())
         SubmissionQueries.submit(principal, response.submissionIds[0])
-        assertFailsWith<ApiConflictException> {
-            SubmissionQueries.deleteDraft(principal, response.submissionIds[0])
+        val ex = assertFailsWith<ApiConflictException> {
+            SubmissionQueries.createDrafts(principal, draftRequest("skill-one"), fakeGh())
         }
+        assertEquals("submission_already_active", ex.code)
     }
 }

--- a/api/src/test/kotlin/dev/androidskills/api/SubmissionQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/SubmissionQueriesTest.kt
@@ -145,9 +145,22 @@ class SubmissionQueriesTest {
 
         SubmissionQueries.createDrafts(alice, request, fakeGh())
         val ex = assertFailsWith<ApiConflictException> {
-            SubmissionQueries.createDrafts(bob, request, fakeGh())
+            // Bob has his own installation on the same owner account, but the bundle is already Alice's.
+            SubmissionQueries.createDrafts(bob, request, fakeGh(listOf(Installation(2L, 43L, "owner", "User"))))
         }
         assertEquals("bundle_ownership_conflict", ex.code)
+    }
+
+    @Test
+    fun `createDrafts 422 when installation belongs to another account`(): Unit = runBlocking {
+        setupDb()
+        // SEC1: an installation for owner "owner" exists, but it belongs to account 42 (not Bob's 43).
+        val (_, bob) = createUser(43L, "bob")
+        val request = draftRequest("skill-one")
+        val ex = assertFailsWith<ApiValidationException> {
+            SubmissionQueries.createDrafts(bob, request, fakeGh(listOf(Installation(1L, 42L, "owner", "User"))))
+        }
+        assertEquals("github_app_not_installed", ex.code)
     }
 
     @Test
@@ -309,4 +322,49 @@ class SubmissionQueriesTest {
             ),
         ),
     )
+
+    @Test
+    fun `submit 404 for other user`(): Unit = runBlocking {
+        setupDb()
+        val (_, alice) = createUser(42L, "alice")
+        val (_, bob) = createUser(43L, "bob")
+        val response = SubmissionQueries.createDrafts(alice, draftRequest("skill-one"), fakeGh())
+        assertFailsWith<ApiNotFoundException> {
+            SubmissionQueries.submit(bob, response.submissionIds[0])
+        }
+    }
+
+    @Test
+    fun `withdraw 404 for other user`(): Unit = runBlocking {
+        setupDb()
+        val (_, alice) = createUser(42L, "alice")
+        val (_, bob) = createUser(43L, "bob")
+        val response = SubmissionQueries.createDrafts(alice, draftRequest("skill-one"), fakeGh())
+        SubmissionQueries.submit(alice, response.submissionIds[0])
+        assertFailsWith<ApiNotFoundException> {
+            SubmissionQueries.withdraw(bob, response.submissionIds[0])
+        }
+    }
+
+    @Test
+    fun `deleteDraft 404 for other user`(): Unit = runBlocking {
+        setupDb()
+        val (_, alice) = createUser(42L, "alice")
+        val (_, bob) = createUser(43L, "bob")
+        val response = SubmissionQueries.createDrafts(alice, draftRequest("skill-one"), fakeGh())
+        assertFailsWith<ApiNotFoundException> {
+            SubmissionQueries.deleteDraft(bob, response.submissionIds[0])
+        }
+    }
+
+    @Test
+    fun `deleteDraft 409 when not draft`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val response = SubmissionQueries.createDrafts(principal, draftRequest("skill-one"), fakeGh())
+        SubmissionQueries.submit(principal, response.submissionIds[0])
+        assertFailsWith<ApiConflictException> {
+            SubmissionQueries.deleteDraft(principal, response.submissionIds[0])
+        }
+    }
 }

--- a/api/src/test/kotlin/dev/androidskills/api/SubmissionQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/SubmissionQueriesTest.kt
@@ -8,18 +8,21 @@ import dev.androidskills.auth.Principal
 import dev.androidskills.auth.SessionStore
 import dev.androidskills.auth.UsersRepo
 import dev.androidskills.db.Bundles
+import dev.androidskills.db.Jobs
 import dev.androidskills.db.Role
 import dev.androidskills.db.Sessions
 import dev.androidskills.db.Skills
 import dev.androidskills.db.Submissions
 import dev.androidskills.db.UserStatus
 import dev.androidskills.db.Users
-import dev.androidskills.github.DisabledGitHubAppClient
+import dev.androidskills.db.Versions
 import dev.androidskills.github.GitHubAppClient
 import dev.androidskills.github.GitHubAppException
 import dev.androidskills.github.Installation
 import dev.androidskills.github.RepoRef
+import dev.androidskills.util.nowIso
 import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import kotlin.test.AfterTest
@@ -186,6 +189,110 @@ class SubmissionQueriesTest {
         val (_, bob) = createUser(43L, "bob")
         val response = SubmissionQueries.createDrafts(alice, draftRequest("skill-one"), fakeGh())
         assertEquals(null, SubmissionQueries.getSubmission(bob, response.submissionIds[0]))
+    }
+
+    @Test
+    fun `submit moves draft to in_review and enqueues review job`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val response = SubmissionQueries.createDrafts(principal, draftRequest("skill-one"), fakeGh())
+        val subId = response.submissionIds[0]
+
+        SubmissionQueries.submit(principal, subId)
+
+        transaction {
+            val sub = Submissions.selectAll().where { Submissions.id eq subId }.single()
+            assertEquals("in_review", sub[Submissions.state])
+            val jobs = Jobs.selectAll().where { Jobs.type eq "review" }.toList()
+            assertEquals(1, jobs.size)
+            assertEquals("queued", jobs[0][Jobs.state])
+        }
+    }
+
+    @Test
+    fun `submit 422 on invalid manifest`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val request = SubmissionQueries.CreateDraftsRequest(
+            repoOwner = "owner", repoName = "repo", ref = "abc123",
+            skills = listOf(SubmissionQueries.SelectedSkill(
+                slug = "skill-one", name = "", description = "", license = "",
+            )),
+        )
+        val response = SubmissionQueries.createDrafts(principal, request, fakeGh())
+        assertFailsWith<ApiValidationException> {
+            SubmissionQueries.submit(principal, response.submissionIds[0])
+        }
+    }
+
+    @Test
+    fun `submit 409 when not draft`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val response = SubmissionQueries.createDrafts(principal, draftRequest("skill-one"), fakeGh())
+        SubmissionQueries.submit(principal, response.submissionIds[0])
+        assertFailsWith<ApiConflictException> {
+            SubmissionQueries.submit(principal, response.submissionIds[0])
+        }
+    }
+
+    @Test
+    fun `withdraw moves in_review back to draft`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val response = SubmissionQueries.createDrafts(principal, draftRequest("skill-one"), fakeGh())
+        val subId = response.submissionIds[0]
+        SubmissionQueries.submit(principal, subId)
+
+        SubmissionQueries.withdraw(principal, subId)
+
+        transaction {
+            val sub = Submissions.selectAll().where { Submissions.id eq subId }.single()
+            assertEquals("draft", sub[Submissions.state])
+            val jobs = Jobs.selectAll().where { Jobs.type eq "review" }.toList()
+            assertEquals(0, jobs.size)
+        }
+    }
+
+    @Test
+    fun `deleteDraft removes submission and shell skill`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val response = SubmissionQueries.createDrafts(principal, draftRequest("skill-one"), fakeGh())
+        val subId = response.submissionIds[0]
+
+        SubmissionQueries.deleteDraft(principal, subId)
+
+        transaction {
+            assertEquals(0, Submissions.selectAll().count())
+            assertEquals(0, Skills.selectAll().count())
+        }
+    }
+
+    @Test
+    fun `deleteDraft keeps skill when versions exist`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val response = SubmissionQueries.createDrafts(principal, draftRequest("skill-one"), fakeGh())
+        val subId = response.submissionIds[0]
+        val skillId = transaction { Submissions.selectAll().where { Submissions.id eq subId }.single()[Submissions.skillId] }
+            ?: error("missing skill")
+        transaction {
+            Versions.insert {
+                it[Versions.id] = "00000000-0000-0000-0000-000000000001"
+                it[Versions.skillId] = skillId
+                it[Versions.version] = "1.0.0"
+                it[Versions.sourceRef] = "sha"
+                it[Versions.createdAt] = nowIso()
+            }
+        }
+
+        SubmissionQueries.deleteDraft(principal, subId)
+
+        transaction {
+            assertEquals(0, Submissions.selectAll().count())
+            assertEquals(1, Skills.selectAll().count())
+        }
     }
 
     private fun draftRequest(slug: String, repoName: String = "repo") = SubmissionQueries.CreateDraftsRequest(

--- a/api/src/test/kotlin/dev/androidskills/api/SubmissionQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/SubmissionQueriesTest.kt
@@ -1,0 +1,205 @@
+package dev.androidskills.api
+
+import dev.androidskills.AppConfig
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.auth.GitHubUser
+import dev.androidskills.auth.Principal
+import dev.androidskills.auth.SessionStore
+import dev.androidskills.auth.UsersRepo
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Role
+import dev.androidskills.db.Sessions
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Submissions
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.github.DisabledGitHubAppClient
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GitHubAppException
+import dev.androidskills.github.Installation
+import dev.androidskills.github.RepoRef
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class SubmissionQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    private fun setupDb() {
+        Database.init(TestSupport.newConfig(dir))
+    }
+
+    private fun createUser(githubId: Long, handle: String): Pair<String, Principal> {
+        val uid = UsersRepo.upsertFromGitHub(GitHubUser(githubId, handle, handle, null), null)
+        val token = SessionStore.create(uid, 3600)
+        val row = transaction {
+            Users.selectAll().where { Users.id eq uid }.single()
+        }
+        val principal = Principal(
+            sessionId = token,
+            userId = uid,
+            githubId = githubId,
+            handle = handle,
+            name = handle,
+            avatarUrl = null,
+            role = Role.parse(row[Users.role]),
+            status = UserStatus.parse(row[Users.status]),
+            createdAt = row[Users.createdAt],
+        )
+        return uid to principal
+    }
+
+    private fun fakeGh(installations: List<Installation> = listOf(Installation(1L, 42L, "owner", "User"))) =
+        object : GitHubAppClient {
+            override val configured = true
+            override suspend fun installations() = installations
+            override suspend fun listRepos(installationId: Long) = emptyList<RepoRef>()
+            override suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String) = "abc"
+            override suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String) = byteArrayOf()
+            override suspend fun verifyAndParseEvent(body: ByteArray, signature: String) = null
+        }
+
+    @Test
+    fun `createDrafts creates bundle skill and submission`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val request = SubmissionQueries.CreateDraftsRequest(
+            repoOwner = "owner",
+            repoName = "repo",
+            ref = "abc123",
+            skills = listOf(
+                SubmissionQueries.SelectedSkill(
+                    slug = "my-skill",
+                    name = "My Skill",
+                    description = "A skill",
+                    license = "MIT",
+                    tags = listOf("android"),
+                    version = "1.0.0",
+                ),
+            ),
+        )
+
+        val response = SubmissionQueries.createDrafts(principal, request, fakeGh())
+        assertEquals(1, response.submissionIds.size)
+
+        transaction {
+            val bundle = Bundles.selectAll().single()
+            assertEquals("repo", bundle[Bundles.kind])
+            assertEquals("owner/repo", bundle[Bundles.provenance])
+            assertEquals(principal.userId, bundle[Bundles.ownerUserId])
+            assertEquals(1L, bundle[Bundles.installationId])
+            assertEquals("abc123", bundle[Bundles.sourceRef])
+
+            val skill = Skills.selectAll().single()
+            assertEquals("my-skill", skill[Skills.slug])
+            assertEquals("unlisted", skill[Skills.status])
+            assertEquals(false, skill[Skills.verified])
+
+            val sub = Submissions.selectAll().single()
+            assertEquals("draft", sub[Submissions.state])
+            assertEquals(principal.userId, sub[Submissions.submitterId])
+            assertNotNull(sub[Submissions.payload])
+        }
+    }
+
+    @Test
+    fun `createDrafts groups by state`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val request = draftRequest("skill-one")
+        SubmissionQueries.createDrafts(principal, request, fakeGh())
+
+        val grouped = SubmissionQueries.mySubmissions(principal)
+        assertEquals(1, grouped.size)
+        assertEquals("draft", grouped[0].state)
+        assertEquals(1, grouped[0].items.size)
+
+        val detail = SubmissionQueries.getSubmission(principal, grouped[0].items[0].id)
+        assertNotNull(detail)
+        assertEquals("skill-one", detail.slug)
+        assertEquals("draft", detail.state)
+    }
+
+    @Test
+    fun `createDrafts 409 when repo owned by another user`(): Unit = runBlocking {
+        setupDb()
+        val (_, alice) = createUser(42L, "alice")
+        val (_, bob) = createUser(43L, "bob")
+        val request = draftRequest("skill-one")
+
+        SubmissionQueries.createDrafts(alice, request, fakeGh())
+        val ex = assertFailsWith<ApiConflictException> {
+            SubmissionQueries.createDrafts(bob, request, fakeGh())
+        }
+        assertEquals("bundle_ownership_conflict", ex.code)
+    }
+
+    @Test
+    fun `createDrafts 409 when slug used by another bundle`(): Unit = runBlocking {
+        setupDb()
+        val (_, alice) = createUser(42L, "alice")
+        SubmissionQueries.createDrafts(alice, draftRequest("shared-slug", repoName = "repo-a"), fakeGh())
+        val ex = assertFailsWith<ApiConflictException> {
+            SubmissionQueries.createDrafts(alice, draftRequest("shared-slug", repoName = "repo-b"), fakeGh(listOf(Installation(2L, 42L, "owner", "User"))))
+        }
+        assertEquals("slug_conflict", ex.code)
+    }
+
+    @Test
+    fun `createDrafts 422 when no github app installation for owner`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val request = draftRequest("skill-one")
+        val ex = assertFailsWith<ApiValidationException> {
+            SubmissionQueries.createDrafts(principal, request, fakeGh(emptyList()))
+        }
+        assertEquals("github_app_not_installed", ex.code)
+    }
+
+    @Test
+    fun `createDrafts 422 on bad slug`(): Unit = runBlocking {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val request = draftRequest("BadSlug")
+        assertFailsWith<ApiValidationException> {
+            SubmissionQueries.createDrafts(principal, request, fakeGh())
+        }
+    }
+
+    @Test
+    fun `getSubmission returns null for other user`(): Unit = runBlocking {
+        setupDb()
+        val (_, alice) = createUser(42L, "alice")
+        val (_, bob) = createUser(43L, "bob")
+        val response = SubmissionQueries.createDrafts(alice, draftRequest("skill-one"), fakeGh())
+        assertEquals(null, SubmissionQueries.getSubmission(bob, response.submissionIds[0]))
+    }
+
+    private fun draftRequest(slug: String, repoName: String = "repo") = SubmissionQueries.CreateDraftsRequest(
+        repoOwner = "owner",
+        repoName = repoName,
+        ref = "abc123",
+        skills = listOf(
+            SubmissionQueries.SelectedSkill(
+                slug = slug,
+                name = "Skill",
+                description = "Desc",
+                license = "MIT",
+                tags = emptyList(),
+            ),
+        ),
+    )
+}

--- a/api/src/test/kotlin/dev/androidskills/api/UserQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/UserQueriesTest.kt
@@ -1,0 +1,111 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.auth.GitHubUser
+import dev.androidskills.auth.OAuthClient
+import dev.androidskills.auth.OAuthTokens
+import dev.androidskills.auth.Principal
+import dev.androidskills.auth.SessionStore
+import dev.androidskills.auth.UsersRepo
+import dev.androidskills.db.Role
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class UserQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    private fun setupDb() {
+        Database.init(TestSupport.newConfig(dir))
+    }
+
+    private fun createUser(githubId: Long, handle: String): Pair<String, Principal> {
+        val uid = UsersRepo.upsertFromGitHub(GitHubUser(githubId, handle, handle, null), null)
+        val row = transaction { Users.selectAll().where { Users.id eq uid }.single() }
+        return uid to Principal(
+            sessionId = "",
+            userId = uid,
+            githubId = githubId,
+            handle = handle,
+            name = handle,
+            avatarUrl = null,
+            role = Role.parse(row[Users.role]),
+            status = UserStatus.parse(row[Users.status]),
+            createdAt = row[Users.createdAt],
+        )
+    }
+
+    @Test
+    fun `getSettings returns defaults when unset`() {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        val settings = UserQueries.getSettings(principal)
+        assertEquals(true, settings.emailNotifications)
+        assertEquals(true, settings.publicProfile)
+    }
+
+    @Test
+    fun `updateSettings persists and getSettings reads back`() {
+        setupDb()
+        val (_, principal) = createUser(42L, "alice")
+        UserQueries.updateSettings(principal, UserQueries.UserSettings(emailNotifications = false, publicProfile = false))
+        val settings = UserQueries.getSettings(principal)
+        assertEquals(false, settings.emailNotifications)
+        assertEquals(false, settings.publicProfile)
+    }
+
+    @Test
+    fun `deleteAccount soft deletes and blocks admin`() {
+        setupDb()
+        val (_, admin) = createUser(42L, "alice-admin")
+        transaction {
+            Users.update({ Users.id eq admin.userId }) { it[Users.role] = Role.admin.name }
+        }
+        assertFailsWith<ApiConflictException> {
+            UserQueries.deleteAccount(admin)
+        }
+        assertNull(transaction { Users.selectAll().where { Users.id eq admin.userId }.singleOrNull()?.get(Users.deletedAt) })
+
+        val (_, member) = createUser(43L, "bob")
+        UserQueries.deleteAccount(member)
+        assertNotNull(transaction { Users.selectAll().where { Users.id eq member.userId }.singleOrNull()?.get(Users.deletedAt) })
+    }
+
+    @Test
+    fun `session lookup excludes deleted users`() {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        val token = SessionStore.create(uid, 3600)
+        assertNotNull(SessionStore.lookup(token))
+
+        UserQueries.deleteAccount(principal)
+        assertNull(SessionStore.lookup(token))
+    }
+
+    @Test
+    fun `upsertFromGitHub reactivates soft deleted account`() {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        UserQueries.deleteAccount(principal)
+        assertNotNull(transaction { Users.selectAll().where { Users.id eq uid }.singleOrNull()?.get(Users.deletedAt) })
+
+        UsersRepo.upsertFromGitHub(GitHubUser(42L, "alice", "Alice", null), null)
+        assertNull(transaction { Users.selectAll().where { Users.id eq uid }.singleOrNull()?.get(Users.deletedAt) })
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/UserQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/UserQueriesTest.kt
@@ -99,6 +99,18 @@ class UserQueriesTest {
     }
 
     @Test
+    fun `deleteAccount revokes existing sessions`() {
+        setupDb()
+        val (uid, principal) = createUser(42L, "alice")
+        val token = SessionStore.create(uid, 3600)
+        assertNotNull(SessionStore.lookup(token))
+
+        UserQueries.deleteAccount(principal)
+
+        assertNull(SessionStore.lookup(token))
+    }
+
+    @Test
     fun `upsertFromGitHub reactivates soft deleted account`() {
         setupDb()
         val (uid, principal) = createUser(42L, "alice")

--- a/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
@@ -25,7 +25,7 @@ class DiscoveryTest {
             "alice-repo-abc123/skills/mvi/references/intent.md" to "Intents are reduced by the VM.\n",
             "alice-repo-abc123/skills/coroutines/SKILL.md" to skillMd("Coroutines", "Testing suspend fns."),
         )
-        val res = Discovery.discover(ArchiveSource.RepoZipball(zip, commitSha = "abc1234567890abcd"))
+        val res = Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", commitSha = "abc1234567890abcd"))
         val found = assertIs<ScanResult.Found>(res)
         assertEquals(2, found.skills.size)
         val mvi = found.skills.first { it.slug == "mvi" }
@@ -67,7 +67,7 @@ class DiscoveryTest {
             "o-r-s/SKILL.md" to ignored,
             "o-r-s/skills/real/SKILL.md" to skillMd("Real", "d"),
         )
-        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha")))
         assertEquals(listOf("real"), found.skills.map { it.slug })
     }
 
@@ -78,7 +78,7 @@ class DiscoveryTest {
             "o-r-s/README.md" to "readme",
             "o-r-s/SKILL.md" to ignored,
         )
-        assertIs<ScanResult.NoSkillsDir>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+        assertIs<ScanResult.NoSkillsDir>(Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha")))
     }
 
     @Test
@@ -94,7 +94,7 @@ class DiscoveryTest {
                 body
             """.trimIndent(),
         )
-        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha")))
         val bad = found.skills[0]
         assertTrue(bad.parseErrors.any { it.field == "tags" }, "expected tags parseError; got ${bad.parseErrors}")
     }
@@ -106,7 +106,7 @@ class DiscoveryTest {
             "o-r-s/skills/x/SKILL.md" to skillMd("X", "d"),
             "o-r-s/../escape.md" to "evil",
         )
-        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha")))
         assertEquals(1, found.skills.size)
     }
 
@@ -116,7 +116,7 @@ class DiscoveryTest {
             "o-r-s/skills/s$i/SKILL.md" to skillMd("s$i", "d")
         }
         val zip = zip(*entries.toTypedArray())
-        assertFailsArchiveTooLarge { Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")) }
+        assertFailsArchiveTooLarge { Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha")) }
     }
 
     @Test
@@ -125,14 +125,14 @@ class DiscoveryTest {
         // stream of compressible data (repeated bytes compress tiny, inflate huge).
         val bomb = ByteArray((Discovery.MAX_INFLATED_BYTES + 1024).toInt()) // ~50MB+1KB
         val zip = zip("o-r-s/skills/x/big.txt" to String(bomb)) // String is inefficient but fine for one test
-        assertFailsArchiveTooLarge { Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")) }
+        assertFailsArchiveTooLarge { Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha")) }
     }
 
     @Test
     fun `bad slug directory is not a skill`() {
         // §10 slug is lowercase kebab; an Upper/dir with spaces yields no skill.
         val zip = zip("o-r-s/skills/Bad_Slug/SKILL.md" to skillMd("Bad", "d"))
-        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "sha")))
+        val found = assertIs<ScanResult.Found>(Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha")))
         assertTrue(found.skills.isEmpty(), "Bad_Slug is not a valid slug; got ${found.skills}")
     }
 


### PR DESCRIPTION
## What this is

Step 6 of `docs/backend-spec.md` §14 — **Contributor flows** (§9 Contributor): drafts from scan results, submit/withdraw/delete submissions, skill owner actions (unpublish/resync), account-synced stars, settings, and soft account deletion.

Built in an isolated worktree (`wt/step6-contributor`) off `develop` (`8d21049`), 6 commits, 196 tests green.

## Commit narrative

| Commit | Scope |
|---|---|
| `e30f024` | Migrations v2 (`users.settings_json`, `users.deleted_at`) + bundle-aware draft creation |
| `f60ad1e` | Submit / withdraw / delete submissions + §10 validation + guarded review enqueue |
| `b65f109` | Skill owner actions: `unpublish`, `resync` (403 for non-owner, 404 for missing slug) |
| `55302e4` | Account-synced stars: list/add/remove |
| `0c04926` | Settings GET/PUT + soft account delete (admins blocked, re-login reactivates) |
| `7ee6dba` | Review fixes: SEC1 cross-account installation guard, published-only stars, message leak, session revocation |

## Key decisions (from the locked plan, verified in review)

- **Bundle ownership is first-come-first-served** (§3.4); bundles are created at draft time; 409 on ownership conflict.
- **Skill shell created at draft time** so the step-5 review worker has a row to read on submit; the real archive is ingested at step-7 approval using the persisted source ref.
- **Submit-time review is metadata-only**; content security review runs after step-7 archive fetch.
- **Owner actions on public skills return 403**, not 404 (the 404-only rule is for `/api/admin/*` routes).
- **Account deletion is soft** via `deleted_at`; sessions are revoked; re-login reactivates; admins cannot self-delete.
- **Cross-account installation hijack closed (review):** `createDrafts` now requires `installation.accountId == principal.githubId`, matching scan's safe filter.

## Test status

**196 tests**, all green. `clean build` green.
