### PR TITLE
fix(api): make gradlew executable in the Docker build

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,6 +12,11 @@ COPY settings.gradle.kts .
 COPY build.gradle.kts .
 COPY gradle/libs.versions.toml gradle/libs.versions.toml
 
+# gradlew is committed non-executable (100644), so on a Linux CI runner `./gradlew`
+# fails with exit 126. Docker Desktop on Windows/macOS masks this by auto-adding the
+# exec bit, which is why local builds pass but the GHCR CI build did not.
+RUN chmod +x gradlew
+
 # Download dependencies and plugins before copying source
 RUN ./gradlew --no-daemon --version
 


### PR DESCRIPTION
Follow-up to #16. The new GHCR `Build images` workflow failed on the **api** image:

```
process "/bin/sh -c ./gradlew --no-daemon --version" did not complete successfully: exit code: 126
```

`api/gradlew` is committed non-executable (`100644`), so on the Linux CI runner `./gradlew` is permission-denied. Local builds passed only because Docker Desktop on Windows/macOS auto-adds the exec bit. `ci.yml` already worked around this with an explicit `chmod +x ./gradlew`; the Dockerfile did not.

**Fix:** `RUN chmod +x gradlew` before the wrapper is invoked (robust regardless of git file mode / host OS).

Validated by dispatching `Build images` on this branch before merge (the workflow only runs on pushes to `develop`, so PR checks alone don't exercise it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
