### PR TITLE
feat(staging): local + Proxmox staging via Cloudflare Tunnel + Access

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,56 @@
+name: Build images
+
+# Builds and pushes the api and web container images to GHCR so staging (and,
+# later, prod) can pull a real CI-built artifact instead of building on the host.
+#
+# NOTE: this is the first image-push pipeline in the repo. Prod currently builds
+# per-service on the VPS via Kamal; reconciling prod onto these images is a
+# follow-up (see .plans/STAGING-PLAN.md, D7 / R1).
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/code-with-the-italians/androidskills
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: api
+            context: ./api
+          - service: web
+            context: ./web
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.service }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-${{ matrix.service }}:develop
+            ${{ env.IMAGE_PREFIX }}-${{ matrix.service }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local runtime data (sqlite db + local file store) — never committed
 /data/
 
+# Staging secrets (tunnel token + GitHub App creds); only the .example is committed
+deploy/staging/.env.staging
+
 # Node / Astro
 web/node_modules/
 web/dist/

--- a/deploy/staging/.env.staging.example
+++ b/deploy/staging/.env.staging.example
@@ -1,0 +1,82 @@
+# staging.androidskills.dev environment — copy to .env.staging and fill in.
+#
+#   cp .env.staging.example .env.staging
+#
+# .env.staging is git-ignored (it holds the tunnel token + GitHub App secrets).
+# Load order matters: `docker compose` interpolates ${...} in the compose file
+# from --env-file / the shell, NOT from a service's `env_file:`. So always pass
+# --env-file .env.staging on the command line.
+
+# ---------------------------------------------------------------------------
+# Image selection
+# ---------------------------------------------------------------------------
+
+# Image tag to pull. CI pushes :develop and :<sha> on pushes to develop.
+TAG=develop
+# Override only if you fork the registry namespace.
+# IMAGE_PREFIX=ghcr.io/code-with-the-italians/androidskills
+
+# ---------------------------------------------------------------------------
+# Canonical URL + proxy posture
+# ---------------------------------------------------------------------------
+
+# Deployed staging: https://staging.androidskills.dev
+# LOCAL TEST (no tunnel): set to http://localhost:4321 instead.
+# Must be a bare scheme://host[:port] with no path (validated at boot).
+PUBLIC_BASE_URL=https://staging.androidskills.dev
+
+# Trusted reverse-proxy hops in front of Ktor (rate-limit source-IP keying only).
+# 1 is correct behind Cloudflare + the Astro proxy (same as prod). Low-stakes.
+TRUSTED_PROXY_COUNT=1
+
+# ---------------------------------------------------------------------------
+# Cloudflare Tunnel (deployed staging only; leave blank for a local test)
+# ---------------------------------------------------------------------------
+
+# Token from the `staging` tunnel in Cloudflare Zero Trust → Networks → Tunnels.
+CF_TUNNEL_TOKEN=
+
+# ---------------------------------------------------------------------------
+# GitHub App (login + repo scan + webhooks) — ONE dedicated staging GitHub App
+# ---------------------------------------------------------------------------
+# Per the single-App invariant, all five come from the SAME staging GitHub App
+# (do NOT create a separate OAuth App). Its callback + webhook URL must point at
+# https://staging.androidskills.dev/... Leave ALL blank to run staging with GitHub
+# features cleanly disabled.
+
+GITHUB_OAUTH_CLIENT_ID=
+GITHUB_OAUTH_CLIENT_SECRET=
+GITHUB_APP_ID=
+
+# PEM private key exported from the GitHub App. IMPORTANT quoting:
+# Docker Compose only expands \n inside DOUBLE-quoted env-file values. Put the key
+# on one line, double-quoted, with literal \n between armor lines, e.g.:
+#   GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n...==\n-----END RSA PRIVATE KEY-----\n"
+# A mis-quoted key silently corrupts and shows as `githubApp: false` at
+# GET /api/health/deep — verify that endpoint after boot.
+GITHUB_APP_PRIVATE_KEY=
+
+GITHUB_WEBHOOK_SECRET=
+
+# ---------------------------------------------------------------------------
+# Cold-start admin (staging convenience)
+# ---------------------------------------------------------------------------
+# SEED_DEMO seeds skills, NOT an admin. Set this to your numeric GitHub user id so
+# your first login is promoted to admin and admin routes are testable.
+BOOTSTRAP_ADMIN_GITHUB_ID=
+
+# ---------------------------------------------------------------------------
+# LLM review worker (optional) — all three-or-none
+# ---------------------------------------------------------------------------
+
+LLM_BASE_URL=
+LLM_API_KEY=
+LLM_MODEL=
+
+# ---------------------------------------------------------------------------
+# Litestream / R2 — INTENTIONALLY UNSET in staging.
+# ---------------------------------------------------------------------------
+# With no R2_* vars, api/entrypoint.sh runs Ktor without Litestream (ephemeral,
+# seeded SQLite on the staging-data volume). Do NOT point these at prod's bucket
+# or backup path. If you ever want to exercise backup/restore, use a SEPARATE
+# bucket or a distinct R2_BACKUP_PATH (e.g. androidskills/staging/db).

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -1,0 +1,108 @@
+# Staging — staging.androidskills.dev
+
+A private staging environment: the same CI-built images, run with Docker Compose on
+a Proxmox LXC, exposed **only** through a Cloudflare Tunnel + Cloudflare Access
+limited to two emails. No inbound ports are opened on the host.
+
+Full rationale and the reviewed design decisions live in `.plans/STAGING-PLAN.md`.
+
+## Topology
+
+```
+Browser ──TLS──► Cloudflare edge ──► Cloudflare Tunnel ──► cloudflared ──► web (Astro :4321) ──► api (Ktor :8080)
+ (2 emails)          │  Access                (outbound-only)      proxies /api/* and /gh/*      SQLite volume
+                     ▼                                                                            (Litestream OFF)
+              Access gate: allow the 2 emails; bypass /gh/webhooks (HMAC-verified)
+```
+
+- `api` is **never** published to the host — internal compose network only (`api:8080`).
+- Litestream/R2 are **off** in staging; data is ephemeral + `SEED_DEMO=1`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.staging.yml` | The three services (`init-data`, `api`, `web`, `cloudflared` behind a `tunnel` profile). |
+| `.env.staging.example` | Copy to `.env.staging` (git-ignored) and fill in. |
+
+## 1. Local test (no tunnel, no Access)
+
+Proves the two-service wiring before anything is exposed.
+
+```bash
+cd deploy/staging
+cp .env.staging.example .env.staging
+# edit .env.staging: PUBLIC_BASE_URL=http://localhost:4321 (leave CF_TUNNEL_TOKEN blank)
+docker compose --env-file .env.staging -f docker-compose.staging.yml up
+```
+
+Then verify at `http://localhost:4321`:
+
+- Site loads; `/api/*` and `/gh/*` reach Ktor through the Astro proxy.
+- `curl http://localhost:4321/api/health` → healthy.
+- `curl http://localhost:4321/api/health/deep` → all green. **If `githubApp` is false**, the
+  multi-line `GITHUB_APP_PRIVATE_KEY` is mis-quoted (see `.env.staging.example`).
+
+> `${...}` in the compose file interpolate from `--env-file` / the shell, **not** from the
+> service `env_file:` — always pass `--env-file .env.staging`. A missing `PUBLIC_BASE_URL`
+> fails loudly at compose time (`:?` guard) instead of silently defaulting to localhost.
+> `CF_TUNNEL_TOKEN` may be left blank for a local run; it is only validated by cloudflared
+> when the `tunnel` profile is active.
+
+## 2. Cloudflare setup (one-time)
+
+**Tunnel** — Zero Trust → Networks → Tunnels → create `staging`. Add a public hostname:
+`staging.androidskills.dev` → service `http://web:4321`. This auto-creates the proxied DNS
+record. Copy the tunnel token into `CF_TUNNEL_TOKEN` in `.env.staging`.
+
+**Access — two applications** (path scoping lives on the *application*, most-specific wins):
+
+1. App `staging.androidskills.dev` → policy **Allow** emails `poggos@gmail.com`,
+   `imorgillo@gmail.com` (Google login or one-time PIN). Gates everything.
+2. App `staging.androidskills.dev/gh/webhooks` → policy **Bypass (Everyone)**. Required, or
+   GitHub's webhook POSTs (no Access cookie) get 302'd to SSO. Safe: Ktor verifies the
+   `X-Hub-Signature-256` HMAC. Scope this exact path — it is the app's only `/gh` route.
+
+**Staging GitHub App** — register ONE GitHub App (not a separate OAuth App) with callback +
+webhook at `https://staging.androidskills.dev/...`. Put all five creds in `.env.staging`
+(`GITHUB_OAUTH_CLIENT_ID/SECRET`, `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`,
+`GITHUB_WEBHOOK_SECRET`).
+
+## 3. Deploy on the Proxmox LXC
+
+1. **Container** — unprivileged LXC, enable `nesting=1` and `keyctl=1` (needed for Docker).
+   If overlay2 misbehaves under the unprivileged container, use `fuse-overlayfs` or run a VM.
+   Open **no** inbound ports — the tunnel is outbound-only.
+2. **Docker** — install Docker Engine + the compose plugin.
+3. **GHCR auth** — packages are private by default:
+   ```bash
+   echo "$GHCR_PAT" | docker login ghcr.io -u <user> --password-stdin   # read:packages PAT
+   ```
+4. **Deploy** — copy this directory + your filled `.env.staging`, then:
+   ```bash
+   cd deploy/staging
+   docker compose --env-file .env.staging -f docker-compose.staging.yml --profile tunnel pull
+   docker compose --env-file .env.staging -f docker-compose.staging.yml --profile tunnel up -d
+   ```
+
+## 4. Verify deployed
+
+- Visiting `https://staging.androidskills.dev` with a non-listed email is refused; the two
+  allowed emails get in.
+- GitHub OAuth round-trips (edge case: an Access session expiring while you idle on GitHub's
+  authorize page forces re-auth on the callback).
+- A signed test webhook (`X-Hub-Signature-256`) reaches Ktor via the bypass app.
+- `/api/health/deep` all green; admin routes reachable (via `BOOTSTRAP_ADMIN_GITHUB_ID`).
+
+## Updating
+
+CI pushes `:develop` (and `:<sha>`) on every push to `develop`. To roll staging forward:
+
+```bash
+docker compose --env-file .env.staging -f docker-compose.staging.yml --profile tunnel pull
+docker compose --env-file .env.staging -f docker-compose.staging.yml --profile tunnel up -d
+```
+
+`watchtower` can automate this, but it will re-flash staging mid-QA on every develop push —
+manual pull is usually preferable. `up -d` recreates stop-then-start, preserving the SQLite
+single-writer invariant.

--- a/deploy/staging/docker-compose.staging.yml
+++ b/deploy/staging/docker-compose.staging.yml
@@ -1,0 +1,85 @@
+# Staging topology for androidskills.dev — see deploy/staging/README.md
+#
+# One file, two run modes:
+#   Local test : docker compose --env-file .env.staging -f docker-compose.staging.yml up
+#   Deployed   : docker compose --env-file .env.staging -f docker-compose.staging.yml --profile tunnel up -d
+#
+# The api service is NEVER published to the host; it is reachable only on the
+# internal compose network as `api:8080`. The only public door is the Cloudflare
+# Tunnel (cloudflared), which dials OUT — no inbound ports are opened on the host.
+
+services:
+  # One-shot: the named volume mounts root:root, but the api image runs as UID 1000
+  # and fail-fasts at boot if /data is not writable (AppConfig.ensureWritable → exit →
+  # restart-loop). Chown the volume once before api starts. Runs as root; keeps CAP_CHOWN.
+  init-data:
+    image: busybox:1.36
+    user: "0:0"
+    command: chown -R 1000:1000 /data
+    volumes:
+      - staging-data:/data
+    security_opt:
+      - no-new-privileges:true
+
+  api:
+    image: ${IMAGE_PREFIX:-ghcr.io/code-with-the-italians/androidskills}-api:${TAG:-develop}
+    env_file: .env.staging
+    environment:
+      DATA_DIR: /data
+      # :? makes a missing/blank value fail loudly. Without it, a blank PUBLIC_BASE_URL
+      # silently defaults to http://localhost:8080 (wrong OAuth redirect_uri, Secure=false).
+      PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:?set PUBLIC_BASE_URL in .env.staging}
+      TRUSTED_PROXY_COUNT: ${TRUSTED_PROXY_COUNT:-1}
+      # Staging seeds demo data into an empty DB and runs WITHOUT Litestream (R2 unset).
+      SEED_DEMO: "1"
+    volumes:
+      - staging-data:/data
+    # Not published to the host — internal compose network only.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    mem_limit: 768m
+    depends_on:
+      init-data:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  web:
+    image: ${IMAGE_PREFIX:-ghcr.io/code-with-the-italians/androidskills}-web:${TAG:-develop}
+    environment:
+      # Astro proxies /api/* and /gh/* here (compose DNS, not 127.0.0.1). The web
+      # service reads only API_URL at runtime; PUBLIC_BASE_URL would be a no-op here.
+      API_URL: http://api:8080
+    ports:
+      # Local-test door. Bound to loopback so it is harmless on the LXC (the tunnel
+      # reaches web over the internal network and bypasses this mapping).
+      - "127.0.0.1:4321:4321"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    mem_limit: 512m
+    depends_on:
+      - api
+    restart: unless-stopped
+
+  cloudflared:
+    # Pin a version — never :latest — so a staging redeploy is reproducible.
+    image: cloudflare/cloudflared:2024.10.0
+    command: tunnel --no-autoupdate run
+    environment:
+      # Defaults to empty so a local (no-tunnel) run works even with CF_TUNNEL_TOKEN
+      # unset — Compose interpolates the whole file eagerly, so a :? guard here would
+      # wrongly fail the base mode. When the tunnel profile IS used, cloudflared exits
+      # loudly on an empty/invalid token (check `docker compose logs cloudflared`).
+      TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN:-}
+    # Only starts with `--profile tunnel`; omit the profile for a local test.
+    profiles:
+      - tunnel
+    depends_on:
+      - web
+    restart: unless-stopped
+
+volumes:
+  staging-data:


### PR DESCRIPTION
## What

Adds a **staging environment** for `staging.androidskills.dev`: the same CI-built container images, run with Docker Compose on a Proxmox LXC (or locally), exposed only through a **Cloudflare Tunnel + Cloudflare Access** (two accounts), with **no inbound ports** on the host. Also adds the first **GHCR build-push** pipeline so staging pulls a real CI artifact.

Full design + reasoning live in `.plans/STAGING-PLAN.md` (agent notes, not committed).

## Files

- `deploy/staging/docker-compose.staging.yml` — `init-data` chown one-shot, internal-only `api`, loopback-bound `web`, `cloudflared` behind a `tunnel` profile; `cap_drop`/`no-new-privileges` hardening.
- `deploy/staging/.env.staging.example` — env surface (R2 off + seeded data, one dedicated GitHub App, multi-line PEM-quoting note, admin bootstrap).
- `deploy/staging/README.md` — local-test → Cloudflare (two Access apps) → Proxmox LXC runbook.
- `.github/workflows/build-images.yml` — build + push `-api`/`-web` `:develop`+`:sha` to GHCR on pushes to `develop`.
- `.gitignore` — never commit the real `deploy/staging/.env.staging`.

## Design highlights

- **Data isolation:** R2/Litestream off in staging; ephemeral seeded SQLite (`SEED_DEMO=1`) — no path can touch prod's replica.
- **Access + webhooks:** two Access apps — allow the two accounts everywhere; **bypass** `/gh/webhooks` (the app's only machine-to-machine route), safe via the `X-Hub-Signature-256` HMAC.
- **One GitHub App** supplies all five creds (single-App invariant), so login *and* webhooks work in staging.
- **Same compose file** runs both the local no-tunnel test and deployed tunnel mode; only `.env` + the `tunnel` profile differ. `PUBLIC_BASE_URL` is hard-guarded; `CF_TUNNEL_TOKEN` is optional so local runs need no token.

## Verified locally (Docker 29 / Compose v5)

- Both images build; stack boots — `init-data` fixes a root-owned `/data` boot crash for the UID-1000 api.
- `web`→`api` proxy live; `/api/health` + `/api/health/deep` green.
- Home / Search / Skill-detail pages render (Playwright/Chromium) against seeded demo data.

## Follow-ups (not in this PR)

- Reconcile **prod** onto this image pipeline (prod currently builds per-service on the VPS via Kamal; see `.plans/STAGING-PLAN.md` R1). Until then `:develop` images are a distinct artifact path.
- First GHCR push creates **private** packages; the LXC needs a `docker login ghcr.io` read-only PAT (documented in the runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
