### PR TITLE
Step 10 Phase 2: Remaining public surfaces + markdown sanitizer tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: TypeScript check
         working-directory: ./web
         run: npx tsc --noEmit
+      - name: Run markdown sanitizer tests
+        working-directory: ./web
+        run: npm test
       - name: Build Astro
         working-directory: ./web
         run: npm run build

--- a/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/UsersRepo.kt
@@ -32,9 +32,10 @@ data class GitHubUser(
  */
 object UsersRepo {
   /**
-   * Upsert with a bounded retry for the one realistic race: two concurrent logins resolving the
-   * same recycled handle both pass check-then-insert and the second violates `uq_users_handle`. On
-   * that specific error we retry — the next [uniqueHandle] call sees the winner's row. (P2-2b.)
+   * Upsert with a bounded retry for the realistic concurrency races under WAL: another writer wins
+   * the commit (SQLITE_BUSY / SQLITE_BUSY_SNAPSHOT) or two logins resolve the same recycled handle
+   * and the second violates `uq_users_handle`. On those specific errors we retry — the next
+   * [uniqueHandle] call sees the winner's row. (P2-2b.)
    */
   fun upsertFromGitHub(user: GitHubUser, bootstrapAdminGithubId: Long?): String {
     var attempt = 0
@@ -42,16 +43,18 @@ object UsersRepo {
       try {
         return upsertOnce(user, bootstrapAdminGithubId)
       } catch (e: org.jetbrains.exposed.exceptions.ExposedSQLException) {
-        if (++attempt > MAX_HANDLE_RETRIES || !isUniqueHandleViolation(e)) throw e
+        if (++attempt > MAX_HANDLE_RETRIES || !isRetryableConcurrencyError(e)) throw e
       }
     }
   }
 
   private const val MAX_HANDLE_RETRIES = 3
 
-  private fun isUniqueHandleViolation(
+  private fun isRetryableConcurrencyError(
     e: org.jetbrains.exposed.exceptions.ExposedSQLException
   ): Boolean {
+    val errorCode = (e.cause as? java.sql.SQLException)?.errorCode
+    if (errorCode == 5 || errorCode == 261) return true // SQLITE_BUSY, SQLITE_BUSY_SNAPSHOT
     val text = buildString {
       append(e.message)
       append(' ')

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,6 +29,7 @@
         "globals": "^17.7.0",
         "openapi-typescript": "^7.13.0",
         "prettier": "^3.9.4",
+        "tsx": "^4.23.0",
         "typescript": "^5.9.3"
       }
     },
@@ -6835,6 +6836,483 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
+    "test": "node --test --import tsx src/lib/markdown.test.ts",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
@@ -35,6 +36,7 @@
     "globals": "^17.7.0",
     "openapi-typescript": "^7.13.0",
     "prettier": "^3.9.4",
+    "tsx": "^4.23.0",
     "typescript": "^5.9.3"
   }
 }

--- a/web/src/components/Avatar.astro
+++ b/web/src/components/Avatar.astro
@@ -1,0 +1,14 @@
+---
+interface Props {
+  src?: string;
+  name: string;
+  size?: 'sm' | 'lg';
+}
+const { src, name, size } = Astro.props;
+const initials = name.split(/\s+/).slice(0, 2).map((w) => w[0]).join('').toUpperCase();
+---
+{src ? (
+  <img class={`avatar ${size ?? ''}`} src={src} alt={name} />
+) : (
+  <div class={`avatar ${size ?? ''}`}>{initials}</div>
+)}

--- a/web/src/components/BarChart.astro
+++ b/web/src/components/BarChart.astro
@@ -1,0 +1,26 @@
+---
+import type { components } from '../lib/api-types';
+type FacetCount = components['schemas']['FacetCount'];
+
+interface Props {
+  title: string;
+  data: FacetCount[];
+  max?: number;
+}
+const { title, data, max } = Astro.props;
+const top = max ?? Math.max(...data.map((d) => d.count), 1);
+---
+<div class="card">
+  <h4 style="font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--text-faint);margin-bottom:16px;">{title}</h4>
+  <div style="display:flex;flex-direction:column;gap:10px;">
+    {data.slice(0, 10).map((item) => (
+      <div class="bar-row" style="display:flex;align-items:center;gap:12px;">
+        <span style="width:120px;font-size:13px;color:var(--text-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{item.label ?? item.key}</span>
+        <div class="bar-track" style="flex:1;height:8px;border-radius:999px;background:var(--surface-2);overflow:hidden;">
+          <div class="bar-fill" style={`height:100%;width:${Math.round((item.count / top) * 100)}%;background:var(--accent);border-radius:999px;`}></div>
+        </div>
+        <span style="font-family:var(--mono);font-size:12px;color:var(--text-faint);width:36px;text-align:right;">{item.count}</span>
+      </div>
+    ))}
+  </div>
+</div>

--- a/web/src/components/StatTile.astro
+++ b/web/src/components/StatTile.astro
@@ -1,0 +1,20 @@
+---
+interface Props {
+  value: string | number;
+  label: string;
+  delta?: string;
+  deltaDir?: 'up' | 'down' | 'flat';
+}
+const { value, label, delta, deltaDir } = Astro.props;
+---
+<div class="stat">
+  <span class="n">{typeof value === 'number' ? value.toLocaleString() : value}</span>
+  <span class="l">{label}</span>
+  {delta && (
+    <span class="faint" style="font-size:11px;margin-top:2px;">
+      {deltaDir === 'up' && '▲ '}
+      {deltaDir === 'down' && '▼ '}
+      {delta}
+    </span>
+  )}
+</div>

--- a/web/src/components/TimelineEvent.astro
+++ b/web/src/components/TimelineEvent.astro
@@ -1,0 +1,38 @@
+---
+import type { components } from '../lib/api-types';
+type TimelineEvent = components['schemas']['TimelineEvent'];
+
+interface Props {
+  event: TimelineEvent;
+}
+
+const { event } = Astro.props;
+
+const icons: Record<string, string> = {
+  publish: 'M20 6L9 17l-5-5',
+  version: 'M12 19V5M5 12l7-7 7 7',
+};
+
+const labels: Record<string, string> = {
+  publish: 'Published',
+  version: 'Version bump',
+};
+---
+<div style="display:flex;gap:14px;padding:14px 0;border-bottom:1px solid var(--border);">
+  <div style={`width:34px;height:34px;border-radius:var(--r-sm);display:grid;place-items:center;flex:none;background:${event.type === 'publish' ? 'var(--accent-soft)' : 'var(--info-soft)'};color:${event.type === 'publish' ? 'var(--accent-text)' : 'var(--info)'};`}>
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+      <path d={icons[event.type] ?? icons.publish} />
+    </svg>
+  </div>
+  <div style="flex:1;min-width:0;">
+    <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+      <a href={`/skill/${event.slug}`} style="font-weight:600;font-size:14.5px;">{event.name}</a>
+      {event.version && <span class="tag">v{event.version}</span>}
+      <span class="badge neutral" style="font-size:10px;">{labels[event.type] ?? event.type}</span>
+    </div>
+    <div style="font-family:var(--mono);font-size:11.5px;color:var(--text-faint);margin-top:3px;">
+      {event.authorHandle && <span>by <a href={`/u/${event.authorHandle}`} style="color:var(--accent-text);">{event.authorHandle}</a> · </span>}
+      {new Date(event.at).toLocaleString()}
+    </div>
+  </div>
+</div>

--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderMarkdown } from './markdown.ts';
+
+describe('renderMarkdown — XSS sanitization', () => {
+  it('strips <script> tags', async () => {
+    const html = await renderMarkdown(
+      '# Hello\n\n<script>alert(1)</script>\n\nWorld',
+    );
+    assert.ok(!html.includes('<script'), `<script> survived: ${html}`);
+    assert.ok(!html.includes('alert(1)'), `alert() survived: ${html}`);
+    assert.ok(html.includes('Hello'));
+    assert.ok(html.includes('World'));
+  });
+
+  it('strips <img onerror> event handlers', async () => {
+    const html = await renderMarkdown('<img src=x onerror=alert(1)>');
+    assert.ok(!html.includes('onerror'), `onerror survived: ${html}`);
+    assert.ok(!html.includes('alert(1)'), `alert() survived: ${html}`);
+  });
+
+  it('strips javascript: URIs in links', async () => {
+    const html = await renderMarkdown('[click me](javascript:alert(1))');
+    assert.ok(!html.includes('javascript:'), `javascript: survived: ${html}`);
+    assert.ok(!html.includes('alert(1)'), `alert() survived: ${html}`);
+  });
+
+  it('strips javascript: URIs in raw <a> tags', async () => {
+    const html = await renderMarkdown(
+      '<a href="javascript:alert(1)">click</a>',
+    );
+    assert.ok(!html.includes('javascript:'), `javascript: survived: ${html}`);
+    assert.ok(!html.includes('alert(1)'), `alert() survived: ${html}`);
+  });
+
+  it('strips inline event-handler attributes', async () => {
+    const html = await renderMarkdown('<div onclick="alert(1)">text</div>');
+    assert.ok(!html.includes('onclick'), `onclick survived: ${html}`);
+    assert.ok(!html.includes('alert(1)'), `alert() survived: ${html}`);
+    assert.ok(html.includes('text'));
+  });
+
+  it('preserves safe markdown (headings, code, links)', async () => {
+    const html = await renderMarkdown(
+      '# Title\n\nSome **bold** text.\n\n[link](https://example.com)\n\n`code`',
+    );
+    assert.ok(html.includes('<h1>'), 'heading lost');
+    assert.ok(html.includes('<strong>bold</strong>'), 'bold lost');
+    assert.ok(html.includes('href="https://example.com"'), 'safe link lost');
+    assert.ok(html.includes('<code>code</code>'), 'code lost');
+  });
+});

--- a/web/src/pages/about.astro
+++ b/web/src/pages/about.astro
@@ -1,0 +1,57 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="About — androidskills.dev" description="About androidskills.dev — a focused index of coding skills for Android developers.">
+  <section class="section" style="padding-top:48px;">
+    <div class="wrap wrap-narrow">
+      <div class="kicker"><span class="tick">//</span> about</div>
+      <h1 style="font-size:36px;margin-top:8px;">About androidskills.dev</h1>
+      <p class="lede" style="margin-top:16px;">
+        A focused index of coding skills for Android developers. androidskills.dev collects the
+        conventions, patterns and references that make AI coding agents genuinely good at Android —
+        Compose, Kotlin, testing, Material&nbsp;3 and the craft around them — and makes them searchable,
+        versioned and reviewable.
+      </p>
+
+      <hr class="divider" style="margin:40px 0;" />
+
+      <div class="kicker"><span class="tick">//</span> how it works</div>
+      <h2 style="font-size:22px;margin-top:10px;margin-bottom:20px;">How it works</h2>
+      <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:24px;">
+        <div class="card">
+          <div class="stat" style="margin-bottom:10px;"><span class="n" style="color:var(--accent-text);">01</span></div>
+          <h3 style="font-size:17px;">Discover</h3>
+          <p class="muted" style="font-size:13.5px;margin-top:6px;">Search and filter by category, tags and token size to find the right skill for the task.</p>
+        </div>
+        <div class="card">
+          <div class="stat" style="margin-bottom:10px;"><span class="n" style="color:var(--accent-text);">02</span></div>
+          <h3 style="font-size:17px;">Inspect</h3>
+          <p class="muted" style="font-size:13.5px;margin-top:6px;">Read the frontmatter, author and every file before you trust it — token estimates included.</p>
+        </div>
+        <div class="card">
+          <div class="stat" style="margin-bottom:10px;"><span class="n" style="color:var(--accent-text);">03</span></div>
+          <h3 style="font-size:17px;">Add to your agent</h3>
+          <p class="muted" style="font-size:13.5px;margin-top:6px;">Install with the CLI or copy the manifest. Skills are plain Markdown — portable across agents.</p>
+        </div>
+      </div>
+
+      <hr class="divider" style="margin:40px 0;" />
+
+      <div class="kicker"><span class="tick">//</span> skill structure</div>
+      <h2 style="font-size:22px;margin-top:10px;margin-bottom:16px;">How a repo should be structured</h2>
+      <div class="prose">
+        <p>
+          A skill is a folder containing a <code>SKILL.md</code> manifest. A single GitHub repo can hold
+          one or many skills — but they must live under a top-level <code>skills/</code> directory. When
+          you submit, androidskills.dev:
+        </p>
+        <ul>
+          <li>looks only inside <code>skills/</code> at the root of the repo;</li>
+          <li>publishes every folder beneath it — at any depth — that contains a <code>SKILL.md</code>;</li>
+          <li>ignores <code>SKILL.md</code> files anywhere else (<code>.github/</code>, <code>.claude/</code>, <code>.agents/</code>, repo root).</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/web/src/pages/bundles/[id].astro
+++ b/web/src/pages/bundles/[id].astro
@@ -1,0 +1,60 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import SkillCard from '../../components/SkillCard.astro';
+import { createApiClient, type BundleDetail } from '../../lib/api';
+
+const id = Astro.params.id!;
+const api = createApiClient(Astro.request);
+
+let bundle: BundleDetail | null = null;
+try {
+  bundle = await api.getBundle(id);
+} catch (e) {
+  return Astro.redirect('/404');
+}
+---
+
+<BaseLayout title={`${bundle.provenance} — Bundle`} description={`Skills in ${bundle.provenance}`}>
+  <section class="section" style="padding-top:32px;">
+    <div class="wrap">
+      <div class="crumb" style="margin-bottom:20px;">
+        <a href="/search">Skills</a>
+        <span class="sep">/</span>
+        <span>Bundles</span>
+        <span class="sep">/</span>
+        <span>{bundle.provenance}</span>
+      </div>
+
+      <div style="display:flex;gap:20px;align-items:flex-start;margin-bottom:32px;">
+        <div class="skill-ico" style="width:56px;height:56px;border-radius:var(--r-lg);">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+        </div>
+        <div style="flex:1;">
+          <h1 style="font-size:28px;">{bundle.provenance}</h1>
+          <div style="display:flex;gap:16px;margin-top:8px;flex-wrap:wrap;font-family:var(--mono);font-size:12.5px;color:var(--text-faint);">
+            <span class="badge neutral">{bundle.kind}</span>
+            {bundle.sourceRef && <span>ref: {bundle.sourceRef.slice(0, 12)}</span>}
+            <span>by <a href={`/u/${bundle.owner.handle}`} style="color:var(--accent-text);">{bundle.owner.handle}</a></span>
+            {bundle.syncedAt && <span>· synced {new Date(bundle.syncedAt).toLocaleDateString()}</span>}
+          </div>
+        </div>
+      </div>
+
+      <div class="between" style="margin-bottom:20px;">
+        <h2 style="font-size:20px;">Skills in this bundle ({bundle.skills.length})</h2>
+        <a class="btn btn-sm btn-outline" href={`/api/bundles/${id}/download`}>Download .zip</a>
+      </div>
+
+      {bundle.skills.length > 0 ? (
+        <div class="grid grid-skills">
+          {bundle.skills.map((skill) => <SkillCard skill={skill} />)}
+        </div>
+      ) : (
+        <div class="state">
+          <h3>No skills yet</h3>
+          <p>This bundle has no published skills.</p>
+        </div>
+      )}
+    </div>
+  </section>
+</BaseLayout>

--- a/web/src/pages/cli.astro
+++ b/web/src/pages/cli.astro
@@ -1,0 +1,66 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="CLI — androidskills.dev" description="The androidskills.dev CLI — search, inspect and add skills from the terminal. Coming soon.">
+  <section class="section" style="padding-top:48px;">
+    <div class="wrap">
+      <div style="max-width:680px;">
+        <span class="eyebrow">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+          Coming soon · v0.1 preview
+        </span>
+        <h1 style="font-size:clamp(32px,4vw,44px);font-weight:800;letter-spacing:-.03em;margin-top:16px;">
+          The androidskills.dev CLI
+        </h1>
+        <p class="lede" style="margin-top:12px;">
+          Search, inspect and add Android skills to your coding agent without leaving the terminal.
+          The CLI is in development — get notified when the first build drops.
+        </p>
+      </div>
+
+      <!-- Terminal demo -->
+      <div style="margin-top:32px;max-width:680px;">
+        <div class="term" style="background:light-dark(#0e1014,#07090c);border:1px solid var(--border-2);border-radius:var(--r-lg);overflow:hidden;box-shadow:var(--shadow-2);">
+          <div style="display:flex;align-items:center;gap:7px;padding:11px 14px;border-bottom:1px solid #ffffff14;">
+            <span style="width:11px;height:11px;border-radius:999px;background:#ffffff26;"></span>
+            <span style="width:11px;height:11px;border-radius:999px;background:#ffffff26;"></span>
+            <span style="width:11px;height:11px;border-radius:999px;background:#ffffff26;"></span>
+            <span style="margin-left:8px;font-family:var(--mono);font-size:11.5px;color:#ffffff66;">zsh — androidskills</span>
+          </div>
+          <pre style="margin:0;padding:18px;font-family:var(--mono);font-size:13px;line-height:1.85;color:#e8eaed;overflow-x:auto;"><code><span style="color:#ffffff55;"># install (preview — not yet live)</span>
+<span style="color:#34d27e;">$</span> brew install androidskills          <span style="color:#ffffff55;"># macOS / Linux</span>
+<span style="color:#34d27e;">$</span> winget install androidskills        <span style="color:#ffffff55;"># Windows</span>
+<span style="color:#34d27e;">$</span> curl -fsSL androidskills.dev/install | sh
+
+<span style="color:#ffffff55;"># search and add a skill</span>
+<span style="color:#34d27e;">$</span> androidskills search <span style="color:#6c8cff;">"compose mvi"</span>
+<span style="color:#34d27e;">$</span> androidskills add jetpack-compose-mvi
+<span style="color:#ffffff55;"># → skill copied to .skills/jetpack-compose-mvi/</span></code></pre>
+        </div>
+      </div>
+
+      <!-- Notify (not wired yet) -->
+      <div class="callout info" style="margin-top:32px;max-width:680px;">
+        <svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+        <span>Notify-me isn't live yet. <a href="https://github.com/code-with-the-italians/androidskills.dev" target="_blank" rel="noopener" style="color:var(--accent-text);">Watch the repo on GitHub</a> to know when the first build drops.</span>
+      </div>
+
+      <!-- Features -->
+      <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:40px;">
+        <div class="card">
+          <h3 style="font-size:16px;">Single binary</h3>
+          <p class="muted" style="font-size:13.5px;margin-top:6px;">No runtime. Ships for macOS, Linux &amp; Windows via Homebrew, winget &amp; an install script.</p>
+        </div>
+        <div class="card">
+          <h3 style="font-size:16px;">Agent-native</h3>
+          <p class="muted" style="font-size:13.5px;margin-top:6px;">Skills are plain Markdown — portable across agents. The CLI just fetches and places them.</p>
+        </div>
+        <div class="card">
+          <h3 style="font-size:16px;">Offline-ready</h3>
+          <p class="muted" style="font-size:13.5px;margin-top:6px;">Cache skills locally and search without a network connection.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/web/src/pages/contact.astro
+++ b/web/src/pages/contact.astro
@@ -1,0 +1,75 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Contact — androidskills.dev" description="Get in touch — questions, takedown requests, partnership ideas, or feedback.">
+  <section class="section" style="padding-top:48px;">
+    <div class="wrap wrap-narrow">
+      <div class="kicker"><span class="tick">//</span> contact</div>
+      <h1 style="font-size:36px;margin-top:8px;">Get in touch</h1>
+      <p class="lede" style="margin-top:16px;">
+        Questions, takedown requests, partnership ideas, or feedback on a review — drop us a line.
+      </p>
+
+      <div style="display:grid;grid-template-columns:1fr 280px;gap:32px;margin-top:32px;align-items:start;">
+        <!-- Form (front-end only — not wired to a backend yet) -->
+        <div>
+          <div class="callout info" style="margin-bottom:20px;">
+            <svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+            <span>This form is not yet live. For now, reach us via the channels on the right.</span>
+          </div>
+          <fieldset disabled style="border:0;padding:0;display:flex;flex-direction:column;gap:16px;">
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+              <div class="field">
+                <label for="name">Name</label>
+                <input class="input" type="text" id="name" placeholder="Your name" />
+              </div>
+              <div class="field">
+                <label for="email">Email</label>
+                <input class="input" type="email" id="email" placeholder="you@example.com" />
+              </div>
+            </div>
+            <div class="field">
+              <label for="topic">Topic</label>
+              <select class="select" id="topic">
+                <option>General question</option>
+                <option>Report a skill</option>
+                <option>Takedown / DMCA</option>
+                <option>Review appeal</option>
+                <option>Partnership</option>
+                <option>Bug report</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="message">Message</label>
+              <textarea class="textarea" id="message" rows="5" placeholder="Don't include secrets or credentials."></textarea>
+            </div>
+            <label class="check">
+              <input type="checkbox" />
+              <span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+              I agree to the privacy policy.
+            </label>
+            <button class="btn btn-primary" type="button" disabled>Send message</button>
+          </fieldset>
+        </div>
+
+        <!-- Channels -->
+        <aside class="stack">
+          <div class="card">
+            <h4 style="font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--text-faint);margin-bottom:14px;">Channels</h4>
+            <div class="stack" style="gap:14px;">
+              <div>
+                <div class="faint" style="font-size:12px;font-family:var(--mono);">Email</div>
+                <a href="mailto:hello@androidskills.dev" style="color:var(--accent-text);font-size:14px;">hello@androidskills.dev</a>
+              </div>
+              <div>
+                <div class="faint" style="font-size:12px;font-family:var(--mono);">Issues</div>
+                <a href="https://github.com/code-with-the-italians/androidskills.dev/issues" target="_blank" rel="noopener" style="color:var(--accent-text);font-size:14px;">GitHub Issues</a>
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/web/src/pages/timeline.astro
+++ b/web/src/pages/timeline.astro
@@ -1,0 +1,61 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import TimelineEvent from '../components/TimelineEvent.astro';
+import { createApiClient, type TimelinePage } from '../lib/api';
+
+const page = parseInt(Astro.url.searchParams.get('page') ?? '1', 10);
+const api = createApiClient(Astro.request);
+
+let result: TimelinePage | null = null;
+try {
+  result = await api.getTimeline(page, 20);
+} catch (e) {
+  // API unreachable
+}
+
+const items = result?.items ?? [];
+const total = result?.total ?? 0;
+const totalPages = result?.totalPages ?? 0;
+---
+
+<BaseLayout title="Timeline — androidskills.dev" description="Every publish, version bump and re-sync, newest first.">
+  <section class="section" style="padding-top:32px;">
+    <div class="wrap wrap-narrow">
+      <div style="margin-bottom:28px;">
+        <div class="kicker"><span class="tick">//</span> activity feed</div>
+        <h1 style="font-size:32px;margin-top:6px;">Timeline</h1>
+        <p class="lede" style="margin-top:8px;">Every publish, version bump and re-sync — traced back to the skill it came from.</p>
+      </div>
+
+      {items.length > 0 ? (
+        <>
+          <div style="font-size:13px;color:var(--text-faint);margin-bottom:12px;">
+            {total} events{page > 1 && <> · page {page}</>}
+          </div>
+          {items.map((event) => <TimelineEvent event={event} />)}
+
+          {totalPages > 1 && (
+            <div style="display:flex;justify-content:center;margin-top:24px;">
+              <div class="pager">
+                {page > 1 && <a href={`/timeline?page=${page - 1}`}>←</a>}
+                <span class="cur">{page}</span>
+                <span class="faint">/ {totalPages}</span>
+                {page < totalPages && <a href={`/timeline?page=${page + 1}`}>→</a>}
+              </div>
+            </div>
+          )}
+        </>
+      ) : (
+        <div class="state">
+          <div class="ico">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+            </svg>
+          </div>
+          <h3>No activity yet</h3>
+          <p>Events will appear here as skills are published and updated.</p>
+        </div>
+      )}
+    </div>
+  </section>
+</BaseLayout>

--- a/web/src/pages/trends.astro
+++ b/web/src/pages/trends.astro
@@ -1,0 +1,72 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import StatTile from '../components/StatTile.astro';
+import BarChart from '../components/BarChart.astro';
+import { createApiClient, type TrendsResponse, type StatsResponse } from '../lib/api';
+
+const api = createApiClient(Astro.request);
+
+let trends: TrendsResponse | null = null;
+let stats: StatsResponse | null = null;
+try {
+  [trends, stats] = await Promise.all([api.getTrends(), api.getStats()]);
+} catch (e) {
+  // API unreachable
+}
+---
+
+<BaseLayout title="Trends — androidskills.dev" description="The state of Android AI coding skills: themes, security, and complexity figures.">
+  <section class="section" style="padding-top:32px;">
+    <div class="wrap">
+      <div style="margin-bottom:32px;">
+        <div class="kicker"><span class="tick">//</span> dashboard</div>
+        <h1 style="font-size:32px;margin-top:6px;">Stats &amp; trends</h1>
+        <p class="lede" style="margin-top:8px;">What the index looks like right now — themes, security and complexity figures extracted during the automated review.</p>
+      </div>
+
+      <!-- Stat tiles -->
+      {stats && (
+        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:16px;margin-bottom:40px;">
+          <div class="card" style="text-align:center;">
+            <StatTile value={stats.indexed} label="Skills indexed" />
+          </div>
+          <div class="card" style="text-align:center;">
+            <StatTile value={stats.contributors} label="Contributors" />
+          </div>
+          {trends?.securityPassRate != null && (
+            <div class="card" style="text-align:center;">
+              <StatTile value={`${Math.round(trends.securityPassRate * 100)}%`} label="Security pass" />
+            </div>
+          )}
+          {trends?.submissionFunnel && (
+            <div class="card" style="text-align:center;">
+              <StatTile value={trends.submissionFunnel['in_review'] ?? 0} label="In review" />
+            </div>
+          )}
+        </div>
+      )}
+
+      <!-- Charts -->
+      {trends && (
+        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(360px,1fr));gap:24px;">
+          {trends.categories.length > 0 && (
+            <BarChart title="By category" data={trends.categories} />
+          )}
+          {trends.tags.length > 0 && (
+            <BarChart title="By tag" data={trends.tags} />
+          )}
+          {trends.tokenMix.length > 0 && (
+            <BarChart title="Token mix" data={trends.tokenMix} />
+          )}
+        </div>
+      )}
+
+      {!trends && !stats && (
+        <div class="state">
+          <h3>Trends unavailable</h3>
+          <p>Couldn't load trend data right now.</p>
+        </div>
+      )}
+    </div>
+  </section>
+</BaseLayout>

--- a/web/src/pages/u/[handle].astro
+++ b/web/src/pages/u/[handle].astro
@@ -1,0 +1,59 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import SkillCard from '../../components/SkillCard.astro';
+import Avatar from '../../components/Avatar.astro';
+import { createApiClient, type AuthorProfile } from '../../lib/api';
+
+const handle = Astro.params.handle!;
+const api = createApiClient(Astro.request);
+
+let author: AuthorProfile | null = null;
+try {
+  author = await api.getAuthor(handle);
+} catch (e) {
+  return Astro.redirect('/404');
+}
+---
+
+<BaseLayout title={`${author.name ?? author.handle} — Author`} description={`Skills by ${author.handle}`}>
+  <section class="section" style="padding-top:32px;">
+    <div class="wrap wrap-narrow">
+      <div class="crumb" style="margin-bottom:20px;">
+        <a href="/search">Skills</a>
+        <span class="sep">/</span>
+        <span>Authors</span>
+        <span class="sep">/</span>
+        <span>{author.handle}</span>
+      </div>
+
+      <div style="display:flex;gap:20px;align-items:center;margin-bottom:32px;">
+        <Avatar name={author.name ?? author.handle} src={author.avatarUrl ?? undefined} size="lg" />
+        <div>
+          <h1 style="font-size:28px;">{author.name ?? author.handle}</h1>
+          <div style="font-family:var(--mono);font-size:13px;color:var(--text-faint);margin-top:4px;">@{author.handle}</div>
+          <div style="display:flex;gap:24px;margin-top:10px;">
+            <div class="stat">
+              <span class="n" style="font-size:18px;">{author.skillCount}</span>
+              <span class="l">Skills</span>
+            </div>
+            <div class="stat">
+              <span class="n" style="font-size:18px;">{author.totalInstalls.toLocaleString()}</span>
+              <span class="l">Installs</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {author.skills.length > 0 ? (
+        <div class="grid grid-skills">
+          {author.skills.map((skill) => <SkillCard skill={skill} />)}
+        </div>
+      ) : (
+        <div class="state">
+          <h3>No published skills</h3>
+          <p>This author hasn't published any skills yet.</p>
+        </div>
+      )}
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## Summary

Phase 1 follow-up + Phase 2 of the Astro frontend build.

### Phase 1 follow-up
- **`markdown.test.ts`** — 6 cases locking the XSS sanitizer invariant: `<script>`, `<img onerror>`, `javascript:` URIs (markdown + raw `<a>`), inline event handlers, and a positive test for safe markdown. Wired into CI.
- **`tsx`** dev dependency for running TS tests via `node --test`.

### Phase 2 — 7 public pages

| Page | Route | API |
|------|-------|-----|
| Bundle detail | `/bundles/{id}` | `GET /api/bundles/{id}` |
| Author profile | `/u/{handle}` | `GET /api/authors/{handle}` |
| Trends | `/trends` | `GET /api/trends` + `GET /api/stats` |
| Timeline | `/timeline` | `GET /api/timeline` |
| About | `/about` | static |
| Contact | `/contact` | static (form disabled — honest "not live yet") |
| CLI | `/cli` | static (notify-me → GitHub watch) |

### New shared components
`Avatar.astro`, `StatTile.astro`, `BarChart.astro` (CSS-only), `TimelineEvent.astro`

### UX honesty notes (from review)
- No visual-only inert tabs (Trends/Timeline time-range tabs omitted until the API supports filtering)
- Contact form is `disabled` with an info callout ("not yet live") — no fake success
- CLI notify-me points to GitHub Watch instead of a dead email input

### Verified
- `npm test` (markdown sanitizer) ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run check` (astro check) ✅
- `npx tsc --noEmit` ✅
- `npm run build` ✅