### PR TITLE
Step 8: operational hardening

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,66 @@
+# androidskills.dev API environment example
+# Copy to .env, fill in the values for your deployment, and source it before
+# running the Ktor app. Values left blank/commented disable the feature cleanly.
+
+# ---------------------------------------------------------------------------
+# Required for any boot
+# ---------------------------------------------------------------------------
+
+# Directory where SQLite and mirrored files live. Must be writable.
+DATA_DIR=../data
+
+# Canonical public URL; used for OAuth redirect_uri and absolute links.
+PUBLIC_BASE_URL=http://localhost:8080
+
+# ---------------------------------------------------------------------------
+# Optional application metadata
+# ---------------------------------------------------------------------------
+
+APP_VERSION=0.0.1-local
+
+# Seed demo skills/users/categories into an empty DB on first boot (local dev).
+# Use only in local/staging.
+SEED_DEMO=0
+
+# ---------------------------------------------------------------------------
+# GitHub OAuth (login) — all three-or-none
+# ---------------------------------------------------------------------------
+
+GITHUB_OAUTH_CLIENT_ID=
+GITHUB_OAUTH_CLIENT_SECRET=
+
+# ---------------------------------------------------------------------------
+# GitHub App (repo scan, install tokens, webhooks) — all three-or-none
+# ---------------------------------------------------------------------------
+
+GITHUB_APP_ID=
+# PEM private key exported from the GitHub App settings (multi-line).
+GITHUB_APP_PRIVATE_KEY=
+GITHUB_WEBHOOK_SECRET=
+
+# ---------------------------------------------------------------------------
+# LLM review worker — all three-or-none
+# ---------------------------------------------------------------------------
+
+LLM_BASE_URL=
+LLM_API_KEY=
+LLM_MODEL=
+
+# ---------------------------------------------------------------------------
+# Session cookie posture
+# ---------------------------------------------------------------------------
+
+# Optional cookie Domain; leave blank for host-only.
+SESSION_COOKIE_DOMAIN=
+
+# 1/true to require Secure cookies. Defaults to true unless PUBLIC_BASE_URL host
+# is localhost/127.0.0.1.
+SESSION_COOKIE_SECURE=
+
+# ---------------------------------------------------------------------------
+# Cold-start admin bootstrap
+# ---------------------------------------------------------------------------
+
+# Numeric GitHub user id that gets promoted to admin on first login. Leave
+# blank once at least one admin exists.
+BOOTSTRAP_ADMIN_GITHUB_ID=

--- a/api/README.md
+++ b/api/README.md
@@ -1,31 +1,51 @@
 # androidskills-api
 
-This project was created using the [Ktor Project Generator](https://start.ktor.io).
+Kotlin/Ktor backend for [androidskills.dev](https://androidskills.dev). Serves `/api/*` and `/gh/webhooks`; everything else is handled by the Astro frontend.
 
-Here are some useful links to get you started:
- * [Ktor Documentation](https://ktor.io/docs/home.html)
- * [Ktor GitHub page](https://github.com/ktorio/ktor)
- * [Ktor Slack chat](https://app.slack.com/client/T09229ZC6/C0A974TJ9). [Request an invite](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up).
+## Quick start
 
+```bash
+./gradlew test
+./gradlew run
+```
 
-## Features
-Here's a list of features included in this project:
+The server listens on the port configured in `application.conf` (8080 by default).
 
-| Name | Description |
-|------|-------------|
+## Configuration
 
-## Building & Running
-To build or run the project, use one of the following tasks:
+Copy `api/.env.example` to `.env` and fill in the values for your environment. The app reads env vars at boot; there are no secrets in the repo.
 
+Required for any boot:
+
+- `DATA_DIR` — directory for SQLite and mirrored files. Must be writable (default: `../data`).
+- `PUBLIC_BASE_URL` — canonical URL used for OAuth redirects and absolute links (default: `http://localhost:8080`).
+
+Feature sets are **all-or-nothing**. If any env var in a feature is present but the others are missing, the app fails to start with a clear error. If all are absent, the feature is disabled cleanly.
+
+- **GitHub OAuth login:** `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`
+- **GitHub App (repo scan, install tokens, webhooks):** `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`
+- **LLM review worker:** `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL`
+
+Optional:
+
+- `APP_VERSION` — reported by `/api/health` (default: `0.0.1-local`).
+- `SEED_DEMO` — set to `1` to seed demo data on first boot (local/dev only).
+- `BOOTSTRAP_ADMIN_GITHUB_ID` — numeric GitHub user id promoted to admin on first login.
+- `SESSION_COOKIE_DOMAIN` — optional `Domain` attribute; leave blank for host-only.
+- `SESSION_COOKIE_SECURE` — `1`/`true` to require `Secure` cookies. Inferred from `PUBLIC_BASE_URL` host by default (false for localhost).
+
+## Operations
+
+- Health (LB probe): `GET /api/health`
+- Deep health (DB/files/GitHub-App/LLM checks): `GET /api/health/deep`
+- Public endpoints are rate-limited by source IP; health and webhook endpoints are exempt.
+
+The app exits non-zero at boot if env validation fails or database migrations fail.
+
+## Useful tasks
 
 | Task | Description |
 |------|-------------|
 | `./gradlew test`    | Run the tests     |
 | `./gradlew build`   | Build the project |
 | `./gradlew run`     | Run the server    |
-
-If the server starts successfully, you'll see the following output:
-```
-2024-12-04 14:32:45.584 [main] INFO  Application - Application started in 0.303 seconds.
-2024-12-04 14:32:45.682 [main] INFO  Application - Responding at http://0.0.0.0:8080
-```

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(ktorLibs.serialization.kotlinx.json)
     implementation(ktorLibs.server.callLogging)
     implementation(ktorLibs.server.statusPages)
+    implementation(ktorLibs.server.rateLimit)
     implementation(libs.logback.classic)
 
     // Persistence: SQLite via Exposed

--- a/api/src/main/kotlin/dev/androidskills/AppConfig.kt
+++ b/api/src/main/kotlin/dev/androidskills/AppConfig.kt
@@ -1,14 +1,14 @@
 package dev.androidskills
 
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
  * Environment-driven config with local-dev defaults. The cloud-shaped values
- * (LLM endpoint, R2 credentials, GitHub OAuth) are read from env / Kamal secrets
- * in prod and simply absent locally, which selects the stub/local/disabled
- * implementations. The HTTP port is owned by Ktor (application.conf / PORT),
- * not this object.
+ * (LLM endpoint, GitHub OAuth) are read from env / Kamal secrets in prod and
+ * simply absent locally, which selects the stub/local/disabled implementations.
+ * The HTTP port is owned by Ktor (application.conf / PORT), not this object.
  */
 data class AppConfig(
     val version: String,
@@ -30,16 +30,64 @@ data class AppConfig(
             "llmBaseUrl=$llmBaseUrl, llmApiKey=${if (llmApiKey == null) "null" else "***"}, " +
             "llmModel=$llmModel, seedDemo=$seedDemo, auth=$auth, githubApp=$githubApp)"
 
+    /**
+     * Fail-fast validation for required paths and URLs. This runs after env parsing
+     * so the app exits with a clear error instead of failing mysteriously later.
+     */
+    fun validate() {
+        ensureWritable(dbPath.parent ?: error("DATA_DIR has no parent directory"), "DATA_DIR")
+        ensureWritable(fileStoreDir, "DATA_DIR/files")
+        runCatching { java.net.URI(auth.publicBaseUrl) }.getOrElse {
+            throw IllegalStateException("PUBLIC_BASE_URL is not a valid URL: ${auth.publicBaseUrl}")
+        }
+    }
+
     companion object {
-        fun fromEnv(): AppConfig {
-            fun env(k: String) = System.getenv(k)?.takeIf { it.isNotBlank() }
+        fun fromEnv(): AppConfig = fromMap(System.getenv())
+
+        fun fromMap(env: Map<String, String>): AppConfig {
+            fun env(k: String) = env[k]?.takeIf { it.isNotBlank() }
             val dataDir = Paths.get(env("DATA_DIR") ?: "../data").toAbsolutePath().normalize()
             val publicBaseUrl = env("PUBLIC_BASE_URL") ?: "http://localhost:8080"
+
             val oauthClientId = env("GITHUB_OAUTH_CLIENT_ID")
             val oauthClientSecret = env("GITHUB_OAUTH_CLIENT_SECRET")
+            requireAllOrNone(
+                "GitHub OAuth",
+                mapOf(
+                    "GITHUB_OAUTH_CLIENT_ID" to oauthClientId,
+                    "GITHUB_OAUTH_CLIENT_SECRET" to oauthClientSecret,
+                ),
+            )
+
+            val llmBaseUrl = env("LLM_BASE_URL")
+            val llmApiKey = env("LLM_API_KEY")
+            val llmModel = env("LLM_MODEL")
+            requireAllOrNone(
+                "LLM",
+                mapOf(
+                    "LLM_BASE_URL" to llmBaseUrl,
+                    "LLM_API_KEY" to llmApiKey,
+                    "LLM_MODEL" to llmModel,
+                ),
+            )
+
+            val githubAppId = env("GITHUB_APP_ID")
+            val githubAppPrivateKey = env("GITHUB_APP_PRIVATE_KEY")
+            val githubAppWebhookSecret = env("GITHUB_WEBHOOK_SECRET")
+            requireAllOrNone(
+                "GitHub App",
+                mapOf(
+                    "GITHUB_APP_ID" to githubAppId,
+                    "GITHUB_APP_PRIVATE_KEY" to githubAppPrivateKey,
+                    "GITHUB_WEBHOOK_SECRET" to githubAppWebhookSecret,
+                ),
+            )
+
             val oauth = if (oauthClientId != null && oauthClientSecret != null) {
                 OAuthConfig(oauthClientId, oauthClientSecret)
             } else null
+
             // Secure cookies by default, but relax for plain-HTTP localhost so a dev
             // browser can actually log in locally (spec §7 wants Secure; the test
             // client and prod-over-HTTPS are unaffected). Overridable via env.
@@ -48,13 +96,14 @@ data class AppConfig(
             val host = runCatching { java.net.URI(publicBaseUrl).host }.getOrNull()
             val localHosts = setOf("localhost", "127.0.0.1", "0.0.0.0", "[::1]", "::1")
             val secureDefault = host == null || host !in localHosts
+
             return AppConfig(
                 version = env("APP_VERSION") ?: "0.0.1-local",
                 dbPath = dataDir.resolve("androidskills.db"),
                 fileStoreDir = dataDir.resolve("files"),
-                llmBaseUrl = env("LLM_BASE_URL"),
-                llmApiKey = env("LLM_API_KEY"),
-                llmModel = env("LLM_MODEL"),
+                llmBaseUrl = llmBaseUrl,
+                llmApiKey = llmApiKey,
+                llmModel = llmModel,
                 seedDemo = env("SEED_DEMO")?.equals("1", ignoreCase = true) == true,
                 auth = AuthConfig(
                     oauth = oauth,
@@ -65,9 +114,30 @@ data class AppConfig(
                     } ?: secureDefault,
                     bootstrapAdminGithubId = env("BOOTSTRAP_ADMIN_GITHUB_ID")?.toLongOrNull(),
                 ),
-                githubApp = GithubAppConfig.fromEnv(),
+                githubApp = GithubAppConfig.fromMap(env),
             )
         }
+    }
+}
+
+private fun requireAllOrNone(feature: String, vars: Map<String, String?>) {
+    val present = vars.count { it.value != null }
+    if (present != 0 && present != vars.size) {
+        val missing = vars.filter { it.value == null }.keys.joinToString(", ")
+        throw IllegalStateException("$feature is partially configured; missing: $missing")
+    }
+}
+
+private fun ensureWritable(path: Path, name: String) {
+    var check: Path? = path
+    while (check != null && !Files.exists(check)) {
+        check = check.parent
+    }
+    if (check == null) {
+        throw IllegalStateException("$name ($path) has no existing parent directory")
+    }
+    if (!Files.isDirectory(check) || !Files.isWritable(check)) {
+        throw IllegalStateException("$name directory ($check) is not writable")
     }
 }
 
@@ -143,8 +213,10 @@ data class GithubAppConfig(
     companion object {
         fun disabled() = GithubAppConfig(appId = null, privateKeyPem = null, webhookSecret = null)
 
-        fun fromEnv(): GithubAppConfig {
-            fun env(k: String) = System.getenv(k)?.takeIf { it.isNotBlank() }
+        fun fromEnv(): GithubAppConfig = fromMap(System.getenv())
+
+        fun fromMap(env: Map<String, String>): GithubAppConfig {
+            fun env(k: String) = env[k]?.takeIf { it.isNotBlank() }
             return GithubAppConfig(
                 appId = env("GITHUB_APP_ID")?.toLongOrNull(),
                 privateKeyPem = env("GITHUB_APP_PRIVATE_KEY"),

--- a/api/src/main/kotlin/dev/androidskills/AppConfig.kt
+++ b/api/src/main/kotlin/dev/androidskills/AppConfig.kt
@@ -217,8 +217,13 @@ data class GithubAppConfig(
 
         fun fromMap(env: Map<String, String>): GithubAppConfig {
             fun env(k: String) = env[k]?.takeIf { it.isNotBlank() }
+            val appIdStr = env("GITHUB_APP_ID")
+            val appId = appIdStr?.toLongOrNull()
+            if (appIdStr != null && appId == null) {
+                throw IllegalStateException("GITHUB_APP_ID must be a numeric GitHub App id")
+            }
             return GithubAppConfig(
-                appId = env("GITHUB_APP_ID")?.toLongOrNull(),
+                appId = appId,
                 privateKeyPem = env("GITHUB_APP_PRIVATE_KEY"),
                 webhookSecret = env("GITHUB_WEBHOOK_SECRET"),
             )

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -21,14 +21,19 @@ import io.ktor.client.HttpClient
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.install
 import io.ktor.server.application.log
 import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -55,6 +60,26 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
     install(ContentNegotiation) { json() }
     install(CallLogging)
     installApiErrorMapping()
+
+    val trustedProxyCount = System.getenv("TRUSTED_PROXY_COUNT")?.toIntOrNull()?.coerceAtLeast(0) ?: 1
+    install(RateLimit) {
+        register(RateLimitName("public")) {
+            rateLimiter(limit = 120, refillPeriod = 60.seconds)
+            requestKey { call -> clientIp(call, trustedProxyCount) }
+        }
+        register(RateLimitName("auth")) {
+            rateLimiter(limit = 10, refillPeriod = 60.seconds)
+            requestKey { call -> clientIp(call, trustedProxyCount) }
+        }
+        register(RateLimitName("authenticated")) {
+            rateLimiter(limit = 60, refillPeriod = 60.seconds)
+            requestKey { call -> clientIp(call, trustedProxyCount) }
+        }
+        register(RateLimitName("admin")) {
+            rateLimiter(limit = 60, refillPeriod = 60.seconds)
+            requestKey { call -> clientIp(call, trustedProxyCount) }
+        }
+    }
 
     val fileStore: FileStore = LocalFsStore(config.fileStoreDir)
     val (llm, llmHttp) = resolveLlm(config)
@@ -149,6 +174,20 @@ private fun resolveOauth(auth: AuthConfig, injected: OAuthClient?): Pair<OAuthCl
     val c = auth.oauth ?: return DisabledOAuthClient() to null
     val http = GitHubOAuthClient.httpClient()
     return GitHubOAuthClient(c.clientId, c.clientSecret, http) to http
+}
+
+internal fun clientIp(call: ApplicationCall, trustedProxyCount: Int): String {
+    if (trustedProxyCount == 0) return call.request.local.remoteHost
+    val xff = call.request.headers["X-Forwarded-For"]
+    if (!xff.isNullOrBlank()) {
+        val parts = xff.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+        if (parts.isNotEmpty()) {
+            val idx = parts.size - trustedProxyCount
+            return if (idx in parts.indices) parts[idx] else parts.last()
+        }
+    }
+    call.request.headers["X-Real-Ip"]?.takeIf { it.isNotBlank() }?.let { return it }
+    return call.request.local.remoteHost
 }
 
 private fun startSessionPurge(app: Application) {

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -197,7 +197,6 @@ internal fun clientIp(call: ApplicationCall, trustedProxyCount: Int): String {
             return if (idx in parts.indices) parts[idx] else parts.last()
         }
     }
-    call.request.headers["X-Real-Ip"]?.takeIf { it.isNotBlank() }?.let { return it }
     return call.request.local.remoteHost
 }
 

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -11,12 +11,14 @@ import dev.androidskills.auth.OAuthClient
 import dev.androidskills.auth.authRoutes
 import dev.androidskills.db.Skills
 import dev.androidskills.github.GitHubAppClient
+import dev.androidskills.github.PemLoader
 import dev.androidskills.gh.webhookRoutes
 import dev.androidskills.llm.LlmClient
 import dev.androidskills.llm.StubLlmClient
 import dev.androidskills.storage.FileStore
 import dev.androidskills.storage.LocalFsStore
 import io.ktor.client.HttpClient
+import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopped
@@ -97,6 +99,22 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
                 ),
             )
         }
+        get("/api/health/deep") {
+            val dbOk = Database.check()
+            val fileStoreOk = fileStore.check()
+            val githubAppOk = if (config.githubApp.configured) {
+                PemLoader.validatePem(config.githubApp.privateKeyPem)
+            } else true
+            val llmOk = if (config.llmBaseUrl != null) {
+                config.llmApiKey != null && config.llmModel != null &&
+                    runCatching { java.net.URI(config.llmBaseUrl) }.isSuccess
+            } else true
+            val checks = DeepHealthChecks(dbOk, fileStoreOk, githubAppOk, llmOk)
+            val ok = dbOk && fileStoreOk && githubAppOk && llmOk
+            val status = if (ok) "ok" else "degraded"
+            val code = if (ok) HttpStatusCode.OK else HttpStatusCode.ServiceUnavailable
+            call.respond(code, DeepHealthResponse(status, checks))
+        }
         publicRoutes(fileStore)
         authRoutes(config, resolvedOauth)
         contributorRoutes(resolvedGithubApp)
@@ -159,4 +177,18 @@ data class HealthResponse(
     val fileStore: String,
     val llm: String,
     val auth: String,
+)
+
+@Serializable
+data class DeepHealthResponse(
+    val status: String,
+    val checks: DeepHealthChecks,
+)
+
+@Serializable
+data class DeepHealthChecks(
+    val database: Boolean,
+    val fileStore: Boolean,
+    val githubApp: Boolean,
+    val llm: Boolean,
 )

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -89,6 +89,17 @@ fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClie
     // P3-3: surface the resolved cookie posture once at boot — Secure/Domain drive
     // auth correctness and a mis-set SESSION_COOKIE_DOMAIN is a silent footgun.
     log.info(
+        "androidskills {} starting: dataDir={}, db={}, fileStore={}, oauth={}, githubApp={}, llm={}, health={}",
+        config.version,
+        config.fileStoreDir.parent,
+        Database.journalMode(),
+        fileStore.kind,
+        if (resolvedOauth.configured) "configured" else "disabled",
+        if (resolvedGithubApp.configured) "configured" else "disabled",
+        if (llm is dev.androidskills.llm.StubLlmClient) "disabled" else "enabled",
+        "${config.auth.publicBaseUrl}/api/health",
+    )
+    log.info(
         "auth: oauth={}, sessionCookie secure={}, domain={}",
         if (resolvedOauth.configured) "configured" else "disabled",
         config.auth.sessionCookieSecure,

--- a/api/src/main/kotlin/dev/androidskills/Application.kt
+++ b/api/src/main/kotlin/dev/androidskills/Application.kt
@@ -47,6 +47,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
  *   when creds are absent (spec §13: "unset → auth disabled").
  */
 fun Application.module(config: AppConfig = AppConfig.fromEnv(), oauth: OAuthClient? = null, githubApp: GitHubAppClient? = null) {
+    config.validate()
     Database.init(config)
 
     install(ContentNegotiation) { json() }

--- a/api/src/main/kotlin/dev/androidskills/Database.kt
+++ b/api/src/main/kotlin/dev/androidskills/Database.kt
@@ -40,6 +40,8 @@ object Database {
         Migrations.run(db)
     }
 
+    fun check(): Boolean = runCatching { journalMode() }.isSuccess
+
     fun journalMode(): String = transaction(db) {
         var mode = "unknown"
         exec("PRAGMA journal_mode;") { rs -> if (rs.next()) mode = rs.getString(1) }

--- a/api/src/main/kotlin/dev/androidskills/api/AdminRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminRoutes.kt
@@ -3,6 +3,8 @@ package dev.androidskills.api
 import dev.androidskills.auth.requireAdmin
 import dev.androidskills.github.GitHubAppClient
 import dev.androidskills.storage.FileStore
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receive
@@ -19,34 +21,36 @@ import io.ktor.server.routing.route
  * Admin routes (spec §9 Admin). Non-admins get 404 via [requireAdmin].
  */
 fun Route.adminRoutes(fileStore: FileStore, githubApp: GitHubAppClient) {
-    route("api/admin") {
-        route("queue") {
-            get { listQueue(call) }
-            get("{id}") { queueDetail(call) }
-            post("{id}/decision") { queueDecision(call, fileStore, githubApp) }
-        }
-        route("skills") {
-            get { listSkills(call) }
-            patch("{id}") { patchSkill(call) }
-            post("bulk") { bulkSkills(call) }
-        }
-        route("users") {
-            get { listUsers(call) }
-            get("export") { exportUsers(call) }
-            patch("{id}") { patchUser(call) }
-        }
-        route("categories") {
-            get { listCategories(call) }
-            post { createCategory(call) }
-            patch("{slug}") { renameCategory(call) }
-            post("{slug}/merge") { mergeCategory(call) }
-        }
-        route("settings") {
-            get { getSettings(call) }
-            put { putSettings(call) }
-        }
-        route("audit") {
-            get { listAudit(call) }
+    rateLimit(RateLimitName("admin")) {
+        route("api/admin") {
+            route("queue") {
+                get { listQueue(call) }
+                get("{id}") { queueDetail(call) }
+                post("{id}/decision") { queueDecision(call, fileStore, githubApp) }
+            }
+            route("skills") {
+                get { listSkills(call) }
+                patch("{id}") { patchSkill(call) }
+                post("bulk") { bulkSkills(call) }
+            }
+            route("users") {
+                get { listUsers(call) }
+                get("export") { exportUsers(call) }
+                patch("{id}") { patchUser(call) }
+            }
+            route("categories") {
+                get { listCategories(call) }
+                post { createCategory(call) }
+                patch("{slug}") { renameCategory(call) }
+                post("{slug}/merge") { mergeCategory(call) }
+            }
+            route("settings") {
+                get { getSettings(call) }
+                put { putSettings(call) }
+            }
+            route("audit") {
+                get { listAudit(call) }
+            }
         }
     }
 }

--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -2,6 +2,8 @@ package dev.androidskills.api
 
 import dev.androidskills.github.GitHubAppClient
 import dev.androidskills.github.GitHubAppException
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.plugins.ratelimit.rateLimit
 import dev.androidskills.ingest.ArchiveSource
 import dev.androidskills.ingest.DetectedSkill
 import dev.androidskills.ingest.Discovery
@@ -41,28 +43,30 @@ import kotlinx.serialization.Serializable
  * `members:read`) — deferred to step 6 where org-ownership actually matters.
  */
 fun Route.contributorRoutes(githubApp: GitHubAppClient) {
-    route("api/me") {
-        get("repos") { repos(call, githubApp) }
-        post("repos/{owner}/{repo}/scan") { scan(call, githubApp) }
+    rateLimit(RateLimitName("authenticated")) {
+        route("api/me") {
+            get("repos") { repos(call, githubApp) }
+            post("repos/{owner}/{repo}/scan") { scan(call, githubApp) }
 
-        get("submissions") { mySubmissions(call) }
-        post("submissions") { createSubmissions(call, githubApp) }
-        get("submissions/{id}") { getSubmission(call) }
-        post("submissions/{id}/submit") { submit(call) }
-        post("submissions/{id}/withdraw") { withdraw(call) }
-        delete("submissions/{id}") { deleteDraft(call) }
+            get("submissions") { mySubmissions(call) }
+            post("submissions") { createSubmissions(call, githubApp) }
+            get("submissions/{id}") { getSubmission(call) }
+            post("submissions/{id}/submit") { submit(call) }
+            post("submissions/{id}/withdraw") { withdraw(call) }
+            delete("submissions/{id}") { deleteDraft(call) }
 
-        get("stars") { listStars(call) }
-        post("stars/{slug}") { addStar(call) }
-        delete("stars/{slug}") { removeStar(call) }
+            get("stars") { listStars(call) }
+            post("stars/{slug}") { addStar(call) }
+            delete("stars/{slug}") { removeStar(call) }
 
-        get("settings") { getSettings(call) }
-        put("settings") { updateSettings(call) }
-        delete("") { deleteAccount(call) }
-    }
-    route("api/skills/{slug}") {
-        post("unpublish") { unpublish(call) }
-        post("resync") { resync(call, githubApp) }
+            get("settings") { getSettings(call) }
+            put("settings") { updateSettings(call) }
+            delete("") { deleteAccount(call) }
+        }
+        route("api/skills/{slug}") {
+            post("unpublish") { unpublish(call) }
+            post("resync") { resync(call, githubApp) }
+        }
     }
 }
 
@@ -100,9 +104,9 @@ private suspend fun scan(call: ApplicationCall, gh: GitHubAppClient) {
         throw ApiBadGatewayException("GitHub installations request failed: ${e.message}", "github_installations_failed")
     }
     val head = try { gh.defaultBranchHead(installationId, owner, repo) }
-        catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub ref lookup failed: ${e.message}", "github_ref_failed") }
+    catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub ref lookup failed: ${e.message}", "github_ref_failed") }
     val zipball = try { gh.downloadZipball(installationId, owner, repo, head) }
-        catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub archive download failed: ${e.message}", "github_archive_failed") }
+    catch (e: GitHubAppException) { throw ApiBadGatewayException("GitHub archive download failed: ${e.message}", "github_archive_failed") }
     // Compressed-body cap (Q4, plan §3 step 1 — the caller bounds this so a giant
     // zipball can't sit fully in memory before Discovery's inflated guard runs).
     if (zipball.size > MAX_COMPRESSED_ZIPBALL) {

--- a/api/src/main/kotlin/dev/androidskills/api/Errors.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Errors.kt
@@ -92,6 +92,13 @@ fun Application.installApiErrorMapping() {
         exception<ApiBadGatewayException> { call, ex ->
             call.respond(HttpStatusCode.BadGateway, ErrorResponse(ErrorBody(ex.code, ex.message ?: "Bad gateway")))
         }
+        status(HttpStatusCode.TooManyRequests) { call, status ->
+            val retryAfter = call.response.headers["Retry-After"] ?: "60"
+            if (!call.response.headers.contains("Retry-After")) {
+                call.response.headers.append("Retry-After", retryAfter)
+            }
+            call.respond(status, ErrorResponse(ErrorBody("rate_limit", "Rate limit exceeded")))
+        }
         exception<Throwable> { call, ex ->
             log.error("Unhandled error serving ${call.request.local.uri}", ex)
             call.respond(

--- a/api/src/main/kotlin/dev/androidskills/api/PublicRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicRoutes.kt
@@ -1,6 +1,8 @@
 package dev.androidskills.api
 
 import dev.androidskills.storage.FileStore
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -19,64 +21,66 @@ import io.ktor.server.routing.route
 fun Route.publicRoutes(fileStore: FileStore) {
     val q = PublicQueries
 
-    route("api") {
-        get("stats") { call.respond(q.stats()) }
+    rateLimit(RateLimitName("public")) {
+        route("api") {
+            get("stats") { call.respond(q.stats()) }
 
-        get("skills") { call.respond(q.search(parseSearchParams(call))) }
-        get("skills/{slug}") { call.respond(q.skillDetail(call.parameters["slug"]!!)) }
-        get("skills/{slug}/files") { call.respond(q.fileTree(call.parameters["slug"]!!)) }
-        get("skills/{slug}/files/{path...}") {
-            val slug = call.parameters["slug"]!!
-            // {path...} is a tailcard: read every captured segment and rejoin so
-            // nested paths like references/guide.md survive the DB path match.
-            val path = call.parameters.getAll("path")?.joinToString("/").orEmpty()
-            val raw = call.request.queryParameters["raw"] == "1"
-            val res = q.fileContent(slug, path, fileStore)
-            if (raw && !res.downloadOnly) {
-                // Raw preview is ALWAYS text/plain (+ nosniff): a published skill
-                // can include an .html file, and serving it as text/html would give
-                // it same-origin script execution — catastrophic once auth/admin
-                // routes share this origin. Source files render fine as text.
-                call.response.headers.append("X-Content-Type-Options", "nosniff")
-                call.respondText(res.content ?: "", contentType = ContentType.Text.Plain.withCharset(Charsets.UTF_8))
-            } else {
-                call.respond(
-                    FileContentResponse(
-                        slug = res.slug, path = res.path, size = res.size, isBinary = res.isBinary,
-                        content = res.content, downloadOnly = res.downloadOnly, downloadUrl = null,
-                    ),
-                )
+            get("skills") { call.respond(q.search(parseSearchParams(call))) }
+            get("skills/{slug}") { call.respond(q.skillDetail(call.parameters["slug"]!!)) }
+            get("skills/{slug}/files") { call.respond(q.fileTree(call.parameters["slug"]!!)) }
+            get("skills/{slug}/files/{path...}") {
+                val slug = call.parameters["slug"]!!
+                // {path...} is a tailcard: read every captured segment and rejoin so
+                // nested paths like references/guide.md survive the DB path match.
+                val path = call.parameters.getAll("path")?.joinToString("/").orEmpty()
+                val raw = call.request.queryParameters["raw"] == "1"
+                val res = q.fileContent(slug, path, fileStore)
+                if (raw && !res.downloadOnly) {
+                    // Raw preview is ALWAYS text/plain (+ nosniff): a published skill
+                    // can include an .html file, and serving it as text/html would give
+                    // it same-origin script execution — catastrophic once auth/admin
+                    // routes share this origin. Source files render fine as text.
+                    call.response.headers.append("X-Content-Type-Options", "nosniff")
+                    call.respondText(res.content ?: "", contentType = ContentType.Text.Plain.withCharset(Charsets.UTF_8))
+                } else {
+                    call.respond(
+                        FileContentResponse(
+                            slug = res.slug, path = res.path, size = res.size, isBinary = res.isBinary,
+                            content = res.content, downloadOnly = res.downloadOnly, downloadUrl = null,
+                        ),
+                    )
+                }
             }
-        }
-        get("skills/{slug}/versions") { call.respond(q.versions(call.parameters["slug"]!!)) }
-        get("skills/{slug}/download") {
-            val slug = call.parameters["slug"]!!
-            val version = call.request.queryParameters["version"]
-            val res = q.download(slug, version, fileStore)
-            call.response.headers.append(HttpHeaders.ContentDisposition, "attachment; filename=\"${res.filename}\"")
-            call.respondBytes(res.bytes, contentType = ContentType.parse(res.contentType))
-        }
+            get("skills/{slug}/versions") { call.respond(q.versions(call.parameters["slug"]!!)) }
+            get("skills/{slug}/download") {
+                val slug = call.parameters["slug"]!!
+                val version = call.request.queryParameters["version"]
+                val res = q.download(slug, version, fileStore)
+                call.response.headers.append(HttpHeaders.ContentDisposition, "attachment; filename=\"${res.filename}\"")
+                call.respondBytes(res.bytes, contentType = ContentType.parse(res.contentType))
+            }
 
-        get("categories") { call.respond(q.categories()) }
-        get("trends") { call.respond(q.trends()) }
-        get("timeline") {
-            val page = PublicQueries.parsePageStrict(call.request.queryParameters["page"])
-            val size = PublicQueries.parsePageSizeStrict(call.request.queryParameters["pageSize"])
-            call.respond(q.timeline(page, size))
-        }
-        get("bundles") {
-            val page = PublicQueries.parsePageStrict(call.request.queryParameters["page"])
-            val size = PublicQueries.parsePageSizeStrict(call.request.queryParameters["pageSize"])
-            call.respond(q.bundles(page, size))
-        }
-        get("bundles/{id}") { call.respond(q.bundle(call.parameters["id"]!!)) }
-        get("authors/{handle}") { call.respond(q.author(call.parameters["handle"]!!)) }
+            get("categories") { call.respond(q.categories()) }
+            get("trends") { call.respond(q.trends()) }
+            get("timeline") {
+                val page = PublicQueries.parsePageStrict(call.request.queryParameters["page"])
+                val size = PublicQueries.parsePageSizeStrict(call.request.queryParameters["pageSize"])
+                call.respond(q.timeline(page, size))
+            }
+            get("bundles") {
+                val page = PublicQueries.parsePageStrict(call.request.queryParameters["page"])
+                val size = PublicQueries.parsePageSizeStrict(call.request.queryParameters["pageSize"])
+                call.respond(q.bundles(page, size))
+            }
+            get("bundles/{id}") { call.respond(q.bundle(call.parameters["id"]!!)) }
+            get("authors/{handle}") { call.respond(q.author(call.parameters["handle"]!!)) }
 
-        post("skills/{slug}/report") {
-            val slug = call.parameters["slug"]!!
-            val body = runCatching { call.receive<ReportRequest>() }.getOrDefault(ReportRequest())
-            val result = q.createReport(slug, body.reason, reporterId = null) // anonymous by default
-            call.respond(HttpStatusCode.Created, result)
+            post("skills/{slug}/report") {
+                val slug = call.parameters["slug"]!!
+                val body = runCatching { call.receive<ReportRequest>() }.getOrDefault(ReportRequest())
+                val result = q.createReport(slug, body.reason, reporterId = null) // anonymous by default
+                call.respond(HttpStatusCode.Created, result)
+            }
         }
     }
 }

--- a/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
@@ -5,6 +5,8 @@ import dev.androidskills.api.ApiBadRequestException
 import dev.androidskills.api.ErrorBody
 import dev.androidskills.api.ErrorResponse
 import dev.androidskills.util.constantTimeEquals
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
@@ -32,7 +34,8 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
     val redirectUri = "${auth.publicBaseUrl.trimEnd('/')}/api/auth/github/callback"
 
     route("api") {
-        get("auth/github/start") {
+        rateLimit(RateLimitName("auth")) {
+            get("auth/github/start") {
             if (!oauth.configured) {
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse(ErrorBody("auth_disabled", "GitHub OAuth is not configured")))
                 return@get
@@ -93,10 +96,12 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
             clearSessionCookie(call, auth)
             call.respond(mapOf("ok" to true))
         }
-
-        get("me") {
-            val principal = call.requireSession()
-            call.respond(principal.toMe())
+        }
+        rateLimit(RateLimitName("authenticated")) {
+            get("me") {
+                val principal = call.requireSession()
+                call.respond(principal.toMe())
+            }
         }
     }
 }

--- a/api/src/main/kotlin/dev/androidskills/github/PemLoader.kt
+++ b/api/src/main/kotlin/dev/androidskills/github/PemLoader.kt
@@ -43,6 +43,9 @@ internal object PemLoader {
         0x04, 0x82.toByte(), 0x00, 0x00,                                    // OCTET STRING, length at [24,25]
     )
 
+    fun validatePem(pem: String?): Boolean =
+        !pem.isNullOrBlank() && runCatching { loadPrivateKey(pem) }.isSuccess
+
     fun loadPrivateKey(pem: String): PrivateKey {
         val (base64, kind) = parsePem(pem)
         val der = Base64.getDecoder().decode(base64)

--- a/api/src/main/kotlin/dev/androidskills/storage/FileStore.kt
+++ b/api/src/main/kotlin/dev/androidskills/storage/FileStore.kt
@@ -12,6 +12,7 @@ interface FileStore {
     fun put(key: String, bytes: ByteArray)
     fun get(key: String): ByteArray?
     fun exists(key: String): Boolean
+    fun check(): Boolean
 }
 
 class LocalFsStore(private val root: Path) : FileStore {
@@ -20,6 +21,8 @@ class LocalFsStore(private val root: Path) : FileStore {
     init {
         Files.createDirectories(root)
     }
+
+    override fun check(): Boolean = Files.isDirectory(root) && Files.isWritable(root)
 
     private fun resolve(key: String): Path =
         root.resolve(key).normalize().also {

--- a/api/src/test/kotlin/dev/androidskills/AppConfigTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/AppConfigTest.kt
@@ -1,0 +1,118 @@
+package dev.androidskills
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AppConfigTest {
+
+    private val base = mapOf(
+        "DATA_DIR" to Files.createTempDirectory("as-config-test").toString(),
+        "PUBLIC_BASE_URL" to "http://localhost:8080",
+    )
+
+    @Test
+    fun `minimal valid config disables all features`() {
+        val cfg = AppConfig.fromMap(base)
+        cfg.validate()
+        assertNull(cfg.auth.oauth)
+        assertNull(cfg.llmBaseUrl)
+        assertEquals(false, cfg.githubApp.configured)
+    }
+
+    @Test
+    fun `all feature vars present enables features`() {
+        val env = base + mapOf(
+            "GITHUB_OAUTH_CLIENT_ID" to "client-id",
+            "GITHUB_OAUTH_CLIENT_SECRET" to "client-secret",
+            "GITHUB_APP_ID" to "123456",
+            "GITHUB_APP_PRIVATE_KEY" to "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----",
+            "GITHUB_WEBHOOK_SECRET" to "wh-secret",
+            "LLM_BASE_URL" to "https://api.openai.com/v1",
+            "LLM_API_KEY" to "sk-secret",
+            "LLM_MODEL" to "gpt-4o-mini",
+        )
+        val cfg = AppConfig.fromMap(env)
+        cfg.validate()
+        assertTrue(cfg.auth.oauth != null)
+        assertTrue(cfg.githubApp.configured)
+        assertEquals("gpt-4o-mini", cfg.llmModel)
+    }
+
+    @Test
+    fun `invalid public base url throws`() {
+        val env = base + mapOf("PUBLIC_BASE_URL" to "not a url")
+        val ex = assertFailsWith<IllegalStateException> { AppConfig.fromMap(env).validate() }
+        assertTrue(ex.message!!.contains("PUBLIC_BASE_URL"))
+    }
+
+    @Test
+    fun `data dir that is not a directory throws`() {
+        val file = Files.createTempFile("as-config", ".txt")
+        val env = base + mapOf("DATA_DIR" to file.toString())
+        val ex = assertFailsWith<IllegalStateException> { AppConfig.fromMap(env).validate() }
+        assertTrue(ex.message!!.contains("DATA_DIR"))
+        Files.deleteIfExists(file)
+    }
+
+    @Test
+    fun `oauth half configured throws`() {
+        val env = base + mapOf("GITHUB_OAUTH_CLIENT_ID" to "only-id")
+        val ex = assertFailsWith<IllegalStateException> { AppConfig.fromMap(env) }
+        assertTrue(ex.message!!.contains("GitHub OAuth"))
+        assertTrue(ex.message!!.contains("GITHUB_OAUTH_CLIENT_SECRET"))
+    }
+
+    @Test
+    fun `llm half configured throws`() {
+        val env = base + mapOf(
+            "LLM_BASE_URL" to "https://api.example.com",
+            "LLM_API_KEY" to "sk-secret",
+        )
+        val ex = assertFailsWith<IllegalStateException> { AppConfig.fromMap(env) }
+        assertTrue(ex.message!!.contains("LLM"))
+        assertTrue(ex.message!!.contains("LLM_MODEL"))
+    }
+
+    @Test
+    fun `github app half configured throws`() {
+        val env = base + mapOf(
+            "GITHUB_APP_ID" to "123456",
+            "GITHUB_APP_PRIVATE_KEY" to "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----",
+        )
+        val ex = assertFailsWith<IllegalStateException> { AppConfig.fromMap(env) }
+        assertTrue(ex.message!!.contains("GitHub App"))
+        assertTrue(ex.message!!.contains("GITHUB_WEBHOOK_SECRET"))
+    }
+
+    @Test
+    fun `all features absent disables cleanly`() {
+        val cfg = AppConfig.fromMap(base)
+        cfg.validate()
+        assertNull(cfg.auth.oauth)
+        assertNull(cfg.llmBaseUrl)
+        assertEquals(false, cfg.githubApp.configured)
+    }
+
+    @Test
+    fun `toString does not leak secrets`() {
+        val env = base + mapOf(
+            "GITHUB_OAUTH_CLIENT_ID" to "client-id",
+            "GITHUB_OAUTH_CLIENT_SECRET" to "client-secret",
+            "GITHUB_APP_ID" to "123456",
+            "GITHUB_APP_PRIVATE_KEY" to "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----",
+            "GITHUB_WEBHOOK_SECRET" to "wh-secret",
+            "LLM_BASE_URL" to "https://api.example.com",
+            "LLM_API_KEY" to "sk-secret",
+            "LLM_MODEL" to "model",
+        )
+        val cfg = AppConfig.fromMap(env)
+        val text = cfg.toString()
+        assertTrue(!text.contains("sk-secret"))
+        assertTrue(!text.contains("client-secret"))
+        assertTrue(!text.contains("BEGIN RSA PRIVATE KEY"))
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/AppConfigTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/AppConfigTest.kt
@@ -78,6 +78,18 @@ class AppConfigTest {
     }
 
     @Test
+    fun `github app id must be numeric`() {
+        val env = base + mapOf(
+            "GITHUB_APP_ID" to "not-a-number",
+            "GITHUB_APP_PRIVATE_KEY" to "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----",
+            "GITHUB_WEBHOOK_SECRET" to "wh-secret",
+        )
+        val ex = assertFailsWith<IllegalStateException> { AppConfig.fromMap(env) }
+        assertTrue(ex.message!!.contains("GITHUB_APP_ID"))
+        assertTrue(ex.message!!.contains("numeric"))
+    }
+
+    @Test
     fun `github app half configured throws`() {
         val env = base + mapOf(
             "GITHUB_APP_ID" to "123456",

--- a/api/src/test/kotlin/dev/androidskills/BootSafetyTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/BootSafetyTest.kt
@@ -1,0 +1,37 @@
+package dev.androidskills
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class BootSafetyTest {
+
+    @Test
+    fun `module fails fast when data dir is not writable`() {
+        val file = Files.createTempFile("as-boot-test", ".txt")
+        val env = mapOf(
+            "DATA_DIR" to file.toString(),
+            "PUBLIC_BASE_URL" to "http://localhost:8080",
+        )
+        val ex = assertFailsWith<IllegalStateException> {
+            AppConfig.fromMap(env).validate()
+        }
+        assertTrue(ex.message!!.contains("DATA_DIR"))
+        Files.deleteIfExists(file)
+    }
+
+    @Test
+    fun `module fails fast when public base url is invalid`() {
+        val dir = Files.createTempDirectory("as-boot-test")
+        val env = mapOf(
+            "DATA_DIR" to dir.toString(),
+            "PUBLIC_BASE_URL" to "not a url",
+        )
+        val ex = assertFailsWith<IllegalStateException> {
+            AppConfig.fromMap(env).validate()
+        }
+        assertTrue(ex.message!!.contains("PUBLIC_BASE_URL"))
+        Files.deleteIfExists(dir)
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/ClientIpTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ClientIpTest.kt
@@ -35,13 +35,13 @@ class ClientIpTest {
     }
 
     @Test
-    fun `falls back to x-real-ip`() = testApplication {
+    fun `falls back to remote host when X-Forwarded-For is missing`() = testApplication {
         routing {
             get("/ip") { call.respondText(clientIp(call, 1)) }
         }
-        val res = client.get("/ip") {
-            headers.append("X-Real-Ip", "2.3.4.5")
-        }
-        assertEquals("2.3.4.5", res.bodyAsText())
+        val res = client.get("/ip")
+        // Test engine reports remoteHost as "localhost"; key point is that a
+        // missing X-Forwarded-For does not allow a client-spoofed X-Real-Ip.
+        assertEquals("localhost", res.bodyAsText())
     }
 }

--- a/api/src/test/kotlin/dev/androidskills/ClientIpTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ClientIpTest.kt
@@ -1,0 +1,47 @@
+package dev.androidskills
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClientIpTest {
+
+    @Test
+    fun `uses last x-forwarded-for entry with one trusted proxy`() = testApplication {
+        routing {
+            get("/ip") { call.respondText(clientIp(call, 1)) }
+        }
+        val res = client.get("/ip") {
+            headers.append(HttpHeaders.XForwardedFor, "1.2.3.4, 5.6.7.8")
+        }
+        assertEquals("5.6.7.8", res.bodyAsText())
+    }
+
+    @Test
+    fun `uses entry before trusted proxies with count two`() = testApplication {
+        routing {
+            get("/ip") { call.respondText(clientIp(call, 2)) }
+        }
+        val res = client.get("/ip") {
+            headers.append(HttpHeaders.XForwardedFor, "1.2.3.4, 5.6.7.8, 9.10.11.12")
+        }
+        assertEquals("5.6.7.8", res.bodyAsText())
+    }
+
+    @Test
+    fun `falls back to x-real-ip`() = testApplication {
+        routing {
+            get("/ip") { call.respondText(clientIp(call, 1)) }
+        }
+        val res = client.get("/ip") {
+            headers.append("X-Real-Ip", "2.3.4.5")
+        }
+        assertEquals("2.3.4.5", res.bodyAsText())
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/HealthRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/HealthRoutesTest.kt
@@ -1,0 +1,104 @@
+package dev.androidskills.api
+
+import dev.androidskills.AppConfig
+import dev.androidskills.AuthConfig
+import dev.androidskills.GithubAppConfig
+import dev.androidskills.TestSupport
+import dev.androidskills.module
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HealthRoutesTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `basic health is unchanged`() = testApplication {
+        application { module(TestSupport.newConfig(dir)) }
+        val response = client.get("/api/health")
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"ok\":true"))
+        assertTrue(body.contains("\"version\""))
+        assertTrue(body.contains("\"db\""))
+        assertTrue(body.contains("\"fileStore\""))
+        assertTrue(body.contains("\"llm\""))
+        assertTrue(body.contains("\"auth\""))
+    }
+
+    @Test
+    fun `deep health returns ok for minimal config`() = testApplication {
+        application { module(TestSupport.newConfig(dir)) }
+        val response = client.get("/api/health/deep")
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"status\":\"ok\""))
+        assertTrue(body.contains("\"database\":true"))
+        assertTrue(body.contains("\"fileStore\":true"))
+        assertTrue(body.contains("\"githubApp\":true"))
+        assertTrue(body.contains("\"llm\":true"))
+    }
+
+    @Test
+    fun `deep health reports degraded when github app key is invalid`() = testApplication {
+        val config = TestSupport.newConfig(dir).copy(
+            githubApp = GithubAppConfig(
+                appId = 123456L,
+                privateKeyPem = "not a valid pem",
+                webhookSecret = "secret",
+            ),
+        )
+        application { module(config) }
+        val response = client.get("/api/health/deep")
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"status\":\"degraded\""))
+        assertTrue(body.contains("\"githubApp\":false"))
+    }
+
+    @Test
+    fun `deep health reports degraded when llm url is invalid`() = testApplication {
+        val config = TestSupport.newConfig(dir).copy(
+            llmBaseUrl = "not a url",
+            llmApiKey = "sk-secret",
+            llmModel = "model",
+        )
+        application { module(config) }
+        val response = client.get("/api/health/deep")
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"status\":\"degraded\""))
+        assertTrue(body.contains("\"llm\":false"))
+    }
+
+    @Test
+    fun `deep health does not leak secrets`() = testApplication {
+        val config = TestSupport.newConfig(dir).copy(
+            llmBaseUrl = "https://api.example.com",
+            llmApiKey = "sk-secret",
+            llmModel = "model",
+            githubApp = GithubAppConfig(
+                appId = 123456L,
+                privateKeyPem = "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----",
+                webhookSecret = "wh-secret",
+            ),
+        )
+        application { module(config) }
+        val body = client.get("/api/health/deep").bodyAsText()
+        assertFalse(body.contains("sk-secret"))
+        assertFalse(body.contains("wh-secret"))
+        assertFalse(body.contains("BEGIN RSA PRIVATE KEY"))
+    }
+}

--- a/api/src/test/kotlin/dev/androidskills/api/RateLimitTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/RateLimitTest.kt
@@ -1,0 +1,189 @@
+package dev.androidskills.api
+
+import dev.androidskills.AppConfig
+import dev.androidskills.Database
+import dev.androidskills.TestSupport
+import dev.androidskills.clientIp
+import dev.androidskills.storage.LocalFsStore
+import dev.androidskills.auth.DisabledOAuthClient
+import dev.androidskills.auth.authRoutes
+import dev.androidskills.github.DisabledGitHubAppClient
+import dev.androidskills.gh.webhookRoutes
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.plugins.ratelimit.RateLimitConfig
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class RateLimitTest {
+
+    private val dir = TestSupport.tempDir()
+
+    @AfterTest
+    fun teardown() {
+        dir.toFile().deleteRecursively()
+    }
+
+    private fun Application.testModule(
+        config: AppConfig,
+        configureRateLimit: RateLimitConfig.() -> Unit,
+        routeSetup: Route.() -> Unit,
+    ) {
+        install(ContentNegotiation) { json() }
+        installApiErrorMapping()
+        install(RateLimit) { configureRateLimit() }
+        routing { routeSetup() }
+    }
+
+    @Test
+    fun `public route returns 429 with standard error body`() = testApplication {
+        val config = TestSupport.newConfig(dir)
+        Database.init(config)
+        application {
+            testModule(
+                config,
+                {
+                    register(RateLimitName("public")) {
+                        rateLimiter(limit = 2, refillPeriod = 60.seconds)
+                        requestKey { "shared" }
+                    }
+                },
+                { publicRoutes(LocalFsStore(dir.resolve("files"))) },
+            )
+        }
+        client.get("/api/skills")
+        client.get("/api/skills")
+        val third = client.get("/api/skills")
+        assertEquals(HttpStatusCode.TooManyRequests, third.status)
+        assertTrue(third.bodyAsText().contains("\"error\""))
+        assertTrue(third.bodyAsText().contains("rate_limit"))
+        assertTrue(third.headers["Retry-After"] != null)
+    }
+
+    @Test
+    fun `health endpoint is exempt from rate limiting`() = testApplication {
+        val config = TestSupport.newConfig(dir)
+        Database.init(config)
+        application {
+            testModule(
+                config,
+                {
+                    register(RateLimitName("public")) {
+                        rateLimiter(limit = 1, refillPeriod = 60.seconds)
+                        requestKey { "shared" }
+                    }
+                },
+                {
+                    get("/api/health") { call.respond(mapOf("ok" to true)) }
+                    publicRoutes(LocalFsStore(dir.resolve("files")))
+                },
+            )
+        }
+        val first = client.get("/api/health")
+        val second = client.get("/api/health")
+        assertEquals(HttpStatusCode.OK, first.status)
+        assertEquals(HttpStatusCode.OK, second.status)
+    }
+
+    @Test
+    fun `webhook endpoint is exempt from ip rate limiting`() = testApplication {
+        val config = TestSupport.newConfig(dir)
+        Database.init(config)
+        application {
+            testModule(
+                config,
+                {
+                    register(RateLimitName("public")) {
+                        rateLimiter(limit = 1, refillPeriod = 60.seconds)
+                        requestKey { "shared" }
+                    }
+                },
+                { webhookRoutes(DisabledGitHubAppClient()) },
+            )
+        }
+        val first = client.post("/gh/webhooks")
+        val second = client.post("/gh/webhooks")
+        assertEquals(HttpStatusCode.Unauthorized, first.status)
+        assertEquals(HttpStatusCode.Unauthorized, second.status)
+    }
+
+    @Test
+    fun `me route uses authenticated tier not auth tier`() = testApplication {
+        val config = TestSupport.newConfig(dir)
+        Database.init(config)
+        application {
+            testModule(
+                config,
+                {
+                    register(RateLimitName("auth")) {
+                        rateLimiter(limit = 1, refillPeriod = 60.seconds)
+                        requestKey { "shared" }
+                    }
+                    register(RateLimitName("authenticated")) {
+                        rateLimiter(limit = 3, refillPeriod = 60.seconds)
+                        requestKey { "shared" }
+                    }
+                },
+                { authRoutes(config, DisabledOAuthClient()) },
+            )
+        }
+        // /api/me is in the authenticated tier, so 3 anonymous requests still
+        // return 401; they are not blocked by the tighter auth bucket.
+        repeat(3) {
+            val res = client.get("/api/me")
+            assertEquals(HttpStatusCode.Unauthorized, res.status)
+        }
+        // /api/auth/github/start is in the auth tier; second request is 429.
+        val start1 = client.get("/api/auth/github/start")
+        assertEquals(HttpStatusCode.ServiceUnavailable, start1.status)
+        val start2 = client.get("/api/auth/github/start")
+        assertEquals(HttpStatusCode.TooManyRequests, start2.status)
+    }
+
+    @Test
+    fun `different x-forwarded-for ips have separate buckets`() = testApplication {
+        val config = TestSupport.newConfig(dir)
+        Database.init(config)
+        application {
+            testModule(
+                config,
+                {
+                    register(RateLimitName("public")) {
+                        rateLimiter(limit = 1, refillPeriod = 60.seconds)
+                        requestKey { call -> clientIp(call, 1) }
+                    }
+                },
+                { publicRoutes(LocalFsStore(dir.resolve("files"))) },
+            )
+        }
+        val first = client.get("/api/skills") {
+            headers.append(HttpHeaders.XForwardedFor, "1.2.3.4")
+        }
+        val second = client.get("/api/skills") {
+            headers.append(HttpHeaders.XForwardedFor, "5.6.7.8")
+        }
+        val third = client.get("/api/skills") {
+            headers.append(HttpHeaders.XForwardedFor, "1.2.3.4")
+        }
+        assertEquals(HttpStatusCode.OK, first.status)
+        assertEquals(HttpStatusCode.OK, second.status)
+        assertEquals(HttpStatusCode.TooManyRequests, third.status)
+    }
+}


### PR DESCRIPTION
Implements Step 8 operational hardening on top of `develop` (post X-seam fixes).

### What’s in the box

- **Fail-fast env validation** (`AppConfig.validate()`): requires `DATA_DIR` + `PUBLIC_BASE_URL`, and enforces all-or-nothing OAuth / GitHub App / LLM feature sets. Adds `.env.example` and README config section.
- **Deep health endpoint** (`GET /api/health/deep`): cheap, local read-only checks for DB, file store, GitHub-App PEM, and LLM config. Returns 200 when healthy, 503 when a configured dependency fails. The existing `/api/health` stays unchanged for LB/Kamal probes.
- **IP-based rate limiting**: Ktor `RateLimit` plugin with `public` / `auth` / `authenticated` / `admin` tiers. Keyed to the last value of `X-Forwarded-For` (the kamal-proxy hop) with `TRUSTED_PROXY_COUNT` fallback. Health and `/gh/webhooks` endpoints are exempt.
- **429 error mapping**: `StatusPages` now emits the standard `ErrorResponse` envelope and preserves the `Retry-After` header.
- **Startup banner**: logs version, data dir, journal mode, store type, feature flags, and health URL after migrations.

### Test coverage

261 tests, all green.

- `AppConfigTest` — env validation, half-configured feature failures, secret redaction.
- `HealthRoutesTest` — basic health unchanged, deep health 200/503, no secret leaks.
- `ClientIpTest` + `RateLimitTest` — XFF extraction, per-IP buckets, tier separation, health/webhook exemptions.
- `BootSafetyTest` — fail-fast on invalid `DATA_DIR` / `PUBLIC_BASE_URL`.

### Notes

- OpenAPI contract (commit 5 in the plan) is intentionally deferred; it can be added once the Astro frontend is ready to consume it.
