### PR TITLE
fix(step 7): decision concurrency guard + admin user list pagination

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
@@ -209,6 +209,12 @@ object AdminQueueQueries {
                 )
 
                 transaction {
+                    val current = Submissions.selectAll()
+                        .where { Submissions.id eq submissionId }
+                        .singleOrNull()
+                    if (current?.get(Submissions.state) !in listOf("in_review", "changes_requested")) {
+                        throw ApiConflictException("Submission state changed concurrently", "concurrent_state_change")
+                    }
                     val now = nowIso()
                     val review = payload.review
                     val categorySlug = review?.category
@@ -240,6 +246,12 @@ object AdminQueueQueries {
             }
             "request_changes" -> {
                 transaction {
+                    val current = Submissions.selectAll()
+                        .where { Submissions.id eq submissionId }
+                        .singleOrNull()
+                    if (current?.get(Submissions.state) !in listOf("in_review", "changes_requested")) {
+                        throw ApiConflictException("Submission state changed concurrently", "concurrent_state_change")
+                    }
                     Submissions.update({ Submissions.id eq submissionId }) {
                         it[Submissions.state] = "changes_requested"
                         it[Submissions.note] = request.note
@@ -255,6 +267,12 @@ object AdminQueueQueries {
             }
             "reject" -> {
                 transaction {
+                    val current = Submissions.selectAll()
+                        .where { Submissions.id eq submissionId }
+                        .singleOrNull()
+                    if (current?.get(Submissions.state) !in listOf("in_review", "changes_requested")) {
+                        throw ApiConflictException("Submission state changed concurrently", "concurrent_state_change")
+                    }
                     Submissions.update({ Submissions.id eq submissionId }) {
                         it[Submissions.state] = "rejected"
                         it[Submissions.note] = request.note

--- a/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
@@ -206,6 +206,16 @@ object AdminQueueQueries {
                     bundleId,
                     store,
                     submission[Submissions.submitterId],
+                    guard = {
+                        val current = transaction {
+                            Submissions.selectAll()
+                                .where { Submissions.id eq submissionId }
+                                .singleOrNull()
+                        }
+                        if (current?.get(Submissions.state) !in listOf("in_review", "changes_requested")) {
+                            throw ApiConflictException("Submission state changed concurrently", "concurrent_state_change")
+                        }
+                    },
                 )
 
                 transaction {

--- a/api/src/main/kotlin/dev/androidskills/api/AdminRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminRoutes.kt
@@ -106,7 +106,7 @@ private suspend fun listUsers(call: ApplicationCall) {
     val principal = call.requireAdmin()
     val filter = call.request.queryParameters["filter"]
     val search = call.request.queryParameters["q"]
-    val page = call.request.queryParameters["page"]?.toIntOrNull()
+    val page = call.request.queryParameters["page"]?.toIntOrNull() ?: 1
     call.respond(AdminUserQueries.list(filter, search, page))
 }
 

--- a/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
@@ -235,7 +235,7 @@ object IngestPipeline {
      *
      * Returns the promoted version. Throws if the slug is not found in the archive.
      */
-    fun promote(skillId: String, source: ArchiveSource, bundleId: String, store: FileStore, submitterId: String): PromoteResult {
+    fun promote(skillId: String, source: ArchiveSource, bundleId: String, store: FileStore, submitterId: String, guard: () -> Unit = {}): PromoteResult {
         val scanResult = Discovery.discover(source)
         if (scanResult is ScanResult.NoSkillsDir) {
             throw IllegalStateException("No top-level 'skills/' directory in archive")
@@ -257,9 +257,15 @@ object IngestPipeline {
         val body = skillMd?.bytes?.toString(Charsets.UTF_8) ?: ""
         val fileEntries = files.map { it.path.removePrefix("$skillDir/") to it.bytes }
 
-        // Build and store version zip before DB writes.
+        // Build version zip, then run the caller-supplied guard before any side effects.
+        // This prevents file-store / DB writes if the submission state changed concurrently
+        // between the initial check and promotion (e.g. another admin rejected the submission).
         val zipKey = "skills/$skillId/versions/${detectedSkill.version}.zip"
         val zipBytes = ZipBuilder.build(fileEntries.map { (p, b) -> p to b }, readmeMd = body.ifBlank { null })
+
+        guard()
+
+        // Build and store version zip before DB writes.
         store.put(zipKey, zipBytes)
 
         // Write file mirror and replace DB skill_files.

--- a/api/src/test/kotlin/dev/androidskills/api/AdminUserQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminUserQueriesTest.kt
@@ -79,6 +79,26 @@ class AdminUserQueriesTest {
     }
 
     @Test
+    fun `list paginates by default`() {
+        val s = seed()
+        transaction {
+            repeat(55) { i ->
+                Users.insert {
+                    it[Users.id] = newId()
+                    it[Users.githubId] = 100L + i
+                    it[Users.handle] = "user-$i"
+                    it[Users.role] = Role.member.name
+                    it[Users.status] = UserStatus.active.name
+                    it[Users.createdAt] = nowIso()
+                    it[Users.updatedAt] = nowIso()
+                }
+            }
+        }
+        val items = AdminUserQueries.list() // default page 1
+        assertEquals(AdminUserQueries.PAGE_SIZE, items.size)
+    }
+
+    @Test
     fun `patch role and status`() {
         val s = seed()
         AdminUserQueries.patch(
@@ -123,7 +143,6 @@ class AdminUserQueriesTest {
                 it[Users.updatedAt] = nowIso()
             }
         }
-        // Demote the original admin (not self) while the other admin exists -> should succeed.
         AdminUserQueries.patch(
             principal(secondAdmin),
             s.adminId,
@@ -134,10 +153,9 @@ class AdminUserQueriesTest {
             assertEquals(Role.member.name, row[Users.role])
         }
 
-        // With only one admin left, demoting that last admin should fail.
         val ex = assertFailsWith<ApiConflictException> {
             AdminUserQueries.patch(
-                principal(s.adminId), // now member, but principal is constructed as admin for the call
+                principal(s.adminId),
                 secondAdmin,
                 AdminUserQueries.AdminUserPatch(role = "member"),
             )
@@ -160,7 +178,6 @@ class AdminUserQueriesTest {
                 it[Users.updatedAt] = nowIso()
             }
         }
-        // Reinstating a suspended admin should not hit last_admin_guard.
         transaction {
             Users.update({ Users.id eq secondAdmin }) {
                 it[Users.status] = UserStatus.suspended.name

--- a/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
@@ -202,4 +202,85 @@ class IngestPipelineTest {
         val subsAfter = transaction { Submissions.selectAll().where { Submissions.skillId eq skillId }.toList() }
         assertEquals(1, subsAfter.size, "open in_review submission must be reused, not duplicated")
     }
+
+    @Test
+    fun `promote guard runs before file store and DB writes`() {
+        val (bundleId, userId) = seedBundle()
+        val skillId = dev.androidskills.util.newId()
+        val now = dev.androidskills.util.nowIso()
+        transaction {
+            Skills.insert {
+                it[Skills.id] = skillId
+                it[Skills.bundleId] = bundleId
+                it[Skills.slug] = "guard-test"
+                it[Skills.name] = "Old"
+                it[Skills.description] = "Old"
+                it[Skills.version] = "0.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.status] = "unlisted"
+                it[Skills.verified] = false
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+        }
+
+        val zipBytes = skillZip("guard-test", "Guard Test", "New", "1.0.0")
+        val ex = kotlin.test.assertFailsWith<dev.androidskills.api.ApiConflictException> {
+            IngestPipeline.promote(
+                skillId,
+                ArchiveSource.UploadedZip(zipBytes, "hash"),
+                bundleId,
+                store,
+                userId,
+                guard = { throw dev.androidskills.api.ApiConflictException("blocked", "blocked") },
+            )
+        }
+        assertEquals("blocked", ex.code)
+
+        assertFalse(store.exists("skills/$skillId/versions/1.0.0.zip"))
+        val row = transaction { Skills.selectAll().where { Skills.id eq skillId }.single() }
+        assertEquals("Old", row[Skills.name])
+        assertEquals("0.0.0", row[Skills.version])
+        val files = transaction { SkillFiles.selectAll().where { SkillFiles.skillId eq skillId }.count() }
+        assertEquals(0, files)
+    }
+
+    @Test
+    fun `promote updates an existing skill shell`() {
+        val (bundleId, userId) = seedBundle()
+        val skillId = dev.androidskills.util.newId()
+        val now = dev.androidskills.util.nowIso()
+        transaction {
+            Skills.insert {
+                it[Skills.id] = skillId
+                it[Skills.bundleId] = bundleId
+                it[Skills.slug] = "promote-test"
+                it[Skills.name] = "Old"
+                it[Skills.description] = "Old"
+                it[Skills.version] = "0.0.0"
+                it[Skills.versionSource] = "manifest"
+                it[Skills.status] = "unlisted"
+                it[Skills.verified] = false
+                it[Skills.createdAt] = now
+                it[Skills.updatedAt] = now
+            }
+        }
+
+        val zipBytes = skillZip("promote-test", "Promote Test", "New", "1.0.0")
+        IngestPipeline.promote(
+            skillId,
+            ArchiveSource.UploadedZip(zipBytes, "hash"),
+            bundleId,
+            store,
+            userId,
+        )
+
+        val row = transaction { Skills.selectAll().where { Skills.id eq skillId }.single() }
+        assertEquals("Promote Test", row[Skills.name])
+        assertEquals("New", row[Skills.description])
+        assertEquals("1.0.0", row[Skills.version])
+        val files = transaction { SkillFiles.selectAll().where { SkillFiles.skillId eq skillId }.map { it[SkillFiles.path] } }
+        assertTrue(files.contains("SKILL.md"))
+        assertTrue(files.contains("references/guide.md"))
+    }
 }


### PR DESCRIPTION
Follow-up to PR #6 (Step 7 admin flows). Addresses the unresolved Bugbot comments on the merged PR.

### Fixes

- **Admin user list pagination regression** — `GET /api/admin/users` now defaults to page 1, restoring the 50-user page limit. CSV export still uses the unpaged path (`page = null`). Added a test asserting `AdminUserQueries.list()` returns exactly `PAGE_SIZE` rows by default.

- **Decision concurrency guard** — `AdminQueueQueries.decision` re-reads the submission state inside the final transaction for `approve`, `request_changes`, and `reject`. If another admin changed the state concurrently, it throws `409 concurrent_state_change` instead of overwriting the later decision.

### Test status

- 233+ tests green, clean build on `wt/step7-followup`.
