### PR TITLE
api: step 7 — admin flows + promotion + audit log

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -1,6 +1,7 @@
 package dev.androidskills
 
 import dev.androidskills.GithubAppConfig
+import dev.androidskills.api.adminRoutes
 import dev.androidskills.api.installApiErrorMapping
 import dev.androidskills.api.publicRoutes
 import dev.androidskills.api.contributorRoutes
@@ -98,6 +99,7 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
         publicRoutes(fileStore)
         authRoutes(config, resolvedOauth)
         contributorRoutes(resolvedGithubApp)
+        adminRoutes()
         webhookRoutes(resolvedGithubApp)
     }
 }

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -99,7 +99,7 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
         publicRoutes(fileStore)
         authRoutes(config, resolvedOauth)
         contributorRoutes(resolvedGithubApp)
-        adminRoutes()
+        adminRoutes(fileStore, resolvedGithubApp)
         webhookRoutes(resolvedGithubApp)
     }
 }

--- a/api/src/main/kotlin/dev/androidskills/api/AdminCategoryQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminCategoryQueries.kt
@@ -1,0 +1,118 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.Principal
+import dev.androidskills.db.Categories
+import dev.androidskills.db.Skills
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+/**
+ * Admin category management (spec §9). Create, rename, and merge categories.
+ */
+object AdminCategoryQueries {
+
+    @Serializable
+    data class CategoryDto(
+        val id: String,
+        val slug: String,
+        val name: String,
+    )
+
+    @Serializable
+    data class RenameRequest(
+        val name: String? = null,
+        val slug: String? = null,
+    )
+
+    fun list(): List<CategoryDto> = transaction {
+        Categories.selectAll().orderBy(Categories.name to SortOrder.ASC).map { row ->
+            CategoryDto(row[Categories.id], row[Categories.slug], row[Categories.name])
+        }
+    }
+
+    fun create(principal: Principal, slug: String, name: String): CategoryDto {
+        val trimmed = slug.trim().lowercase().replace(Regex("[^a-z0-9-]"), "-")
+        if (trimmed.isEmpty() || trimmed.length < 2) {
+            throw ApiValidationException(mapOf("slug" to "must be at least 2 alphanumeric chars"))
+        }
+        return transaction {
+            val existing = Categories.selectAll().where { Categories.slug eq trimmed }.singleOrNull()
+            if (existing != null) throw ApiConflictException("Category slug already exists", "duplicate_category")
+            val id = newId()
+            Categories.insert {
+                it[Categories.id] = id
+                it[Categories.slug] = trimmed
+                it[Categories.name] = name
+            }
+            AuditLogQueries.write(
+                actorId = principal.userId,
+                action = "category.create",
+                target = "category:$trimmed",
+            )
+            CategoryDto(id, trimmed, name)
+        }
+    }
+
+    fun rename(principal: Principal, oldSlug: String, request: RenameRequest): CategoryDto {
+        val newSlug = request.slug?.trim()?.lowercase()?.replace(Regex("[^a-z0-9-]"), "-")
+        val newName = request.name?.trim()
+        transaction {
+            val category = Categories.selectAll().where { Categories.slug eq oldSlug }.singleOrNull()
+                ?: throw ApiNotFoundException("Category not found")
+            newSlug?.let { slug ->
+                if (slug != oldSlug) {
+                    val conflict = Categories.selectAll().where { Categories.slug eq slug }.singleOrNull()
+                    if (conflict != null) throw ApiConflictException("Target slug already in use", "duplicate_category")
+                }
+            }
+            val targetSlug = newSlug ?: oldSlug
+            val targetName = newName ?: category[Categories.name]
+            Categories.update({ Categories.id eq category[Categories.id] }) {
+                it[Categories.slug] = targetSlug
+                it[Categories.name] = targetName
+            }
+            AuditLogQueries.write(
+                actorId = principal.userId,
+                action = "category.rename",
+                target = "category:$oldSlug",
+                meta = AuditLogQueries.AuditMeta(after = mapOf("slug" to targetSlug, "name" to targetName)),
+            )
+        }
+        val finalSlug = newSlug ?: oldSlug
+        val row = transaction { Categories.selectAll().where { Categories.slug eq finalSlug }.single() }
+        return CategoryDto(row[Categories.id], row[Categories.slug], row[Categories.name])
+    }
+
+    fun merge(principal: Principal, fromSlug: String, toSlug: String) {
+        if (fromSlug == toSlug) throw ApiConflictException("Cannot merge a category into itself", "merge_self")
+        transaction {
+            val from = Categories.selectAll().where { Categories.slug eq fromSlug }.singleOrNull()
+                ?: throw ApiNotFoundException("Source category not found")
+            val to = Categories.selectAll().where { Categories.slug eq toSlug }.singleOrNull()
+                ?: throw ApiNotFoundException("Target category not found")
+            val fromId = from[Categories.id]
+            val toId = to[Categories.id]
+
+            Skills.update({ Skills.categoryId eq fromId }) {
+                it[Skills.categoryId] = toId
+                it[Skills.updatedAt] = nowIso()
+            }
+            val deleteOp = org.jetbrains.exposed.sql.SqlExpressionBuilder.run { Categories.id eq fromId }
+            Categories.deleteWhere { deleteOp }
+            AuditLogQueries.write(
+                actorId = principal.userId,
+                action = "category.merge",
+                target = "category:$fromSlug",
+                meta = AuditLogQueries.AuditMeta(after = mapOf("into" to toSlug)),
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
@@ -1,0 +1,132 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.Principal
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.SkillFiles
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Submissions
+import dev.androidskills.db.Users
+import dev.androidskills.ingest.ReviewOutputPayload
+import dev.androidskills.ingest.StagedPayload
+import dev.androidskills.ingest.SubmissionPayload
+import dev.androidskills.util.appJson
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+
+/**
+ * Admin review queue (spec §9 Admin, step 7 commit 1).
+ */
+object AdminQueueQueries {
+
+    @Serializable
+    data class QueueItem(
+        val id: String,
+        val slug: String,
+        val state: String,
+        val submitterHandle: String,
+        val lintScore: Int?,
+        val review: ReviewOutputPayload?,
+        val staged: StagedPayload?,
+        val createdAt: String,
+        val updatedAt: String,
+    )
+
+    @Serializable
+    data class SkillFileSummary(
+        val path: String,
+        val size: Int,
+        val isBinary: Boolean,
+    )
+
+    @Serializable
+    data class QueueDetail(
+        val id: String,
+        val slug: String,
+        val state: String,
+        val submitterHandle: String,
+        val lintScore: Int?,
+        val note: String?,
+        val payload: SubmissionPayload?,
+        val files: List<SkillFileSummary>,
+        val provenance: String,
+        val sourceRef: String,
+        val reviewIsMetadataOnly: Boolean,
+        val createdAt: String,
+        val updatedAt: String,
+    )
+
+    fun queue(filter: String? = null, q: String? = null): List<QueueItem> = transaction {
+        val states = when (filter) {
+            "in_review" -> listOf("in_review")
+            "changes_requested" -> listOf("changes_requested")
+            null, "all" -> listOf("in_review", "changes_requested")
+            else -> throw ApiValidationException(mapOf("filter" to "must be all, in_review, or changes_requested"))
+        }
+        val query = (Submissions innerJoin Skills leftJoin Users)
+            .selectAll()
+            .where { Submissions.state inList states }
+            .orderBy(Submissions.updatedAt to SortOrder.DESC)
+
+        query.map { row ->
+            val payload = row[Submissions.payload]?.let {
+                runCatching { appJson.decodeFromString(SubmissionPayload.serializer(), it) }.getOrNull()
+            }
+            QueueItem(
+                id = row[Submissions.id],
+                slug = row[Skills.slug],
+                state = row[Submissions.state],
+                submitterHandle = row[Users.handle],
+                lintScore = row[Submissions.lintScore],
+                review = payload?.review,
+                staged = payload?.staged,
+                createdAt = row[Submissions.createdAt],
+                updatedAt = row[Submissions.updatedAt],
+            )
+        }.filter { item ->
+            q.isNullOrBlank() || item.slug.contains(q, ignoreCase = true) || item.submitterHandle.contains(q, ignoreCase = true)
+        }
+    }
+
+    fun detail(id: String): QueueDetail? = transaction {
+        val row = (Submissions innerJoin Skills leftJoin Users leftJoin Bundles)
+            .selectAll()
+            .where { Submissions.id eq id }
+            .singleOrNull() ?: return@transaction null
+
+        val payload = row[Submissions.payload]?.let {
+            runCatching { appJson.decodeFromString(SubmissionPayload.serializer(), it) }.getOrNull()
+        }
+        val skillId = row[Skills.id]
+        val files = SkillFiles.selectAll()
+            .where { SkillFiles.skillId eq skillId }
+            .map {
+                SkillFileSummary(
+                    path = it[SkillFiles.path],
+                    size = it[SkillFiles.size],
+                    isBinary = it[SkillFiles.isBinary],
+                )
+            }
+
+        val provenance = row[Bundles.provenance]
+        val sourceRef = payload?.staged?.sourceRef?.let { "${it.repoOwner}/${it.repoName}@${it.ref}" } ?: ""
+
+        QueueDetail(
+            id = row[Submissions.id],
+            slug = row[Skills.slug],
+            state = row[Submissions.state],
+            submitterHandle = row[Users.handle],
+            lintScore = row[Submissions.lintScore],
+            note = row[Submissions.note],
+            payload = payload,
+            files = files,
+            provenance = provenance,
+            sourceRef = sourceRef,
+            reviewIsMetadataOnly = true, // step-5/6 review only sees name/description/tags
+            createdAt = row[Submissions.createdAt],
+            updatedAt = row[Submissions.updatedAt],
+        )
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
@@ -2,22 +2,30 @@ package dev.androidskills.api
 
 import dev.androidskills.auth.Principal
 import dev.androidskills.db.Bundles
+import dev.androidskills.db.Categories
 import dev.androidskills.db.SkillFiles
 import dev.androidskills.db.Skills
 import dev.androidskills.db.Submissions
 import dev.androidskills.db.Users
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GitHubAppException
+import dev.androidskills.ingest.ArchiveSource
+import dev.androidskills.ingest.IngestPipeline
 import dev.androidskills.ingest.ReviewOutputPayload
 import dev.androidskills.ingest.StagedPayload
 import dev.androidskills.ingest.SubmissionPayload
+import dev.androidskills.storage.FileStore
 import dev.androidskills.util.appJson
+import dev.androidskills.util.nowIso
 import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
 
 /**
- * Admin review queue (spec §9 Admin, step 7 commit 1).
+ * Admin review queue (spec §9 Admin, step 7).
  */
 object AdminQueueQueries {
 
@@ -32,6 +40,12 @@ object AdminQueueQueries {
         val staged: StagedPayload?,
         val createdAt: String,
         val updatedAt: String,
+    )
+
+    @Serializable
+    data class DecisionRequest(
+        val decision: String, // approve|request_changes|reject|skip
+        val note: String? = null,
     )
 
     @Serializable
@@ -128,5 +142,136 @@ object AdminQueueQueries {
             createdAt = row[Submissions.createdAt],
             updatedAt = row[Submissions.updatedAt],
         )
+    }
+
+    /**
+     * Admin decision on a submission (approve/request_changes/reject/skip).
+     * Approve fetches the archive, runs [IngestPipeline.promote], and publishes the skill
+     * in the same transaction as the audit log write.
+     */
+    suspend fun decision(
+        principal: Principal,
+        submissionId: String,
+        request: DecisionRequest,
+        store: FileStore,
+        gh: GitHubAppClient,
+    ) {
+        if (!gh.configured) throw ApiBadGatewayException("GitHub App is not configured", "github_app_disabled")
+
+        val submission = transaction {
+            Submissions.selectAll()
+                .where { Submissions.id eq submissionId }
+                .singleOrNull()
+        } ?: throw ApiNotFoundException("Submission not found")
+
+        val state = submission[Submissions.state]
+        if (state !in listOf("in_review", "changes_requested")) {
+            throw ApiConflictException("Submission is not awaiting decision", code = "invalid_state_transition")
+        }
+
+        val skillId = submission[Submissions.skillId]
+            ?: throw ApiNotFoundException("Submission has no skill")
+        val skill = transaction {
+            Skills.selectAll().where { Skills.id eq skillId }.singleOrNull()
+        } ?: throw ApiNotFoundException("Skill not found")
+        val bundleId = submission[Submissions.bundleId]
+            ?: throw ApiNotFoundException("Submission has no bundle")
+        val bundle = transaction {
+            Bundles.selectAll().where { Bundles.id eq bundleId }.singleOrNull()
+        } ?: throw ApiNotFoundException("Bundle not found")
+        val slug = skill[Skills.slug]
+
+        when (request.decision) {
+            "approve" -> {
+                val payload = submission[Submissions.payload]?.let {
+                    runCatching { appJson.decodeFromString(SubmissionPayload.serializer(), it) }.getOrNull()
+                } ?: throw ApiBadGatewayException("Submission has no staged payload", "missing_staged_payload")
+                val sourceRef = payload.staged?.sourceRef
+                    ?: throw ApiBadGatewayException("Submission has no source ref", "missing_source_ref")
+
+                val installationId = bundle[Bundles.installationId]
+                    ?: throw ApiBadGatewayException("Bundle has no installation", "bundle_no_installation")
+                val (owner, repo) = bundle[Bundles.provenance].split("/", limit = 2).let {
+                    if (it.size == 2) it[0] to it[1] else throw ApiBadGatewayException("Bundle provenance malformed", "bundle_provenance_malformed")
+                }
+
+                val zipball = try {
+                    gh.downloadZipball(installationId, owner, repo, sourceRef.ref)
+                } catch (e: GitHubAppException) {
+                    throw ApiBadGatewayException("Archive download failed: ${e.message}", "archive_download_failed")
+                }
+                val result = IngestPipeline.promote(
+                    skillId,
+                    ArchiveSource.RepoZipball(zipball, owner, repo, sourceRef.ref),
+                    bundleId,
+                    store,
+                    submission[Submissions.submitterId],
+                )
+
+                transaction {
+                    val now = nowIso()
+                    val review = payload.review
+                    val categorySlug = review?.category
+                    val categoryId = categorySlug?.let { cat ->
+                        Categories.selectAll().where { Categories.slug eq cat }.singleOrNull()?.get(Categories.id)
+                    }
+
+                    Skills.update({ Skills.id eq skillId }) {
+                        it[Skills.status] = "published"
+                        it[Skills.verified] = true
+                        it[Skills.categoryId] = categoryId
+                        it[Skills.updatedAt] = now
+                    }
+                    Submissions.update({ Submissions.id eq submissionId }) {
+                        it[Submissions.state] = "published"
+                        it[Submissions.note] = request.note
+                        it[Submissions.updatedAt] = now
+                    }
+                    AuditLogQueries.write(
+                        actorId = principal.userId,
+                        action = "submission.approve",
+                        target = "submission:$submissionId",
+                        meta = AuditLogQueries.AuditMeta(
+                            note = request.note,
+                            after = mapOf("status" to "published", "verified" to "true", "version" to result.version),
+                        ),
+                    )
+                }
+            }
+            "request_changes" -> {
+                transaction {
+                    Submissions.update({ Submissions.id eq submissionId }) {
+                        it[Submissions.state] = "changes_requested"
+                        it[Submissions.note] = request.note
+                        it[Submissions.updatedAt] = nowIso()
+                    }
+                    AuditLogQueries.write(
+                        actorId = principal.userId,
+                        action = "submission.request_changes",
+                        target = "submission:$submissionId",
+                        meta = AuditLogQueries.AuditMeta(note = request.note),
+                    )
+                }
+            }
+            "reject" -> {
+                transaction {
+                    Submissions.update({ Submissions.id eq submissionId }) {
+                        it[Submissions.state] = "rejected"
+                        it[Submissions.note] = request.note
+                        it[Submissions.updatedAt] = nowIso()
+                    }
+                    AuditLogQueries.write(
+                        actorId = principal.userId,
+                        action = "submission.reject",
+                        target = "submission:$submissionId",
+                        meta = AuditLogQueries.AuditMeta(note = request.note),
+                    )
+                }
+            }
+            "skip" -> {
+                // no-op
+            }
+            else -> throw ApiValidationException(mapOf("decision" to "must be approve, request_changes, reject, or skip"))
+        }
     }
 }

--- a/api/src/main/kotlin/dev/androidskills/api/AdminRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminRoutes.kt
@@ -1,21 +1,52 @@
 package dev.androidskills.api
 
 import dev.androidskills.auth.requireAdmin
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.storage.FileStore
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receive
 import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 
 /**
  * Admin routes (spec §9 Admin). Non-admins get 404 via [requireAdmin].
  */
-fun Route.adminRoutes() {
+fun Route.adminRoutes(fileStore: FileStore, githubApp: GitHubAppClient) {
     route("api/admin") {
         route("queue") {
             get { listQueue(call) }
             get("{id}") { queueDetail(call) }
+            post("{id}/decision") { queueDecision(call, fileStore, githubApp) }
+        }
+        route("skills") {
+            get { listSkills(call) }
+            patch("{id}") { patchSkill(call) }
+            post("bulk") { bulkSkills(call) }
+        }
+        route("users") {
+            get { listUsers(call) }
+            get("export") { exportUsers(call) }
+            patch("{id}") { patchUser(call) }
+        }
+        route("categories") {
+            get { listCategories(call) }
+            post { createCategory(call) }
+            patch("{slug}") { renameCategory(call) }
+            post("{slug}/merge") { mergeCategory(call) }
+        }
+        route("settings") {
+            get { getSettings(call) }
+            put { putSettings(call) }
+        }
+        route("audit") {
+            get { listAudit(call) }
         }
     }
 }
@@ -32,4 +63,119 @@ private suspend fun queueDetail(call: ApplicationCall) {
     val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing submission id")
     val detail = AdminQueueQueries.detail(id) ?: throw ApiNotFoundException("Submission not found")
     call.respond(detail)
+}
+
+private suspend fun queueDecision(call: ApplicationCall, fileStore: FileStore, githubApp: GitHubAppClient) {
+    val principal = call.requireAdmin()
+    val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing submission id")
+    val request = runCatching { call.receive<AdminQueueQueries.DecisionRequest>() }.getOrElse {
+        throw ApiValidationException(mapOf("body" to "invalid JSON"))
+    }
+    AdminQueueQueries.decision(principal, id, request, fileStore, githubApp)
+    call.respond(HttpStatusCode.OK, mapOf("ok" to true))
+}
+
+private suspend fun listSkills(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val filter = call.request.queryParameters["filter"]
+    val search = call.request.queryParameters["q"]
+    val sort = call.request.queryParameters["sort"]
+    val page = call.request.queryParameters["page"]?.toIntOrNull()
+    call.respond(AdminSkillQueries.list(filter, search, sort, page))
+}
+
+private suspend fun patchSkill(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing skill id")
+    val patch = runCatching { call.receive<AdminSkillQueries.AdminSkillPatch>() }.getOrElse {
+        throw ApiValidationException(mapOf("body" to "invalid JSON"))
+    }
+    AdminSkillQueries.patch(principal, id, patch)
+    call.respond(HttpStatusCode.OK, mapOf("ok" to true))
+}
+
+private suspend fun bulkSkills(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val request = runCatching { call.receive<AdminSkillQueries.BulkActionRequest>() }.getOrElse {
+        throw ApiValidationException(mapOf("body" to "invalid JSON"))
+    }
+    call.respond(AdminSkillQueries.bulk(principal, request))
+}
+
+private suspend fun listUsers(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val filter = call.request.queryParameters["filter"]
+    val search = call.request.queryParameters["q"]
+    val page = call.request.queryParameters["page"]?.toIntOrNull()
+    call.respond(AdminUserQueries.list(filter, search, page))
+}
+
+private suspend fun exportUsers(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val filter = call.request.queryParameters["filter"]
+    val search = call.request.queryParameters["q"]
+    val csv = AdminUserQueries.exportCsv(filter, search)
+    call.response.headers.append("Content-Disposition", "attachment; filename=\"users.csv\"")
+    call.respondText(csv, io.ktor.http.ContentType.Text.CSV, HttpStatusCode.OK)
+}
+
+private suspend fun patchUser(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing user id")
+    val patch = runCatching { call.receive<AdminUserQueries.AdminUserPatch>() }.getOrElse {
+        throw ApiValidationException(mapOf("body" to "invalid JSON"))
+    }
+    AdminUserQueries.patch(principal, id, patch)
+    call.respond(HttpStatusCode.OK, mapOf("ok" to true))
+}
+
+private suspend fun listCategories(call: ApplicationCall) {
+    call.requireAdmin()
+    call.respond(AdminCategoryQueries.list())
+}
+
+private suspend fun createCategory(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val params = call.request.queryParameters
+    val slug = params["slug"] ?: throw ApiBadRequestException("Missing slug")
+    val name = params["name"] ?: throw ApiBadRequestException("Missing name")
+    call.respond(AdminCategoryQueries.create(principal, slug, name))
+}
+
+private suspend fun renameCategory(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val slug = call.parameters["slug"] ?: throw ApiBadRequestException("Missing slug")
+    val request = runCatching { call.receive<AdminCategoryQueries.RenameRequest>() }.getOrElse {
+        throw ApiValidationException(mapOf("body" to "invalid JSON"))
+    }
+    call.respond(AdminCategoryQueries.rename(principal, slug, request))
+}
+
+private suspend fun mergeCategory(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val from = call.parameters["slug"] ?: throw ApiBadRequestException("Missing slug")
+    val to = call.request.queryParameters["to"] ?: throw ApiBadRequestException("Missing 'to' query")
+    AdminCategoryQueries.merge(principal, from, to)
+    call.respond(HttpStatusCode.OK, mapOf("ok" to true))
+}
+
+private suspend fun getSettings(call: ApplicationCall) {
+    call.requireAdmin()
+    call.respond(AdminSettingsQueries.get())
+}
+
+private suspend fun putSettings(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val settings = runCatching { call.receive<AdminSettingsQueries.PlatformSettings>() }.getOrElse {
+        throw ApiValidationException(mapOf("body" to "invalid JSON"))
+    }
+    call.respond(AdminSettingsQueries.put(principal, settings))
+}
+
+private suspend fun listAudit(call: ApplicationCall) {
+    call.requireAdmin()
+    val action = call.request.queryParameters["action"]
+    val target = call.request.queryParameters["target"]
+    val page = call.request.queryParameters["page"]?.toIntOrNull()
+    call.respond(AuditLogQueries.list(action, target, page))
 }

--- a/api/src/main/kotlin/dev/androidskills/api/AdminRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminRoutes.kt
@@ -1,0 +1,35 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.requireAdmin
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+
+/**
+ * Admin routes (spec §9 Admin). Non-admins get 404 via [requireAdmin].
+ */
+fun Route.adminRoutes() {
+    route("api/admin") {
+        route("queue") {
+            get { listQueue(call) }
+            get("{id}") { queueDetail(call) }
+        }
+    }
+}
+
+private suspend fun listQueue(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val filter = call.request.queryParameters["filter"]
+    val q = call.request.queryParameters["q"]
+    call.respond(AdminQueueQueries.queue(filter, q))
+}
+
+private suspend fun queueDetail(call: ApplicationCall) {
+    val principal = call.requireAdmin()
+    val id = call.parameters["id"] ?: throw ApiBadRequestException("Missing submission id")
+    val detail = AdminQueueQueries.detail(id) ?: throw ApiNotFoundException("Submission not found")
+    call.respond(detail)
+}

--- a/api/src/main/kotlin/dev/androidskills/api/AdminSettingsQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminSettingsQueries.kt
@@ -1,0 +1,58 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.Principal
+import dev.androidskills.db.PlatformSettings as PlatformSettingsTable
+import dev.androidskills.util.appJson
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+/**
+ * Platform settings (spec §9). Stored as a single JSON row under key `settings`
+ * in the [PlatformSettings] table.
+ */
+object AdminSettingsQueries {
+
+    const val SETTINGS_KEY = "settings"
+
+    @Serializable
+    data class PlatformSettings(
+        val reviewPolicy: String = "manual",
+        val tokenSoftCap: Int = 1000,
+        val llmEnabled: Boolean = false,
+    )
+
+    fun get(): PlatformSettings = transaction {
+        val row = PlatformSettingsTable.selectAll().where { PlatformSettingsTable.key eq SETTINGS_KEY }.singleOrNull()
+        row?.get(PlatformSettingsTable.value)?.let { v ->
+            runCatching { appJson.decodeFromString(PlatformSettings.serializer(), v) }.getOrNull()
+        } ?: PlatformSettings()
+    }
+
+    fun put(principal: Principal, settings: PlatformSettings): PlatformSettings {
+        val json = appJson.encodeToString(PlatformSettings.serializer(), settings)
+        transaction {
+            val existing = PlatformSettingsTable.selectAll().where { PlatformSettingsTable.key eq SETTINGS_KEY }.singleOrNull()
+            if (existing != null) {
+                PlatformSettingsTable.update({ PlatformSettingsTable.key eq SETTINGS_KEY }) {
+                    it[PlatformSettingsTable.value] = json
+                }
+            } else {
+                PlatformSettingsTable.insert {
+                    it[PlatformSettingsTable.key] = SETTINGS_KEY
+                    it[PlatformSettingsTable.value] = json
+                }
+            }
+            AuditLogQueries.write(
+                actorId = principal.userId,
+                action = "settings.put",
+                target = "platform:$SETTINGS_KEY",
+                meta = AuditLogQueries.AuditMeta(after = mapOf("value" to json)),
+            )
+        }
+        return settings
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/AdminSkillQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminSkillQueries.kt
@@ -1,0 +1,192 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.Principal
+import dev.androidskills.db.Categories
+import dev.androidskills.db.Skills
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.or
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+/**
+ * Admin skill management (spec §9). Admins may edit only non-manifest fields;
+ * [name/description/license/tags] are read-only from SKILL.md.
+ */
+object AdminSkillQueries {
+
+    const val PAGE_SIZE = 50
+
+    @Serializable
+    data class SkillListItem(
+        val id: String,
+        val slug: String,
+        val name: String,
+        val status: String,
+        val verified: Boolean,
+        val featured: Boolean,
+        val categoryId: String?,
+        val categorySlug: String?,
+        val installs: Int,
+        val updatedAt: String,
+    )
+
+    @Serializable
+    data class AdminSkillPatch(
+        val featured: Boolean? = null,
+        val status: String? = null, // published|unlisted|flagged
+        val categoryId: String? = null,
+    )
+
+    @Serializable
+    data class BulkActionRequest(
+        val ids: List<String>,
+        val action: String, // feature|unlist|delete
+    )
+
+    @Serializable
+    data class BulkActionResponse(
+        val results: Map<String, Boolean>,
+        val failed: Map<String, String>,
+    )
+
+    fun list(filter: String? = null, search: String? = null, sort: String? = "updated", page: Int? = 1): List<SkillListItem> = transaction {
+        val validStatuses = setOf("published", "unlisted", "flagged")
+        if (filter != null && filter !in validStatuses) {
+            throw ApiValidationException(mapOf("filter" to "must be published, unlisted, or flagged"))
+        }
+        val query = (Skills leftJoin Categories)
+            .selectAll()
+            .apply {
+                if (filter != null) andWhere { Skills.status eq filter }
+                if (!search.isNullOrBlank()) {
+                    val pat = "%${search.replace("%", "").replace("_", "")}%"
+                    andWhere { (Skills.slug like pat) or (Skills.name like pat) }
+                }
+            }
+            .orderBy(resolveSort(sort) to SortOrder.DESC)
+            .limit(PAGE_SIZE)
+            .offset(((page ?: 1).coerceAtLeast(1) - 1L) * PAGE_SIZE)
+
+        query.map { row ->
+            SkillListItem(
+                id = row[Skills.id],
+                slug = row[Skills.slug],
+                name = row[Skills.name],
+                status = row[Skills.status],
+                verified = row[Skills.verified],
+                featured = row[Skills.featured],
+                categoryId = row[Skills.categoryId],
+                categorySlug = row[Categories.slug],
+                installs = row[Skills.installs],
+                updatedAt = row[Skills.updatedAt],
+            )
+        }
+    }
+
+    private fun resolveSort(sort: String?): Column<*> = when (sort) {
+        "updated" -> Skills.updatedAt
+        "installs" -> Skills.installs
+        "created" -> Skills.createdAt
+        "name" -> Skills.name
+        else -> Skills.updatedAt
+    }
+
+    fun patch(principal: Principal, id: String, patch: AdminSkillPatch) {
+        transaction {
+            val skill = Skills.selectAll().where { Skills.id eq id }.singleOrNull()
+                ?: throw ApiNotFoundException("Skill not found")
+
+            val status = patch.status?.let {
+                when (it) {
+                    "published", "unlisted", "flagged" -> it
+                    else -> throw ApiValidationException(mapOf("status" to "must be published, unlisted, or flagged"))
+                }
+            }
+
+            patch.categoryId?.let { catId ->
+                if (Categories.selectAll().where { Categories.id eq catId }.count() == 0L) {
+                    throw ApiNotFoundException("Category not found")
+                }
+            }
+
+            val before = mapOf(
+                "status" to skill[Skills.status],
+                "featured" to skill[Skills.featured].toString(),
+                "categoryId" to skill[Skills.categoryId],
+            )
+            val now = nowIso()
+            Skills.update({ Skills.id eq id }) {
+                patch.featured?.let { v -> it[Skills.featured] = v }
+                status?.let { v -> it[Skills.status] = v }
+                patch.categoryId?.let { v -> it[Skills.categoryId] = v }
+                it[Skills.updatedAt] = now
+            }
+            val after = mapOf(
+                "status" to (status ?: skill[Skills.status]),
+                "featured" to (patch.featured?.toString() ?: skill[Skills.featured].toString()),
+                "categoryId" to (patch.categoryId ?: skill[Skills.categoryId]),
+            )
+
+            AuditLogQueries.write(
+                actorId = principal.userId,
+                action = "skill.patch",
+                target = "skill:$id",
+                meta = AuditLogQueries.AuditMeta(before = before, after = after),
+            )
+        }
+    }
+
+    fun bulk(principal: Principal, request: BulkActionRequest): BulkActionResponse {
+        val results = mutableMapOf<String, Boolean>()
+        val failed = mutableMapOf<String, String>()
+
+        for (id in request.ids) {
+            try {
+                transaction {
+                    val skill = Skills.selectAll().where { Skills.id eq id }.singleOrNull()
+                        ?: throw ApiNotFoundException("Skill not found")
+
+                    when (request.action) {
+                        "feature" -> {
+                            Skills.update({ Skills.id eq id }) {
+                                it[Skills.featured] = true
+                                it[Skills.updatedAt] = nowIso()
+                            }
+                            AuditLogQueries.write(
+                                actorId = principal.userId,
+                                action = "skill.feature",
+                                target = "skill:$id",
+                                meta = AuditLogQueries.AuditMeta(after = mapOf("featured" to "true")),
+                            )
+                        }
+                        "unlist" -> {
+                            Skills.update({ Skills.id eq id }) {
+                                it[Skills.status] = "unlisted"
+                                it[Skills.updatedAt] = nowIso()
+                            }
+                            AuditLogQueries.write(
+                                actorId = principal.userId,
+                                action = "skill.unlist",
+                                target = "skill:$id",
+                                meta = AuditLogQueries.AuditMeta(after = mapOf("status" to "unlisted")),
+                            )
+                        }
+                        "delete" -> {
+                            throw ApiBadRequestException("Delete not implemented; use unlist")
+                        }
+                        else -> throw ApiValidationException(mapOf("action" to "must be feature, unlist, or delete"))
+                    }
+                }
+                results[id] = true
+            } catch (e: Throwable) {
+                failed[id] = e.message ?: "failed"
+            }
+        }
+        return BulkActionResponse(results, failed)
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/AdminUserQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminUserQueries.kt
@@ -1,0 +1,167 @@
+package dev.androidskills.api
+
+import dev.androidskills.auth.Principal
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Role
+import dev.androidskills.db.Skills
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.count
+import org.jetbrains.exposed.sql.or
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+/**
+ * Admin user roster management (spec §9). Includes §3.9 self-guards: an admin
+ * cannot modify their own role/status, and the last remaining admin cannot be
+ * demoted or suspended.
+ */
+object AdminUserQueries {
+
+    const val PAGE_SIZE = 50
+
+    @Serializable
+    data class UserListItem(
+        val id: String,
+        val handle: String,
+        val role: String,
+        val status: String,
+        val skillCount: Int,
+        val createdAt: String,
+    )
+
+    @Serializable
+    data class AdminUserPatch(
+        val role: String? = null,
+        val status: String? = null,
+    )
+
+    fun list(filter: String? = null, search: String? = null, page: Int? = 1): List<UserListItem> = transaction {
+        filter?.let {
+            when (it) {
+                "active", "suspended" -> Unit
+                else -> throw ApiValidationException(mapOf("filter" to "must be active or suspended"))
+            }
+        }
+
+        val query = Users
+            .selectAll()
+            .apply {
+                if (filter == "active") andWhere { Users.status eq UserStatus.active.name }
+                if (filter == "suspended") andWhere { Users.status eq UserStatus.suspended.name }
+                if (!search.isNullOrBlank()) {
+                    val pat = "%${search.replace("%", "").replace("_", "")}%"
+                    andWhere { (Users.handle like pat) or (Users.name like pat) }
+                }
+            }
+            .orderBy(Users.createdAt to SortOrder.DESC)
+            .limit(PAGE_SIZE)
+            .offset(((page ?: 1).coerceAtLeast(1) - 1L) * PAGE_SIZE)
+
+        val rows = query.toList()
+        val userIds = rows.map { it[Users.id] }
+        val counts = if (userIds.isEmpty()) emptyMap() else {
+            Skills.join(Bundles, JoinType.INNER, Skills.bundleId, Bundles.id)
+                .select(Bundles.ownerUserId, Skills.id.count())
+                .where { Bundles.ownerUserId inList userIds }
+                .groupBy(Bundles.ownerUserId)
+                .associate { it[Bundles.ownerUserId] to it[Skills.id.count()].toInt() }
+        }
+
+        rows.map { row ->
+            UserListItem(
+                id = row[Users.id],
+                handle = row[Users.handle],
+                role = row[Users.role],
+                status = row[Users.status],
+                skillCount = counts[row[Users.id]] ?: 0,
+                createdAt = row[Users.createdAt],
+            )
+        }
+    }
+
+    fun patch(principal: Principal, id: String, patch: AdminUserPatch) {
+        if (principal.userId == id) {
+            throw ApiConflictException("Admins cannot modify their own role or status", "admin_self_guard")
+        }
+        transaction {
+            val user = Users.selectAll().where { Users.id eq id }.singleOrNull()
+                ?: throw ApiNotFoundException("User not found")
+
+            val role = patch.role?.let { r ->
+                when (r) {
+                    "member", "contributor", "admin" -> r
+                    else -> throw ApiValidationException(mapOf("role" to "must be member, contributor, or admin"))
+                }
+            }
+            val status = patch.status?.let { s ->
+                when (s) {
+                    "active", "suspended" -> s
+                    else -> throw ApiValidationException(mapOf("status" to "must be active or suspended"))
+                }
+            }
+
+            // If demoting or suspending an admin, ensure they are not the last admin.
+            val targetRole = user[Users.role]
+            if (targetRole == Role.admin.name && (role != Role.admin.name || status == UserStatus.suspended.name)) {
+                val adminCount = Users.selectAll().where { Users.role eq Role.admin.name }.count()
+                if (adminCount <= 1) {
+                    throw ApiConflictException("Cannot remove the last admin", "last_admin_guard")
+                }
+            }
+
+            val before = mapOf("role" to user[Users.role], "status" to user[Users.status])
+            Users.update({ Users.id eq id }) {
+                role?.let { v -> it[Users.role] = v }
+                status?.let { v -> it[Users.status] = v }
+                it[Users.updatedAt] = nowIso()
+            }
+            val after = mapOf(
+                "role" to (role ?: user[Users.role]),
+                "status" to (status ?: user[Users.status]),
+            )
+
+            AuditLogQueries.write(
+                actorId = principal.userId,
+                action = "user.patch",
+                target = "user:$id",
+                meta = AuditLogQueries.AuditMeta(before = before, after = after),
+            )
+        }
+    }
+
+    fun exportCsv(filter: String? = null, search: String? = null): String = transaction {
+        val rows = list(filter, search, page = 1)
+        val lines = mutableListOf("id,handle,role,status,skillCount,createdAt")
+        rows.forEach { u ->
+            lines += listOf(
+                u.id,
+                u.handle,
+                u.role,
+                u.status,
+                u.skillCount.toString(),
+                u.createdAt,
+            ).joinToString(",") { cell -> escapeCsv(cell) }
+        }
+        lines.joinToString("\r\n")
+    }
+
+    private fun escapeCsv(value: String): String {
+        // Formula injection guard: prefix leading =, +, -, @ with a single quote (spec D8).
+        var v = value
+        if (v.isNotEmpty() && v[0] in setOf('=', '+', '-', '@')) {
+            v = "'$v"
+        }
+        if (v.contains(",") || v.contains("\"") || v.contains("\n") || v.contains("\r")) {
+            v = v.replace("\"", "\"\"")
+            v = "\"$v\""
+        }
+        return v
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/api/AdminUserQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminUserQueries.kt
@@ -43,11 +43,9 @@ object AdminUserQueries {
     )
 
     fun list(filter: String? = null, search: String? = null, page: Int? = 1): List<UserListItem> = transaction {
-        filter?.let {
-            when (it) {
-                "active", "suspended" -> Unit
-                else -> throw ApiValidationException(mapOf("filter" to "must be active or suspended"))
-            }
+        val validStatuses = setOf("active", "suspended")
+        if (filter != null && filter !in validStatuses) {
+            throw ApiValidationException(mapOf("filter" to "must be active or suspended"))
         }
 
         val query = Users
@@ -61,10 +59,12 @@ object AdminUserQueries {
                 }
             }
             .orderBy(Users.createdAt to SortOrder.DESC)
-            .limit(PAGE_SIZE)
-            .offset(((page ?: 1).coerceAtLeast(1) - 1L) * PAGE_SIZE)
 
-        val rows = query.toList()
+        val paged = page?.let { p ->
+            query.limit(PAGE_SIZE).offset(((p.coerceAtLeast(1) - 1L) * PAGE_SIZE))
+        } ?: query
+
+        val rows = paged.toList()
         val userIds = rows.map { it[Users.id] }
         val counts = if (userIds.isEmpty()) emptyMap() else {
             Skills.join(Bundles, JoinType.INNER, Skills.bundleId, Bundles.id)
@@ -109,7 +109,7 @@ object AdminUserQueries {
 
             // If demoting or suspending an admin, ensure they are not the last admin.
             val targetRole = user[Users.role]
-            if (targetRole == Role.admin.name && (role != Role.admin.name || status == UserStatus.suspended.name)) {
+            if (targetRole == Role.admin.name && ((role != null && role != Role.admin.name) || status == UserStatus.suspended.name)) {
                 val adminCount = Users.selectAll().where { Users.role eq Role.admin.name }.count()
                 if (adminCount <= 1) {
                     throw ApiConflictException("Cannot remove the last admin", "last_admin_guard")
@@ -137,7 +137,7 @@ object AdminUserQueries {
     }
 
     fun exportCsv(filter: String? = null, search: String? = null): String = transaction {
-        val rows = list(filter, search, page = 1)
+        val rows = list(filter, search, page = null)
         val lines = mutableListOf("id,handle,role,status,skillCount,createdAt")
         rows.forEach { u ->
             lines += listOf(

--- a/api/src/main/kotlin/dev/androidskills/api/AuditLogQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AuditLogQueries.kt
@@ -1,0 +1,85 @@
+package dev.androidskills.api
+
+import dev.androidskills.db.AuditLog
+import dev.androidskills.db.Users
+import dev.androidskills.util.appJson
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+
+/**
+ * Append-only audit log (spec §11). Every admin mutation writes one row in the
+ * same transaction as the mutation.
+ */
+object AuditLogQueries {
+
+    const val PAGE_SIZE = 50
+
+    @Serializable
+    data class AuditMeta(
+        val note: String? = null,
+        val before: Map<String, String?>? = null,
+        val after: Map<String, String?>? = null,
+    )
+
+    @Serializable
+    data class AuditLogEntry(
+        val id: String,
+        val actorHandle: String,
+        val action: String,
+        val target: String,
+        val meta: String?,
+        val createdAt: String,
+    )
+
+    fun write(
+        actorId: String,
+        action: String,
+        target: String,
+        meta: AuditMeta? = null,
+    ) {
+        transaction {
+            AuditLog.insert {
+                it[AuditLog.id] = newId()
+                it[AuditLog.actorId] = actorId
+                it[AuditLog.action] = action
+                it[AuditLog.target] = target
+                it[AuditLog.meta] = meta?.let { appJson.encodeToString(AuditMeta.serializer(), it) }
+                it[AuditLog.createdAt] = nowIso()
+            }
+        }
+    }
+
+    /**
+     * List recent audit log entries (spec §11). Used by GET /api/admin/audit.
+     */
+    fun list(action: String? = null, target: String? = null, page: Int? = 1): List<AuditLogEntry> = transaction {
+        val query = AuditLog
+            .join(Users, JoinType.LEFT, AuditLog.actorId, Users.id)
+            .selectAll()
+            .apply {
+                if (!action.isNullOrBlank()) andWhere { AuditLog.action like "$action%" }
+                if (!target.isNullOrBlank()) andWhere { AuditLog.target like "%$target%" }
+            }
+            .orderBy(AuditLog.createdAt to SortOrder.DESC)
+            .limit(PAGE_SIZE)
+            .offset(((page ?: 1).coerceAtLeast(1) - 1L) * PAGE_SIZE)
+
+        query.map { row ->
+            AuditLogEntry(
+                id = row[AuditLog.id],
+                actorHandle = row[Users.handle] ?: "system",
+                action = row[AuditLog.action],
+                target = row[AuditLog.target],
+                meta = row[AuditLog.meta],
+                createdAt = row[AuditLog.createdAt],
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/androidskills/db/Migrations.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/Migrations.kt
@@ -1,6 +1,9 @@
 package dev.androidskills.db
 
+import dev.androidskills.util.appJson
 import dev.androidskills.util.newId
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.insertIgnore
@@ -29,6 +32,10 @@ object Migrations {
             migrateV2()
             writeVersion(2)
         }
+        if (version < 3) {
+            migrateV3()
+            writeVersion(3)
+        }
     }
 
     /** v1: the full initial schema (spec §4) + default category taxonomy. */
@@ -53,6 +60,22 @@ object Migrations {
     private fun Transaction.migrateV2() {
         addColumnIfNotExists("users", "settings_json", "TEXT")
         addColumnIfNotExists("users", "deleted_at", "TEXT")
+    }
+
+    /** v3: platform settings for admin config (step 7). */
+    private fun Transaction.migrateV3() {
+        exec("""
+            CREATE TABLE IF NOT EXISTS platform_settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+        """)
+        val default = buildJsonObject {
+            put("reviewPolicy", "manual")
+            put("tokenSoftCap", 1000)
+            put("llmEnabled", false)
+        }
+        exec("INSERT OR IGNORE INTO platform_settings(key, value) VALUES ('settings', '${appJson.encodeToString(default)}');")
     }
 
     private fun Transaction.addColumnIfNotExists(table: String, column: String, type: String) {

--- a/api/src/main/kotlin/dev/androidskills/db/Tables.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/Tables.kt
@@ -226,6 +226,13 @@ object AuditLog : Table("audit_log") {
     }
 }
 
+object PlatformSettings : Table("platform_settings") {
+    val key = text("key")
+    val value = text("value")
+
+    override val primaryKey = PrimaryKey(key)
+}
+
 object Reports : Table("reports") {
     val id = varchar("id", 36)
     val skillId = varchar("skill_id", 36).references(Skills.id, onDelete = ReferenceOption.CASCADE)

--- a/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
@@ -1,5 +1,6 @@
 package dev.androidskills.ingest
 
+import dev.androidskills.api.ApiConflictException
 import dev.androidskills.db.Bundles
 import dev.androidskills.db.Jobs
 import dev.androidskills.db.Skills
@@ -13,6 +14,7 @@ import dev.androidskills.util.appJson
 import dev.androidskills.util.newId
 import dev.androidskills.util.nowIso
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertIgnore
 import org.jetbrains.exposed.sql.selectAll
@@ -224,6 +226,96 @@ object IngestPipeline {
         }
         return subId
     }
+
+    /**
+     * Step-7 promotion: copies the staged archive content onto an existing skill
+     * shell (file mirror, skill_files, readme_md, live metadata, version zip/row).
+     * Unlike [ingest], this does NOT create a new skill row and does NOT enqueue
+     * a review job — the review already happened when the submission was in_review.
+     *
+     * Returns the promoted version. Throws if the slug is not found in the archive.
+     */
+    fun promote(skillId: String, source: ArchiveSource, bundleId: String, store: FileStore, submitterId: String): PromoteResult {
+        val scanResult = Discovery.discover(source)
+        if (scanResult is ScanResult.NoSkillsDir) {
+            throw IllegalStateException("No top-level 'skills/' directory in archive")
+        }
+        val detected = (scanResult as ScanResult.Found).skills
+        val extracted = Discovery.extract(source)
+
+        val skillRow = transaction {
+            Skills.selectAll().where { Skills.id eq skillId }.singleOrNull()
+        } ?: throw IllegalStateException("Skill $skillId not found for promotion")
+        val slug = skillRow[Skills.slug]
+        val version = skillRow[Skills.version]
+        val skillDir = "skills/$slug"
+
+        val detectedSkill = detected.firstOrNull { it.slug == slug }
+            ?: throw ApiConflictException("Skill '$slug' not found in the archive; contributor may have removed or renamed it", "slug_mismatch")
+
+        val files = extracted.filter { Discovery.topDir(it.path) == skillDir }
+        val skillMd = files.firstOrNull { it.path == "$skillDir/SKILL.md" }
+        val body = skillMd?.bytes?.toString(Charsets.UTF_8) ?: ""
+        val fileEntries = files.map { it.path.removePrefix("$skillDir/") to it.bytes }
+
+        // Build and store version zip before DB writes.
+        val zipKey = "skills/$skillId/versions/$version.zip"
+        val zipBytes = ZipBuilder.build(fileEntries.map { (p, b) -> p to b }, readmeMd = body.ifBlank { null })
+        store.put(zipKey, zipBytes)
+
+        // Write file mirror and replace DB skill_files.
+        for ((relPath, bytes) in fileEntries) {
+            val safePath = SkillPaths.safeRelativeOrNull(relPath) ?: continue
+            store.put("skills/$skillId/files/$safePath", bytes)
+        }
+
+        transaction {
+            val now = nowIso()
+            // Delete existing skill_files so we can re-insert without unique constraint violations.
+            val deleteOp = org.jetbrains.exposed.sql.SqlExpressionBuilder.run { SkillFiles.skillId eq skillId }
+            SkillFiles.deleteWhere { deleteOp }
+            for ((relPath, bytes) in fileEntries) {
+                val safePath = SkillPaths.safeRelativeOrNull(relPath) ?: continue
+                SkillFiles.insert {
+                    it[SkillFiles.id] = newId()
+                    it[SkillFiles.skillId] = skillId
+                    it[SkillFiles.path] = safePath
+                    it[SkillFiles.size] = bytes.size
+                    it[SkillFiles.isBinary] = isProbablyBinary(bytes)
+                    it[SkillFiles.r2Key] = "skills/$skillId/files/$safePath"
+                }
+            }
+
+            // Update live skill metadata from the archive (source-of-truth fields).
+            Skills.update({ Skills.id eq skillId }) {
+                it[Skills.name] = detectedSkill.name
+                it[Skills.description] = detectedSkill.description
+                it[Skills.license] = detectedSkill.license
+                it[Skills.tags] = appJson.encodeToString(detectedSkill.tags)
+                it[Skills.version] = detectedSkill.version
+                it[Skills.versionSource] = detectedSkill.versionSource
+                it[Skills.tokenUpfront] = detectedSkill.tokenUpfront
+                it[Skills.tokenOndemand] = detectedSkill.tokenOndemand
+                it[Skills.tokenBand] = detectedSkill.tokenBand
+                it[Skills.readmeMd] = body
+                it[Skills.updatedAt] = now
+            }
+
+            // Ensure version row exists (idempotent for re-promotion).
+            Versions.insertIgnore {
+                it[Versions.id] = newId()
+                it[Versions.skillId] = skillId
+                it[Versions.version] = detectedSkill.version
+                it[Versions.sourceRef] = "${detectedSkill.versionSource}:${detectedSkill.version}"
+                it[Versions.r2ZipKey] = zipKey
+                it[Versions.createdAt] = now
+            }
+        }
+
+        return PromoteResult(skillId, slug, detectedSkill.version)
+    }
+
+    data class PromoteResult(val skillId: String, val slug: String, val version: String)
 
     private fun isProbablyBinary(bytes: ByteArray): Boolean {
         val n = minOf(bytes.size, 2048)

--- a/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
@@ -247,7 +247,6 @@ object IngestPipeline {
             Skills.selectAll().where { Skills.id eq skillId }.singleOrNull()
         } ?: throw IllegalStateException("Skill $skillId not found for promotion")
         val slug = skillRow[Skills.slug]
-        val version = skillRow[Skills.version]
         val skillDir = "skills/$slug"
 
         val detectedSkill = detected.firstOrNull { it.slug == slug }
@@ -259,7 +258,7 @@ object IngestPipeline {
         val fileEntries = files.map { it.path.removePrefix("$skillDir/") to it.bytes }
 
         // Build and store version zip before DB writes.
-        val zipKey = "skills/$skillId/versions/$version.zip"
+        val zipKey = "skills/$skillId/versions/${detectedSkill.version}.zip"
         val zipBytes = ZipBuilder.build(fileEntries.map { (p, b) -> p to b }, readmeMd = body.ifBlank { null })
         store.put(zipKey, zipBytes)
 

--- a/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
@@ -3,6 +3,7 @@ package dev.androidskills
 import dev.androidskills.db.DEFAULT_CATEGORIES
 import dev.androidskills.db.Bundles
 import dev.androidskills.db.Categories
+import dev.androidskills.db.PlatformSettings
 import dev.androidskills.db.SkillFiles
 import dev.androidskills.db.Skills
 import dev.androidskills.db.Users
@@ -16,6 +17,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class MigrationTest {
@@ -45,13 +47,13 @@ class MigrationTest {
     }
 
     @Test
-    fun `schema_meta version is 2 after migration`() {
+    fun `schema_meta version is 3 after migration`() {
         Database.init(TestSupport.newConfig(dir))
         transaction {
             val v = exec("SELECT value FROM schema_meta WHERE key='version'") { rs ->
                 rs.next(); rs.getString(1).toInt()
             }
-            assertEquals(2, v)
+            assertEquals(3, v)
         }
     }
 
@@ -77,7 +79,26 @@ class MigrationTest {
             val v = exec("SELECT value FROM schema_meta WHERE key='version'") { rs ->
                 rs.next(); rs.getString(1).toInt()
             }
-            assertEquals(2, v)
+            assertEquals(3, v)
+        }
+    }
+
+    @Test
+    fun `v3 creates platform_settings with default settings row`() {
+        Database.init(TestSupport.newConfig(dir))
+        transaction {
+            val tables = exec("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name") { rs ->
+                val out = mutableListOf<String>()
+                while (rs.next()) out += rs.getString(1)
+                out
+            } ?: emptyList()
+            assertTrue("platform_settings table missing") { "platform_settings" in tables }
+
+            val row = PlatformSettings.selectAll().where { PlatformSettings.key eq "settings" }.singleOrNull()
+            assertNotNull(row)
+            val json = row!![PlatformSettings.value]
+            assertTrue(json.contains("reviewPolicy"))
+            assertTrue(json.contains("tokenSoftCap"))
         }
     }
 

--- a/api/src/test/kotlin/dev/androidskills/api/AdminCategoryQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminCategoryQueriesTest.kt
@@ -1,0 +1,132 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.AuditLog
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Categories
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Users
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AdminCategoryQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @BeforeTest
+    fun setup() = Database.init(TestSupport.newConfig(dir))
+
+    @AfterTest
+    fun teardown() { dir.toFile().deleteRecursively() }
+
+    private fun principal(userId: String) = dev.androidskills.auth.Principal(
+        sessionId = "s",
+        userId = userId,
+        githubId = 1,
+        handle = "admin",
+        name = null,
+        avatarUrl = null,
+        role = dev.androidskills.db.Role.admin,
+        status = dev.androidskills.db.UserStatus.active,
+        createdAt = nowIso(),
+    )
+
+    private fun seedAdmin(): String {
+        val id = newId()
+        val now = nowIso()
+        transaction {
+            Users.insert {
+                it[Users.id] = id
+                it[Users.githubId] = 1
+                it[Users.handle] = "admin"
+                it[Users.role] = dev.androidskills.db.Role.admin.name
+                it[Users.status] = dev.androidskills.db.UserStatus.active.name
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+        }
+        return id
+    }
+
+    @Test
+    fun `create and list categories`() {
+        val admin = seedAdmin()
+        val cat = AdminCategoryQueries.create(principal(admin), "new-category", "New Category")
+        assertEquals("new-category", cat.slug)
+        assertEquals("New Category", cat.name)
+        assertTrue(AdminCategoryQueries.list().any { it.slug == "new-category" })
+    }
+
+    @Test
+    fun `rename category`() {
+        val admin = seedAdmin()
+        val cat = AdminCategoryQueries.create(principal(admin), "old-slug", "Old")
+        val updated = AdminCategoryQueries.rename(principal(admin), "old-slug", AdminCategoryQueries.RenameRequest(slug = "renamed-slug", name = "Renamed"))
+        assertEquals("renamed-slug", updated.slug)
+        assertEquals("Renamed", updated.name)
+        transaction {
+            assertNull(Categories.selectAll().where { Categories.slug eq "old-slug" }.singleOrNull())
+        }
+    }
+
+    @Test
+    fun `merge reassigns skills and deletes source`() {
+        val admin = seedAdmin()
+        val fromId = transaction { Categories.selectAll().where { Categories.slug eq "build-ci" }.single()[Categories.id] }
+        val toId = transaction { Categories.selectAll().where { Categories.slug eq "kotlin-language" }.single()[Categories.id] }
+        val bundleId = newId()
+        val skillId = newId()
+        val now = nowIso()
+        transaction {
+            Bundles.insert {
+                it[Bundles.id] = bundleId
+                it[Bundles.kind] = "repo"
+                it[Bundles.provenance] = "owner/repo"
+                it[Bundles.ownerUserId] = admin
+                it[Bundles.createdAt] = now
+            }
+            Skills.insert {
+                it[Skills.id] = skillId
+                it[Skills.bundleId] = bundleId
+                it[Skills.slug] = "sample"
+                it[Skills.name] = "Sample"
+                it[Skills.description] = "d"
+                it[Skills.version] = "1.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.status] = "published"
+                it[Skills.categoryId] = fromId
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+        }
+        AdminCategoryQueries.merge(principal(admin), "build-ci", "kotlin-language")
+        transaction {
+            val skill = Skills.selectAll().where { Skills.id eq skillId }.single()
+            assertEquals(toId, skill[Skills.categoryId])
+            assertNull(Categories.selectAll().where { Categories.slug eq "build-ci" }.singleOrNull())
+            val audit = AuditLog.selectAll().where { AuditLog.action eq "category.merge" }.single()
+            assertEquals("category:build-ci", audit[AuditLog.target])
+        }
+    }
+
+    @Test
+    fun `merge into self throws conflict`() {
+        val admin = seedAdmin()
+        val ex = assertFailsWith<ApiConflictException> {
+            AdminCategoryQueries.merge(principal(admin), "kotlin-language", "kotlin-language")
+        }
+        assertEquals("merge_self", ex.code)
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/AdminQueueDecisionTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminQueueDecisionTest.kt
@@ -1,0 +1,379 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.AuditLog
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Categories
+import dev.androidskills.db.SkillFiles
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Submissions
+import dev.androidskills.db.Users
+import dev.androidskills.db.Versions
+import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.GitHubAppException
+import dev.androidskills.github.GithubWebhookEvent
+import dev.androidskills.github.Installation
+import dev.androidskills.github.RepoRef
+import dev.androidskills.ingest.ReviewOutputPayload
+import dev.androidskills.ingest.StagedPayload
+import dev.androidskills.ingest.SubmissionPayload
+import dev.androidskills.storage.LocalFsStore
+import dev.androidskills.util.appJson
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
+
+/**
+ * Tests for [AdminQueueQueries.decision] and the promote-based approval flow.
+ * Uses fakes: no GitHub or LLM network calls.
+ */
+class AdminQueueDecisionTest {
+
+    private val dir = TestSupport.tempDir()
+    private val store = LocalFsStore(dir.resolve("files"))
+
+    @BeforeTest
+    fun setup() = Database.init(TestSupport.newConfig(dir))
+
+    @AfterTest
+    fun teardown() { dir.toFile().deleteRecursively() }
+
+    private class FakeApp(val zipball: ByteArray) : GitHubAppClient {
+        override val configured = true
+        override suspend fun installations() = emptyList<Installation>()
+        override suspend fun listRepos(installationId: Long) = emptyList<RepoRef>()
+        override suspend fun defaultBranchHead(installationId: Long, owner: String, repo: String) = "main"
+        override suspend fun downloadZipball(installationId: Long, owner: String, repo: String, ref: String): ByteArray = zipball
+        override suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent? = null
+    }
+
+    private fun makeZipball(slug: String): ByteArray {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            zos.putNextEntry(ZipEntry("repo-main/skills/$slug/SKILL.md"))
+            zos.write(
+                """
+                ---
+                name: $slug
+                description: A test skill.
+                license: Apache-2.0
+                tags: [android, kotlin]
+                metadata:
+                  version: 1.0.0
+                ---
+                # $slug
+                
+                Usage.
+                """.trimIndent().toByteArray()
+            )
+            zos.closeEntry()
+            zos.putNextEntry(ZipEntry("repo-main/skills/$slug/README.md"))
+            zos.write("# Readme".toByteArray())
+            zos.closeEntry()
+            zos.putNextEntry(ZipEntry("repo-main/skills/$slug/src/main.kt"))
+            zos.write("fun main() {}".toByteArray())
+            zos.closeEntry()
+        }
+        return baos.toByteArray()
+    }
+
+    private data class Seed(
+        val adminId: String,
+        val adminHandle: String,
+        val submitterId: String,
+        val bundleId: String,
+        val skillId: String,
+        val submissionId: String,
+    )
+
+    private fun seed(slug: String = "test-skill", ref: String = "abc123", payload: SubmissionPayload? = null): Seed {
+        val adminId = newId()
+        val submitterId = newId()
+        val bundleId = newId()
+        val skillId = newId()
+        val submissionId = newId()
+        val now = nowIso()
+
+        transaction {
+            Users.insert {
+                it[Users.id] = adminId
+                it[Users.githubId] = 1
+                it[Users.handle] = "admin"
+                it[Users.role] = dev.androidskills.db.Role.admin.name
+                it[Users.status] = dev.androidskills.db.UserStatus.active.name
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+            Users.insert {
+                it[Users.id] = submitterId
+                it[Users.githubId] = 2
+                it[Users.handle] = "alice"
+                it[Users.role] = dev.androidskills.db.Role.contributor.name
+                it[Users.status] = dev.androidskills.db.UserStatus.active.name
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+            Bundles.insert {
+                it[Bundles.id] = bundleId
+                it[Bundles.kind] = "repo"
+                it[Bundles.provenance] = "owner/repo"
+                it[Bundles.installationId] = 42L
+                it[Bundles.ownerUserId] = submitterId
+                it[Bundles.createdAt] = now
+            }
+            Skills.insert {
+                it[Skills.id] = skillId
+                it[Skills.bundleId] = bundleId
+                it[Skills.slug] = slug
+                it[Skills.name] = "Old name"
+                it[Skills.description] = "Old description"
+                it[Skills.version] = "0.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.status] = "unlisted"
+                it[Skills.verified] = false
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+            val staged = StagedPayload(
+                version = "1.0.0",
+                versionSource = "manifest",
+                name = "Old name",
+                description = "Old description",
+                license = "Apache-2.0",
+                tags = listOf("android", "kotlin"),
+                sourceRef = StagedPayload.SourceRef("owner", "repo", ref),
+            )
+            Submissions.insert {
+                it[Submissions.id] = submissionId
+                it[Submissions.bundleId] = bundleId
+                it[Submissions.skillId] = skillId
+                it[Submissions.submitterId] = submitterId
+                it[Submissions.state] = "in_review"
+                it[Submissions.payload] = appJson.encodeToString(
+                    SubmissionPayload.serializer(),
+                    payload ?: SubmissionPayload(
+                        staged = staged,
+                        review = ReviewOutputPayload(
+                            category = "kotlin-language",
+                            tagsValidated = listOf("android", "kotlin"),
+                            securityPassed = true,
+                            securityFindings = emptyList(),
+                            lintScore = 85,
+                        ),
+                    ),
+                )
+                it[Submissions.createdAt] = now
+                it[Submissions.updatedAt] = now
+            }
+        }
+        return Seed(adminId, "admin", submitterId, bundleId, skillId, submissionId)
+    }
+
+    private fun principal(userId: String, handle: String) = dev.androidskills.auth.Principal(
+        sessionId = "ignored",
+        userId = userId,
+        githubId = 1,
+        handle = handle,
+        name = null,
+        avatarUrl = null,
+        role = dev.androidskills.db.Role.admin,
+        status = dev.androidskills.db.UserStatus.active,
+        createdAt = nowIso(),
+    )
+
+    @Test
+    fun `approve promotes files and publishes skill`() {
+        val slug = "test-skill"
+        val s = seed(slug)
+        val zip = makeZipball(slug)
+
+        runBlocking {
+            AdminQueueQueries.decision(
+                principal(s.adminId, s.adminHandle),
+                s.submissionId,
+                AdminQueueQueries.DecisionRequest("approve"),
+                store,
+                FakeApp(zip),
+            )
+        }
+
+        transaction {
+            val skill = Skills.selectAll().where { Skills.id eq s.skillId }.single()
+            assertEquals("published", skill[Skills.status])
+            assertEquals(true, skill[Skills.verified])
+            assertEquals(slug, skill[Skills.name])
+            assertEquals("A test skill.", skill[Skills.description])
+            assertEquals("1.0.0", skill[Skills.version])
+            assertEquals("manifest", skill[Skills.versionSource])
+
+            val category = skill[Skills.categoryId]
+            assertNotNull(category)
+            val categorySlug = Categories.selectAll().where { Categories.id eq category }.single()[Categories.slug]
+            assertEquals("kotlin-language", categorySlug)
+
+            val submission = Submissions.selectAll().where { Submissions.id eq s.submissionId }.single()
+            assertEquals("published", submission[Submissions.state])
+
+            val files = SkillFiles.selectAll().where { SkillFiles.skillId eq s.skillId }.map { it[SkillFiles.path] }
+            assertEquals(3, files.size)
+            assertTrue(files.contains("SKILL.md"))
+            assertTrue(files.contains("README.md"))
+            assertTrue(files.contains("src/main.kt"))
+
+            val versions = Versions.selectAll()
+                .where { Versions.skillId eq s.skillId }
+                .map { it[Versions.version] }
+            assertEquals(listOf("1.0.0"), versions)
+
+            val audit = AuditLog.selectAll().where { AuditLog.target eq "submission:${s.submissionId}" }.single()
+            assertEquals("submission.approve", audit[AuditLog.action])
+            assertEquals(s.adminId, audit[AuditLog.actorId])
+        }
+    }
+
+    @Test
+    fun `approve replaces existing skill_files`() {
+        val slug = "test-skill"
+        val s = seed(slug)
+
+        transaction {
+            SkillFiles.insert {
+                it[SkillFiles.id] = newId()
+                it[SkillFiles.skillId] = s.skillId
+                it[SkillFiles.path] = "stale.txt"
+                it[SkillFiles.r2Key] = "old"
+                it[SkillFiles.size] = 1
+                it[SkillFiles.isBinary] = false
+            }
+        }
+
+        val zip = makeZipball(slug)
+        runBlocking {
+            AdminQueueQueries.decision(
+                principal(s.adminId, s.adminHandle),
+                s.submissionId,
+                AdminQueueQueries.DecisionRequest("approve"),
+                store,
+                FakeApp(zip),
+            )
+        }
+
+        transaction {
+            val files = SkillFiles.selectAll()
+                .where { SkillFiles.skillId eq s.skillId }
+                .map { it[SkillFiles.path] }
+                .toSet()
+            assertTrue(!files.contains("stale.txt"), "stale file should be replaced")
+            assertTrue(files.contains("SKILL.md"))
+        }
+    }
+
+    @Test
+    fun `approve fails with slug_mismatch if contributor renamed slug`() {
+        val s = seed("test-skill")
+        // The zip contains skills/wrong-slug, not the expected test-skill.
+        val zip = makeZipball("wrong-slug")
+
+        val ex = assertFailsWith<ApiConflictException> {
+            runBlocking {
+                AdminQueueQueries.decision(
+                    principal(s.adminId, s.adminHandle),
+                    s.submissionId,
+                    AdminQueueQueries.DecisionRequest("approve"),
+                    store,
+                    FakeApp(zip),
+                )
+            }
+        }
+        assertEquals("slug_mismatch", ex.code)
+    }
+
+    @Test
+    fun `request_changes updates submission state and writes audit`() {
+        val slug = "test-skill"
+        val s = seed(slug)
+
+        runBlocking {
+            AdminQueueQueries.decision(
+                principal(s.adminId, s.adminHandle),
+                s.submissionId,
+                AdminQueueQueries.DecisionRequest("request_changes", "needs docs"),
+                store,
+                FakeApp(ByteArray(0)),
+            )
+        }
+
+        transaction {
+            val submission = Submissions.selectAll().where { Submissions.id eq s.submissionId }.single()
+            assertEquals("changes_requested", submission[Submissions.state])
+            assertEquals("needs docs", submission[Submissions.note])
+
+            val audit = AuditLog.selectAll().where { AuditLog.target eq "submission:${s.submissionId}" }.single()
+            assertEquals("submission.request_changes", audit[AuditLog.action])
+        }
+    }
+
+    @Test
+    fun `reject updates submission state and writes audit`() {
+        val slug = "test-skill"
+        val s = seed(slug)
+
+        runBlocking {
+            AdminQueueQueries.decision(
+                principal(s.adminId, s.adminHandle),
+                s.submissionId,
+                AdminQueueQueries.DecisionRequest("reject"),
+                store,
+                FakeApp(ByteArray(0)),
+            )
+        }
+
+        transaction {
+            val submission = Submissions.selectAll().where { Submissions.id eq s.submissionId }.single()
+            assertEquals("rejected", submission[Submissions.state])
+
+            val audit = AuditLog.selectAll().where { AuditLog.target eq "submission:${s.submissionId}" }.single()
+            assertEquals("submission.reject", audit[AuditLog.action])
+        }
+    }
+
+    @Test
+    fun `decision on non awaiting submission throws conflict`() {
+        val slug = "test-skill"
+        val s = seed(slug)
+        transaction {
+            Submissions.update({ Submissions.id eq s.submissionId }) {
+                it[Submissions.state] = "published"
+                it[Submissions.updatedAt] = nowIso()
+            }
+        }
+
+        val ex = assertFailsWith<ApiConflictException> {
+            runBlocking {
+                AdminQueueQueries.decision(
+                    principal(s.adminId, s.adminHandle),
+                    s.submissionId,
+                    AdminQueueQueries.DecisionRequest("approve"),
+                    store,
+                    FakeApp(ByteArray(0)),
+                )
+            }
+        }
+        assertEquals("invalid_state_transition", ex.code)
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/AdminQueueDecisionTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminQueueDecisionTest.kt
@@ -62,7 +62,7 @@ class AdminQueueDecisionTest {
         override suspend fun verifyAndParseEvent(body: ByteArray, signature: String): GithubWebhookEvent? = null
     }
 
-    private fun makeZipball(slug: String): ByteArray {
+    private fun makeZipball(slug: String, version: String = "1.0.0"): ByteArray {
         val baos = ByteArrayOutputStream()
         ZipOutputStream(baos).use { zos ->
             zos.putNextEntry(ZipEntry("repo-main/skills/$slug/SKILL.md"))
@@ -74,7 +74,7 @@ class AdminQueueDecisionTest {
                 license: Apache-2.0
                 tags: [android, kotlin]
                 metadata:
-                  version: 1.0.0
+                  version: $version
                 ---
                 # $slug
                 
@@ -243,6 +243,102 @@ class AdminQueueDecisionTest {
             val audit = AuditLog.selectAll().where { AuditLog.target eq "submission:${s.submissionId}" }.single()
             assertEquals("submission.approve", audit[AuditLog.action])
             assertEquals(s.adminId, audit[AuditLog.actorId])
+
+            // Regression guards: readme persisted and the stored version zip is complete.
+            assertTrue(skill[Skills.readmeMd]?.contains("# $slug") == true, "readme_md should be populated")
+            val versionRow = Versions.selectAll().where { Versions.skillId eq s.skillId }.single()
+            val zipKey = versionRow[Versions.r2ZipKey]!!
+            val zipBytes = store.get(zipKey)
+            assertNotNull(zipBytes, "version zip should be stored")
+            val entries = readZipEntries(zipBytes)
+            assertTrue(entries.contains("SKILL.md"))
+            assertTrue(entries.contains("README.md"))
+            assertTrue(entries.contains("src/main.kt"))
+        }
+    }
+
+    private fun readZipEntries(bytes: ByteArray): Set<String> {
+        val names = mutableSetOf<String>()
+        java.util.zip.ZipInputStream(bytes.inputStream()).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                names += entry.name
+                entry = zis.nextEntry
+            }
+        }
+        return names
+    }
+
+    @Test
+    fun `re-promotion with a new version stores both versions and updates live version`() {
+        val slug = "test-skill"
+        val s = seed(slug)
+
+        // Approve v1.0.0
+        runBlocking {
+            AdminQueueQueries.decision(
+                principal(s.adminId, s.adminHandle),
+                s.submissionId,
+                AdminQueueQueries.DecisionRequest("approve"),
+                store,
+                FakeApp(makeZipball(slug)),
+            )
+        }
+
+        // Update staged payload to v2.0.0 and approve again with a manifest that also says v2.0.0.
+        val stagedV2 = StagedPayload(
+            version = "2.0.0",
+            versionSource = "manifest",
+            name = "test-skill",
+            description = "A test skill v2.",
+            license = "Apache-2.0",
+            tags = listOf("android"),
+            sourceRef = StagedPayload.SourceRef("owner", "repo", "def456"),
+        )
+        transaction {
+            Submissions.update({ Submissions.id eq s.submissionId }) {
+                it[Submissions.state] = "in_review"
+                it[Submissions.payload] = appJson.encodeToString(
+                    SubmissionPayload.serializer(),
+                    SubmissionPayload(
+                        staged = stagedV2,
+                        review = ReviewOutputPayload(
+                            category = "kotlin-language",
+                            tagsValidated = listOf("android"),
+                            securityPassed = true,
+                            securityFindings = emptyList(),
+                            lintScore = 90,
+                        ),
+                    ),
+                )
+                it[Submissions.updatedAt] = nowIso()
+            }
+        }
+
+        runBlocking {
+            AdminQueueQueries.decision(
+                principal(s.adminId, s.adminHandle),
+                s.submissionId,
+                AdminQueueQueries.DecisionRequest("approve"),
+                store,
+                FakeApp(makeZipball(slug, version = "2.0.0")),
+            )
+        }
+
+        transaction {
+            val skill = Skills.selectAll().where { Skills.id eq s.skillId }.single()
+            assertEquals("2.0.0", skill[Skills.version])
+            // Description stays tied to the manifest body, which our fixture keeps as "A test skill."
+            assertEquals("A test skill.", skill[Skills.description])
+
+            val versions = Versions.selectAll()
+                .where { Versions.skillId eq s.skillId }
+                .orderBy(Versions.version)
+                .map { it[Versions.version] to it[Versions.r2ZipKey] }
+                .toMap()
+            assertEquals(setOf("1.0.0", "2.0.0"), versions.keys)
+            assertTrue(versions["1.0.0"]!!.endsWith("/1.0.0.zip"))
+            assertTrue(versions["2.0.0"]!!.endsWith("/2.0.0.zip"))
         }
     }
 

--- a/api/src/test/kotlin/dev/androidskills/api/AdminQueueQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminQueueQueriesTest.kt
@@ -1,0 +1,179 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.auth.GitHubUser
+import dev.androidskills.auth.SessionStore
+import dev.androidskills.auth.UsersRepo
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Role
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Submissions
+import dev.androidskills.db.Users
+import dev.androidskills.ingest.ReviewOutputPayload
+import dev.androidskills.ingest.StagedPayload
+import dev.androidskills.ingest.SubmissionPayload
+import dev.androidskills.util.appJson
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AdminQueueQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    private fun setupDb() {
+        Database.init(TestSupport.newConfig(dir))
+    }
+
+    private fun makeAdmin(githubId: Long = 1L, handle: String = "admin-alice"): String {
+        val uid = UsersRepo.upsertFromGitHub(GitHubUser(githubId, handle, handle, null), null)
+        transaction {
+            Users.update({ Users.id eq uid }) { it[Users.role] = Role.admin.name }
+        }
+        return SessionStore.create(uid, 3600)
+    }
+
+    private fun insertInReviewSubmission(slug: String = "queued-skill"): String {
+        val now = nowIso()
+        val uid = dev.androidskills.util.newId()
+        val bid = dev.androidskills.util.newId()
+        val sid = dev.androidskills.util.newId()
+        val subId = dev.androidskills.util.newId()
+        transaction {
+            Users.insert {
+                it[Users.id] = uid
+                it[Users.githubId] = (System.currentTimeMillis() + slug.hashCode())
+                it[Users.handle] = "submitter-$slug"
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+            Bundles.insert {
+                it[Bundles.id] = bid
+                it[Bundles.kind] = "repo"
+                it[Bundles.provenance] = "owner/$slug"
+                it[Bundles.ownerUserId] = uid
+                it[Bundles.installationId] = 1L
+                it[Bundles.createdAt] = now
+            }
+            Skills.insert {
+                it[Skills.id] = sid
+                it[Skills.bundleId] = bid
+                it[Skills.slug] = slug
+                it[Skills.name] = "Queued Skill"
+                it[Skills.description] = "Desc"
+                it[Skills.license] = "MIT"
+                it[Skills.tags] = "[]"
+                it[Skills.version] = "1.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.categoryId] = null
+                it[Skills.status] = "unlisted"
+                it[Skills.verified] = false
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+            val payload = SubmissionPayload(
+                staged = StagedPayload(
+                    version = "1.0.0",
+                    versionSource = "manifest",
+                    name = "Queued Skill",
+                    description = "Desc",
+                    license = "MIT",
+                    tags = listOf("android"),
+                    sourceRef = StagedPayload.SourceRef("owner", "repo", "abc123"),
+                ),
+                review = ReviewOutputPayload(
+                    category = "ui",
+                    tagsValidated = listOf("android"),
+                    securityPassed = true,
+                    securityFindings = emptyList(),
+                    lintScore = 85,
+                ),
+            )
+            Submissions.insert {
+                it[Submissions.id] = subId
+                it[Submissions.bundleId] = bid
+                it[Submissions.skillId] = sid
+                it[Submissions.submitterId] = uid
+                it[Submissions.state] = "in_review"
+                it[Submissions.lintScore] = 85
+                it[Submissions.payload] = appJson.encodeToString(SubmissionPayload.serializer(), payload)
+                it[Submissions.createdAt] = now
+                it[Submissions.updatedAt] = now
+            }
+        }
+        return subId
+    }
+
+    @Test
+    fun `queue lists in_review submissions`() {
+        setupDb()
+        insertInReviewSubmission("skill-one")
+        insertInReviewSubmission("skill-two")
+        val items = AdminQueueQueries.queue()
+        assertEquals(2, items.size)
+        val slugs = items.map { it.slug }.toSet()
+        assertTrue("skill-one" in slugs)
+        assertTrue("skill-two" in slugs)
+        val item = items.first { it.slug == "skill-one" }
+        assertEquals(85, item.lintScore)
+        assertEquals("submitter-skill-one", item.submitterHandle)
+        assertEquals("ui", item.review?.category)
+        assertEquals("owner/repo@abc123", item.staged?.sourceRef?.let { "${it.repoOwner}/${it.repoName}@${it.ref}" })
+    }
+
+    @Test
+    fun `queue filters by state`() {
+        setupDb()
+        val subId = insertInReviewSubmission("in-review")
+        transaction {
+            Submissions.update({ Submissions.id eq subId }) { it[Submissions.state] = "changes_requested" }
+        }
+        assertEquals(1, AdminQueueQueries.queue("changes_requested").size)
+        assertEquals(0, AdminQueueQueries.queue("in_review").size)
+    }
+
+    @Test
+    fun `queue searches by slug or handle`() {
+        setupDb()
+        insertInReviewSubmission("alpha-skill")
+        insertInReviewSubmission("beta-skill")
+        assertEquals(2, AdminQueueQueries.queue(q = "skill").size)
+        assertEquals(1, AdminQueueQueries.queue(q = "alpha").size)
+        assertEquals(2, AdminQueueQueries.queue(q = "submitter-").size)
+        assertEquals(0, AdminQueueQueries.queue(q = "gamma").size)
+    }
+
+    @Test
+    fun `detail returns submission and source ref`() {
+        setupDb()
+        val slug = "skill-one"
+        val subId = insertInReviewSubmission(slug)
+        val detail = AdminQueueQueries.detail(subId)
+        assertNotNull(detail)
+        assertEquals("skill-one", detail!!.slug)
+        assertEquals("in_review", detail.state)
+        assertEquals("owner/repo@abc123", detail.sourceRef)
+        assertEquals("owner/$slug", detail.provenance)
+        assertTrue(detail.reviewIsMetadataOnly)
+        assertEquals(85, detail.lintScore)
+    }
+
+    @Test
+    fun `detail returns null for missing id`() {
+        setupDb()
+        assertEquals(null, AdminQueueQueries.detail("no-such-id"))
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/AdminRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminRoutesTest.kt
@@ -1,0 +1,78 @@
+package dev.androidskills.api
+
+import dev.androidskills.AppConfig
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.auth.GitHubUser
+import dev.androidskills.auth.OAuthClient
+import dev.androidskills.auth.OAuthTokens
+import dev.androidskills.auth.SessionStore
+import dev.androidskills.auth.UsersRepo
+import dev.androidskills.db.Role
+import dev.androidskills.db.Users
+import dev.androidskills.module
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AdminRoutesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    private fun setupUser(role: Role, githubId: Long = 1L): String {
+        Database.init(TestSupport.newConfig(dir))
+        val uid = UsersRepo.upsertFromGitHub(GitHubUser(githubId, "alice", "Alice", null), null)
+        transaction {
+            Users.update({ Users.id eq uid }) { it[Users.role] = role.name }
+        }
+        return SessionStore.create(uid, 3600)
+    }
+
+    private fun fakeOAuth() = object : OAuthClient {
+        override val configured = true
+        override fun authorizeUrl(state: String, redirectUri: String) = ""
+        override suspend fun exchange(code: String, redirectUri: String) = OAuthTokens("tok")
+        override suspend fun userInfo(accessToken: String) = GitHubUser(1L, "alice", "Alice", null)
+    }
+
+    @Test
+    fun `admin queue returns 404 for non admin`() = testApplication {
+        val token = setupUser(Role.member)
+        application { module(TestSupport.newConfig(dir), oauth = fakeOAuth()) }
+        val res = client.get("/api/admin/queue") {
+            header("Cookie", "as_session=$token")
+        }
+        assertEquals(HttpStatusCode.NotFound, res.status)
+    }
+
+    @Test
+    fun `admin queue returns 200 for admin`() = testApplication {
+        val token = setupUser(Role.admin)
+        application { module(TestSupport.newConfig(dir), oauth = fakeOAuth()) }
+        val res = client.get("/api/admin/queue") {
+            header("Cookie", "as_session=$token")
+        }
+        assertEquals(HttpStatusCode.OK, res.status)
+        assertTrue(res.bodyAsText().startsWith("["))
+    }
+
+    @Test
+    fun `admin queue returns 404 for anonymous`() = testApplication {
+        application { module(TestSupport.newConfig(dir), oauth = fakeOAuth()) }
+        assertEquals(HttpStatusCode.NotFound, client.get("/api/admin/queue").status)
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/AdminSettingsQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminSettingsQueriesTest.kt
@@ -1,0 +1,84 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.AuditLog
+import dev.androidskills.db.PlatformSettings
+import dev.androidskills.db.Users
+import dev.androidskills.util.appJson
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AdminSettingsQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @BeforeTest
+    fun setup() = Database.init(TestSupport.newConfig(dir))
+
+    @AfterTest
+    fun teardown() { dir.toFile().deleteRecursively() }
+
+    private fun principal(userId: String) = dev.androidskills.auth.Principal(
+        sessionId = "s",
+        userId = userId,
+        githubId = 1,
+        handle = "admin",
+        name = null,
+        avatarUrl = null,
+        role = dev.androidskills.db.Role.admin,
+        status = dev.androidskills.db.UserStatus.active,
+        createdAt = nowIso(),
+    )
+
+    private fun seedAdmin(): String {
+        val id = newId()
+        val now = nowIso()
+        transaction {
+            Users.insert {
+                it[Users.id] = id
+                it[Users.githubId] = 1
+                it[Users.handle] = "admin"
+                it[Users.role] = dev.androidskills.db.Role.admin.name
+                it[Users.status] = dev.androidskills.db.UserStatus.active.name
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+        }
+        return id
+    }
+
+    @Test
+    fun `get returns default settings when absent`() {
+        val settings = AdminSettingsQueries.get()
+        assertEquals("manual", settings.reviewPolicy)
+        assertEquals(1000, settings.tokenSoftCap)
+        assertFalse(settings.llmEnabled)
+    }
+
+    @Test
+    fun `put persists settings and writes audit`() {
+        val admin = seedAdmin()
+        val updated = AdminSettingsQueries.PlatformSettings(reviewPolicy = "auto_after_lint_threshold", tokenSoftCap = 500, llmEnabled = true)
+        val result = AdminSettingsQueries.put(principal(admin), updated)
+        assertEquals(updated, result)
+
+        val stored = AdminSettingsQueries.get()
+        assertEquals("auto_after_lint_threshold", stored.reviewPolicy)
+        assertTrue(stored.llmEnabled)
+
+        transaction {
+            val audit = AuditLog.selectAll().where { AuditLog.action eq "settings.put" }.single()
+            assertEquals("platform:settings", audit[AuditLog.target])
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/AdminSkillQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminSkillQueriesTest.kt
@@ -1,0 +1,161 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.AuditLog
+import dev.androidskills.db.Bundles
+import dev.androidskills.db.Categories
+import dev.androidskills.db.Skills
+import dev.androidskills.db.Users
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AdminSkillQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @BeforeTest
+    fun setup() = Database.init(TestSupport.newConfig(dir))
+
+    @AfterTest
+    fun teardown() { dir.toFile().deleteRecursively() }
+
+    private data class Seed(
+        val adminId: String,
+        val catId: String,
+        val skillId: String,
+    )
+
+    private fun seed(): Seed {
+        val adminId = newId()
+        val bundleId = newId()
+        val skillId = newId()
+        val now = nowIso()
+        val catId = transaction {
+            Categories.selectAll().where { Categories.slug eq "kotlin-language" }.single()[Categories.id]
+        }
+        transaction {
+            Users.insert {
+                it[Users.id] = adminId
+                it[Users.githubId] = 1
+                it[Users.handle] = "admin"
+                it[Users.role] = dev.androidskills.db.Role.admin.name
+                it[Users.status] = dev.androidskills.db.UserStatus.active.name
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+            Bundles.insert {
+                it[Bundles.id] = bundleId
+                it[Bundles.kind] = "repo"
+                it[Bundles.provenance] = "owner/repo"
+                it[Bundles.ownerUserId] = adminId
+                it[Bundles.createdAt] = now
+            }
+            Skills.insert {
+                it[Skills.id] = skillId
+                it[Skills.bundleId] = bundleId
+                it[Skills.slug] = "mvi"
+                it[Skills.name] = "MVI"
+                it[Skills.description] = "d"
+                it[Skills.version] = "1.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.status] = "published"
+                it[Skills.verified] = true
+                it[Skills.featured] = false
+                it[Skills.categoryId] = catId
+                it[Skills.installs] = 5
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+        }
+        return Seed(adminId, catId, skillId)
+    }
+
+    private fun principal(userId: String) = dev.androidskills.auth.Principal(
+        sessionId = "s",
+        userId = userId,
+        githubId = 1,
+        handle = "admin",
+        name = null,
+        avatarUrl = null,
+        role = dev.androidskills.db.Role.admin,
+        status = dev.androidskills.db.UserStatus.active,
+        createdAt = nowIso(),
+    )
+
+    @Test
+    fun `list filters and searches skills`() {
+        val s = seed()
+        val items = AdminSkillQueries.list(filter = "published", search = "mv", sort = "updated", page = 1)
+        assertEquals(1, items.size)
+        assertEquals("mvi", items[0].slug)
+        assertEquals("kotlin-language", items[0].categorySlug)
+    }
+
+    @Test
+    fun `patch updates status and featured`() {
+        val s = seed()
+        AdminSkillQueries.patch(
+            principal(s.adminId),
+            s.skillId,
+            AdminSkillQueries.AdminSkillPatch(status = "flagged", featured = true),
+        )
+        transaction {
+            val skill = Skills.selectAll().where { Skills.id eq s.skillId }.single()
+            assertEquals("flagged", skill[Skills.status])
+            assertEquals(true, skill[Skills.featured])
+            val audit = AuditLog.selectAll().where { AuditLog.target eq "skill:${s.skillId}" }.single()
+            assertEquals("skill.patch", audit[AuditLog.action])
+        }
+    }
+
+    @Test
+    fun `patch rejects manifest fields`() {
+        val s = seed()
+        AdminSkillQueries.patch(
+            principal(s.adminId),
+            s.skillId,
+            AdminSkillQueries.AdminSkillPatch(),
+        )
+        transaction {
+            val skill = Skills.selectAll().where { Skills.id eq s.skillId }.single()
+            assertEquals("MVI", skill[Skills.name])
+        }
+    }
+
+    @Test
+    fun `bulk features multiple skills`() {
+        val s = seed()
+        val response = AdminSkillQueries.bulk(
+            principal(s.adminId),
+            AdminSkillQueries.BulkActionRequest(ids = listOf(s.skillId), action = "feature"),
+        )
+        assertEquals(mapOf(s.skillId to true), response.results)
+        assertTrue(response.failed.isEmpty())
+        transaction {
+            val skill = Skills.selectAll().where { Skills.id eq s.skillId }.single()
+            assertEquals(true, skill[Skills.featured])
+        }
+    }
+
+    @Test
+    fun `bulk reports partial failures`() {
+        val s = seed()
+        val response = AdminSkillQueries.bulk(
+            principal(s.adminId),
+            AdminSkillQueries.BulkActionRequest(ids = listOf(s.skillId, "missing"), action = "feature"),
+        )
+        assertEquals(mapOf(s.skillId to true), response.results)
+        assertEquals(1, response.failed.size)
+        assertNotNull(response.failed["missing"])
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/AdminSkillQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminSkillQueriesTest.kt
@@ -158,4 +158,16 @@ class AdminSkillQueriesTest {
         assertEquals(1, response.failed.size)
         assertNotNull(response.failed["missing"])
     }
+
+    @Test
+    fun `bulk delete is a stub and returns failed`() {
+        val s = seed()
+        val response = AdminSkillQueries.bulk(
+            principal(s.adminId),
+            AdminSkillQueries.BulkActionRequest(ids = listOf(s.skillId), action = "delete"),
+        )
+        assertTrue(response.results.isEmpty())
+        assertEquals(1, response.failed.size)
+        assertNotNull(response.failed[s.skillId])
+    }
 }

--- a/api/src/test/kotlin/dev/androidskills/api/AdminUserQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminUserQueriesTest.kt
@@ -1,0 +1,137 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.AuditLog
+import dev.androidskills.db.Role
+import dev.androidskills.db.UserStatus
+import dev.androidskills.db.Users
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class AdminUserQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @BeforeTest
+    fun setup() = Database.init(TestSupport.newConfig(dir))
+
+    @AfterTest
+    fun teardown() { dir.toFile().deleteRecursively() }
+
+    private data class Seed(val adminId: String, val userId: String)
+
+    private fun seed(): Seed {
+        val adminId = newId()
+        val userId = newId()
+        val now = nowIso()
+        transaction {
+            Users.insert {
+                it[Users.id] = adminId
+                it[Users.githubId] = 1
+                it[Users.handle] = "admin"
+                it[Users.role] = Role.admin.name
+                it[Users.status] = UserStatus.active.name
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+            Users.insert {
+                it[Users.id] = userId
+                it[Users.githubId] = 2
+                it[Users.handle] = "bob"
+                it[Users.role] = Role.member.name
+                it[Users.status] = UserStatus.active.name
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+        }
+        return Seed(adminId, userId)
+    }
+
+    private fun principal(userId: String) = dev.androidskills.auth.Principal(
+        sessionId = "s",
+        userId = userId,
+        githubId = 1,
+        handle = "admin",
+        name = null,
+        avatarUrl = null,
+        role = Role.admin,
+        status = UserStatus.active,
+        createdAt = nowIso(),
+    )
+
+    @Test
+    fun `list users with search`() {
+        val s = seed()
+        val items = AdminUserQueries.list(search = "bob", page = 1)
+        assertEquals(1, items.size)
+        assertEquals("bob", items[0].handle)
+    }
+
+    @Test
+    fun `patch role and status`() {
+        val s = seed()
+        AdminUserQueries.patch(
+            principal(s.adminId),
+            s.userId,
+            AdminUserQueries.AdminUserPatch(role = "contributor", status = "suspended"),
+        )
+        transaction {
+            val row = Users.selectAll().where { Users.id eq s.userId }.single()
+            assertEquals(Role.contributor.name, row[Users.role])
+            assertEquals(UserStatus.suspended.name, row[Users.status])
+            val audit = AuditLog.selectAll().where { AuditLog.target eq "user:${s.userId}" }.single()
+            assertEquals("user.patch", audit[AuditLog.action])
+        }
+    }
+
+    @Test
+    fun `self guard prevents admin modifying own role`() {
+        val s = seed()
+        val ex = assertFailsWith<ApiConflictException> {
+            AdminUserQueries.patch(
+                principal(s.adminId),
+                s.adminId,
+                AdminUserQueries.AdminUserPatch(role = "member"),
+            )
+        }
+        assertEquals("admin_self_guard", ex.code)
+    }
+
+    @Test
+    fun `last admin guard prevents demotion`() {
+        val s = seed()
+        // Remove the second admin if any; here only one admin exists.
+        val ex = assertFailsWith<ApiConflictException> {
+            AdminUserQueries.patch(
+                principal(s.adminId),
+                s.adminId,
+                AdminUserQueries.AdminUserPatch(role = "member"),
+            )
+        }
+        assertEquals("admin_self_guard", ex.code)
+    }
+
+    @Test
+    fun `csv export escapes formula injection`() {
+        val s = seed()
+        transaction {
+            Users.update({ Users.id eq s.userId }) {
+                it[Users.handle] = "@bad"
+            }
+        }
+        val csv = AdminUserQueries.exportCsv()
+        assertTrue(csv.contains("'@bad"))
+        assertTrue(csv.contains("id,handle,role,status,skillCount,createdAt"))
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/AdminUserQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminUserQueriesTest.kt
@@ -109,17 +109,95 @@ class AdminUserQueriesTest {
     }
 
     @Test
-    fun `last admin guard prevents demotion`() {
+    fun `last admin guard blocks demoting second to last admin`() {
         val s = seed()
-        // Remove the second admin if any; here only one admin exists.
+        val secondAdmin = newId()
+        transaction {
+            Users.insert {
+                it[Users.id] = secondAdmin
+                it[Users.githubId] = 3
+                it[Users.handle] = "other-admin"
+                it[Users.role] = Role.admin.name
+                it[Users.status] = UserStatus.active.name
+                it[Users.createdAt] = nowIso()
+                it[Users.updatedAt] = nowIso()
+            }
+        }
+        // Demote the original admin (not self) while the other admin exists -> should succeed.
+        AdminUserQueries.patch(
+            principal(secondAdmin),
+            s.adminId,
+            AdminUserQueries.AdminUserPatch(role = "member"),
+        )
+        transaction {
+            val row = Users.selectAll().where { Users.id eq s.adminId }.single()
+            assertEquals(Role.member.name, row[Users.role])
+        }
+
+        // With only one admin left, demoting that last admin should fail.
         val ex = assertFailsWith<ApiConflictException> {
             AdminUserQueries.patch(
-                principal(s.adminId),
-                s.adminId,
+                principal(s.adminId), // now member, but principal is constructed as admin for the call
+                secondAdmin,
                 AdminUserQueries.AdminUserPatch(role = "member"),
             )
         }
-        assertEquals("admin_self_guard", ex.code)
+        assertEquals("last_admin_guard", ex.code)
+    }
+
+    @Test
+    fun `status-only patch on last admin does not trigger last admin guard`() {
+        val s = seed()
+        val secondAdmin = newId()
+        transaction {
+            Users.insert {
+                it[Users.id] = secondAdmin
+                it[Users.githubId] = 3
+                it[Users.handle] = "other-admin"
+                it[Users.role] = Role.admin.name
+                it[Users.status] = UserStatus.active.name
+                it[Users.createdAt] = nowIso()
+                it[Users.updatedAt] = nowIso()
+            }
+        }
+        // Reinstating a suspended admin should not hit last_admin_guard.
+        transaction {
+            Users.update({ Users.id eq secondAdmin }) {
+                it[Users.status] = UserStatus.suspended.name
+                it[Users.updatedAt] = nowIso()
+            }
+        }
+        AdminUserQueries.patch(
+            principal(s.adminId),
+            secondAdmin,
+            AdminUserQueries.AdminUserPatch(status = "active"),
+        )
+        transaction {
+            val row = Users.selectAll().where { Users.id eq secondAdmin }.single()
+            assertEquals(UserStatus.active.name, row[Users.status])
+        }
+    }
+
+    @Test
+    fun `csv export includes all users not just first page`() {
+        val s = seed()
+        transaction {
+            repeat(55) { i ->
+                Users.insert {
+                    it[Users.id] = newId()
+                    it[Users.githubId] = 100L + i
+                    it[Users.handle] = "user-$i"
+                    it[Users.role] = Role.member.name
+                    it[Users.status] = UserStatus.active.name
+                    it[Users.createdAt] = nowIso()
+                    it[Users.updatedAt] = nowIso()
+                }
+            }
+        }
+        val csv = AdminUserQueries.exportCsv()
+        assertTrue(csv.contains("user-0"), "CSV should include user beyond page 1")
+        assertTrue(csv.contains("user-54"), "CSV should include the last seeded user")
+        assertEquals(58, csv.lines().filter { it.isNotBlank() }.size)
     }
 
     @Test

--- a/api/src/test/kotlin/dev/androidskills/api/AuditLogQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AuditLogQueriesTest.kt
@@ -1,0 +1,58 @@
+package dev.androidskills.api
+
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.db.AuditLog
+import dev.androidskills.db.Users
+import dev.androidskills.util.newId
+import dev.androidskills.util.nowIso
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuditLogQueriesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @BeforeTest
+    fun setup() = Database.init(TestSupport.newConfig(dir))
+
+    @AfterTest
+    fun teardown() { dir.toFile().deleteRecursively() }
+
+    private fun seedAdmin(): String {
+        val id = newId()
+        val now = nowIso()
+        transaction {
+            Users.insert {
+                it[Users.id] = id
+                it[Users.githubId] = 1
+                it[Users.handle] = "admin"
+                it[Users.role] = dev.androidskills.db.Role.admin.name
+                it[Users.status] = dev.androidskills.db.UserStatus.active.name
+                it[Users.createdAt] = now
+                it[Users.updatedAt] = now
+            }
+        }
+        return id
+    }
+
+    @Test
+    fun `write and list audit entries`() {
+        val admin = seedAdmin()
+        AuditLogQueries.write(admin, "skill.patch", "skill:abc", AuditLogQueries.AuditMeta(note = "note"))
+        AuditLogQueries.write(admin, "user.patch", "user:xyz", null)
+
+        val entries = AuditLogQueries.list()
+        assertEquals(2, entries.size)
+
+        val filtered = AuditLogQueries.list(action = "skill")
+        assertEquals(1, filtered.size)
+        assertEquals("skill.patch", filtered[0].action)
+        assertEquals("admin", filtered[0].actorHandle)
+    }
+}


### PR DESCRIPTION
## Summary

Completes Step 7 of the §14 build order: the full admin surface for review decisions, skill/user/category management, platform settings, and audit logging.

### What's in the PR

- `IngestPipeline.promote()` — explicit approval-time promotion for staged submissions (replaces `skill_files`, builds/stores version zip, updates live metadata).
- `AdminQueueQueries.decision()` with approve / request_changes / reject / skip, atomic publish + audit.
- `AdminSkillQueries` + routes: list/patch/bulk (feature/unlist) with audit.
- `AdminUserQueries` + routes: roster, patch role/status with self-guard and last-admin guard, CSV export with formula-injection defence.
- `AdminCategoryQueries` + routes: create, rename, merge (reassign skills and delete source).
- `AdminSettingsQueries` + routes: get/put single JSON settings row.
- `AuditLogQueries`: append-only writes + paginated list.

### Security / design notes

- Admin routes return 404 for non-admins via `requireAdmin()`.
- Promotion validates slug match and returns `slug_mismatch` (409) if the contributor removed/renamed the skill.
- Re-promotion deletes existing `skill_files` before re-insert to avoid `uq_skill_files_skill_path` collisions.
- Archive download uses the existing `MAX_COMPRESSED_ZIPBALL` 50 MB cap.
- Manifest fields (`name`, `description`, `license`, `tags`) remain read-only; admin skill patch only touches `featured`, `status`, `categoryId`.

### Test status

- `229` tests, all green.
- Clean build.

### PR checklist

- [x] Each commit compiles and tests pass.
- [x] No cloud credentials in repo.
- [x] Admin routes return 404 for non-admins.
- [x] Audit writes happen in the same DB transaction as the mutation.
- [x] Formula injection guard applied to CSV export.

**Closes the Step 7 implementation.**
