### PR TITLE
Step 10 Phase 3: Authed contributor surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ npm-debug.log*
 
 # Gradle / Ktor
 api/.gradle/
+api/.kotlin/
 api/build/
 .gradle/
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,23 @@ OpenAI-compatible endpoint in prod). Both swap in via configuration, not code.
 
 ### Web (`web/`)
 
-A skeleton Astro app is present. It is not yet connected to the API; that happens
-in the next step.
+An Astro SSR app (`output: 'server'`, `@astrojs/node/standalone`) proxies public and
+authenticated routes to the Ktor API.
 
 ```sh
 npm install --prefix web
 npm run --prefix web build
+npm run --prefix web preview   # serves the production build on :4321
 ```
 
-For local development it can be run with `npm run --prefix web dev`; in
-production it is served behind Kamal as a Node SSR app.
+For local development:
+
+```sh
+npm run --prefix web dev       # dev server on :4321
+```
+
+> **Dev-server note:** `astro dev` can fail to pick up **brand-new route files**
+> added while it is already running, returning 404 for those routes even though the
+> files exist and work after `astro build`. If a route that was present before the
+> server started returns 404, stop and restart `astro dev`. This is a dev-server
+> quirk; production SSR is unaffected.

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
-    "test": "node --test --import tsx src/lib/markdown.test.ts",
+    "test": "node --test --import tsx src/lib/markdown.test.ts src/scripts/submit-wizard.test.ts",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/web/src/components/AuthHeader.astro
+++ b/web/src/components/AuthHeader.astro
@@ -1,0 +1,85 @@
+---
+import Avatar from './Avatar.astro';
+import { createApiClient } from '../lib/api';
+
+const api = createApiClient(Astro.request);
+
+let me: Awaited<ReturnType<typeof api.getMe>> | null = null;
+try {
+  me = await api.getMe();
+} catch {
+  me = null;
+}
+---
+
+{
+  me ? (
+    <div class="auth-menu" style="position:relative;display:inline-flex;align-items:center;gap:8px;">
+      <button
+        class="row auth-btn"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        data-auth-toggle
+        style="gap:8px;background:transparent;border:0;cursor:pointer;padding:3px 8px 3px 4px;border-radius:999px;color:var(--text);"
+      >
+        <Avatar name={me.name ?? me.handle} src={me.avatarUrl ?? undefined} size="sm" />
+        <span class="hide-sm" style="font-size:13.5px;font-weight:500;">{me.handle}</span>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="muted chev">
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      <div
+        class="dropdown"
+        data-auth-dropdown
+        style="position:absolute;top:calc(100% + 8px);right:0;width:200px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);box-shadow:var(--shadow-2);padding:8px;display:none;flex-direction:column;gap:2px;z-index:100;"
+      >
+        <a class="btn btn-ghost btn-block" style="justify-content:flex-start;" href="/settings">Settings</a>
+        <a class="btn btn-ghost btn-block" style="justify-content:flex-start;" href="/submissions">My submissions</a>
+        <a class="btn btn-ghost btn-block" style="justify-content:flex-start;" href="/starred">Starred skills</a>
+        <div style="border-top:1px solid var(--border);margin:4px 0;" />
+        <button class="btn btn-ghost btn-block" data-logout style="justify-content:flex-start;color:var(--danger);" type="button">Sign out</button>
+      </div>
+    </div>
+  ) : (
+    <a class="btn btn-sm btn-primary" href="/signin">Sign in</a>
+  )
+}
+
+<script>
+  (function () {
+    const menu = document.querySelector('[data-auth-toggle]')?.closest('.auth-menu');
+    const btn = menu?.querySelector('[data-auth-toggle]') as HTMLElement | null;
+    const dropdown = menu?.querySelector('[data-auth-dropdown]') as HTMLElement | null;
+    const logout = menu?.querySelector('[data-logout]') as HTMLElement | null;
+
+    function close() {
+      if (!dropdown || !btn) return;
+      dropdown.style.display = 'none';
+      btn.setAttribute('aria-expanded', 'false');
+    }
+
+    function open() {
+      if (!dropdown || !btn) return;
+      dropdown.style.display = 'flex';
+      btn.setAttribute('aria-expanded', 'true');
+    }
+
+    btn?.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      if (expanded) close(); else open();
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!menu?.contains(e.target as Node)) close();
+    });
+
+    logout?.addEventListener('click', async () => {
+      try {
+        await fetch('/api/auth/logout', { method: 'POST' });
+      } catch (e) {
+        // ignore; reload will clear the UI anyway
+      }
+      window.location.reload();
+    });
+  })();
+</script>

--- a/web/src/components/SkillCard.astro
+++ b/web/src/components/SkillCard.astro
@@ -1,11 +1,13 @@
 ---
+import StarButton from './StarButton.astro';
 import type { SkillCard as SkillCardType } from '../lib/api';
 
 interface Props {
   skill: SkillCardType;
+  anonymous?: boolean;
 }
 
-const { skill } = Astro.props;
+const { skill, anonymous = false } = Astro.props;
 
 const initials = skill.name
   .split(/\s+/)
@@ -15,7 +17,9 @@ const initials = skill.name
   .toUpperCase();
 ---
 
-<a class="card card-link skill-card" href={`/skill/${skill.slug}`}>
+<div class="card skill-card" style="position:relative;">
+  <a class="card-link" href={`/skill/${skill.slug}`} style="position:absolute;inset:0;z-index:1;"
+></a>
   <div class="top">
     <div class="skill-ico">{initials}</div>
     <div style="flex:1;min-width:0;">
@@ -45,4 +49,7 @@ const initials = skill.name
       </>
     )}
   </div>
-</a>
+  <div style="position:relative;z-index:2;margin-top:12px;display:inline-flex;">
+    <StarButton slug={skill.slug} anonymous={anonymous} />
+  </div>
+</div>

--- a/web/src/components/StarButton.astro
+++ b/web/src/components/StarButton.astro
@@ -1,0 +1,55 @@
+---
+interface Props {
+  slug: string;
+  starred?: boolean;
+  anonymous?: boolean;
+  size?: 'sm' | 'md';
+}
+
+const { slug, starred = false, anonymous = false, size = 'sm' } = Astro.props;
+const btnClass = size === 'md' ? 'btn btn-outline' : 'btn btn-sm btn-ghost';
+---
+
+{
+  anonymous ? (
+    <a class={btnClass} href="/signin" aria-label="Sign in to star">
+      <svg class="ic" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+      </svg>
+      <span>Star</span>
+    </a>
+  ) : (
+    <button class={btnClass} data-star data-slug={slug} data-starred={String(starred)} type="button" aria-pressed={starred ? 'true' : 'false'} aria-label={starred ? 'Unstar' : 'Star'}>
+      <svg class="ic" width="16" height="16" viewBox="0 0 24 24" fill={starred ? 'currentColor' : 'none'} stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+      </svg>
+      <span data-star-label>{starred ? 'Starred' : 'Star'}</span>
+    </button>
+  )
+}
+
+<script>
+  (function () {
+    document.addEventListener('click', async (e) => {
+      const btn = (e.target as HTMLElement).closest('[data-star]') as HTMLButtonElement | null;
+      if (!btn) return;
+      e.preventDefault();
+      const slug = btn.getAttribute('data-slug');
+      if (!slug) return;
+      const currently = btn.getAttribute('aria-pressed') === 'true';
+      const label = btn.querySelector('[data-star-label]') as HTMLElement | null;
+      const svg = btn.querySelector('svg') as SVGElement | null;
+      try {
+        const res = await fetch(`/api/me/stars/${encodeURIComponent(slug)}`, { method: currently ? 'DELETE' : 'POST' });
+        if (res.status === 401) { window.location.href = '/signin'; return; }
+        if (!res.ok) throw new Error(await res.text());
+        const next = !currently;
+        btn.setAttribute('aria-pressed', String(next));
+        if (label) label.textContent = next ? 'Starred' : 'Star';
+        if (svg) svg.setAttribute('fill', next ? 'currentColor' : 'none');
+      } catch (err) {
+        console.error('Star toggle failed', err);
+      }
+    });
+  })();
+</script>

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import ThemeInit from '../components/ThemeInit.astro';
+import AuthHeader from '../components/AuthHeader.astro';
 import '../styles/global.css';
 
 interface Props {
@@ -63,7 +64,7 @@ function navActive(href: string): boolean {
                 </svg>
               </button>
               <a class="btn btn-sm btn-outline hide-sm" href="/submit">Submit a skill</a>
-              <a class="btn btn-sm btn-primary" href="/auth">Sign in</a>
+              <AuthHeader />
               <button class="icon-btn menu-btn" data-menu-open aria-label="Open menu">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
                   <path d="M3 6h18M3 12h18M3 18h18" />

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -101,7 +101,7 @@ function navActive(href: string): boolean {
               <div>
                 <h5>Contribute</h5>
                 <a href="/submit">Submit a skill</a>
-                <a href="/auth">Sign in</a>
+                <a href="/signin">Sign in</a>
                 <a href="/about">Guidelines</a>
                 <a href="/contact">Contact</a>
               </div>
@@ -120,7 +120,7 @@ function navActive(href: string): boolean {
       )
     }
 
-    <!-- Theme toggle script -->
+    <!-- Theme / accent / density script -->
     <script is:inline>
       (function () {
         function getSettings() {
@@ -134,6 +134,17 @@ function navActive(href: string): boolean {
           var s = getSettings();
           Object.assign(s, partial);
           localStorage.setItem('androidskills', JSON.stringify(s));
+          applySettings();
+        }
+        function applySettings() {
+          var s = getSettings();
+          var r = document.documentElement;
+          if (s.theme && s.theme !== 'system') r.setAttribute('data-theme', s.theme);
+          else r.removeAttribute('data-theme');
+          if (s.accent && s.accent !== 'green') r.setAttribute('data-accent', s.accent);
+          else r.removeAttribute('data-accent');
+          if (s.density && s.density !== 'regular') r.setAttribute('data-density', s.density);
+          else r.removeAttribute('data-density');
         }
         function resolvedDark() {
           var s = getSettings();
@@ -150,14 +161,15 @@ function navActive(href: string): boolean {
         document.querySelectorAll('[data-theme-toggle]').forEach(function (btn) {
           btn.addEventListener('click', function () {
             saveSettings({ theme: resolvedDark() ? 'light' : 'dark' });
-            var s = getSettings();
-            var r = document.documentElement;
-            if (s.theme === 'system') r.removeAttribute('data-theme');
-            else r.setAttribute('data-theme', s.theme);
             syncToggles();
           });
         });
+        document.addEventListener('prefs:apply', function () {
+          syncToggles();
+          applySettings();
+        });
         syncToggles();
+        applySettings();
       })();
     </script>
   </body>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,22 @@ export type FileContentResponse = Schemas['FileContentResponse'];
 export type VersionsResponse = Schemas['VersionsResponse'];
 export type ReportResponse = Schemas['ReportResponse'];
 export type MeResponse = Schemas['MeResponse'];
+
+/** Settings actually persisted by the backend (only two keys; everything else is localStorage). */
+export interface UserSettings {
+  emailNotifications?: boolean;
+  publicProfile?: boolean;
+}
+
+export type RepoDto = Schemas['RepoDto'];
+export type ReposResponse = Schemas['ReposResponse'];
+export type ScanResponse = Schemas['ScanResponse'];
+export type DetectedSkillDto = Schemas['DetectedSkillDto'];
+export type CreateDraftsRequest = Schemas['CreateDraftsRequest'];
+export type CreateDraftsResponse = Schemas['CreateDraftsResponse'];
+export type GroupedSubmissions = Schemas['GroupedSubmissions'];
+export type SubmissionSummary = Schemas['SubmissionSummary'];
+export type SubmissionDetail = Schemas['SubmissionDetail'];
 export type BundleDetail = Schemas['BundleDetail'];
 export type PageOfBundleSummary = Schemas['PageOfBundleSummary'];
 export type AuthorProfile = Schemas['AuthorProfile'];
@@ -186,6 +202,79 @@ export class ApiClient {
 
   getMe(): Promise<MeResponse> {
     return this.fetchJson('/api/me');
+  }
+
+  deleteAccount(): Promise<void> {
+    return this.fetchJson('/api/me', { method: 'DELETE' });
+  }
+
+  logout(): Promise<{ ok: boolean }> {
+    return this.fetchJson('/api/auth/logout', { method: 'POST' });
+  }
+
+  // ---- Settings ----
+
+  getSettings(): Promise<UserSettings> {
+    return this.fetchJson('/api/me/settings');
+  }
+
+  putSettings(settings: UserSettings): Promise<{ ok: boolean }> {
+    return this.fetchJson('/api/me/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(settings),
+    });
+  }
+
+  // ---- Repos / scan ----
+
+  getRepos(): Promise<ReposResponse> {
+    return this.fetchJson('/api/me/repos');
+  }
+
+  scanRepo(owner: string, repo: string): Promise<ScanResponse> {
+    return this.fetchJson(
+      `/api/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/scan`,
+      { method: 'POST' },
+    );
+  }
+
+  // ---- Submissions ----
+
+  getSubmissions(): Promise<GroupedSubmissions[]> {
+    return this.fetchJson('/api/me/submissions');
+  }
+
+  createDrafts(request: CreateDraftsRequest): Promise<CreateDraftsResponse> {
+    return this.fetchJson('/api/me/submissions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+  }
+
+  getSubmission(id: string): Promise<SubmissionDetail> {
+    return this.fetchJson(`/api/me/submissions/${encodeURIComponent(id)}`);
+  }
+
+  deleteSubmission(id: string): Promise<void> {
+    return this.fetchJson(`/api/me/submissions/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  submitDraft(id: string): Promise<{ ok: boolean }> {
+    return this.fetchJson(
+      `/api/me/submissions/${encodeURIComponent(id)}/submit`,
+      { method: 'POST' },
+    );
+  }
+
+  withdrawSubmission(id: string): Promise<{ ok: boolean }> {
+    return this.fetchJson(
+      `/api/me/submissions/${encodeURIComponent(id)}/withdraw`,
+      { method: 'POST' },
+    );
   }
 
   // ---- Starred ----

--- a/web/src/pages/settings.astro
+++ b/web/src/pages/settings.astro
@@ -1,0 +1,249 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Avatar from '../components/Avatar.astro';
+import { createApiClient } from '../lib/api';
+
+const api = createApiClient(Astro.request);
+
+let me: Awaited<ReturnType<typeof api.getMe>> | null = null;
+let settings: Awaited<ReturnType<typeof api.getSettings>> | null = null;
+let repos: Awaited<ReturnType<typeof api.getRepos>> | null = null;
+
+try {
+  [me, settings, repos] = await Promise.all([api.getMe(), api.getSettings(), api.getRepos()]);
+} catch (e) {
+  return Astro.redirect('/signin');
+}
+---
+
+<BaseLayout title="Settings — androidskills.dev" description="Manage your account, preferences, and GitHub access.">
+  <section class="section" style="padding-top:32px;">
+    <div class="wrap" style="max-width:1000px;">
+      <div style="margin-bottom:26px;">
+        <div class="kicker"><span class="tick">//</span> ACCOUNT</div>
+        <h1 style="font-size:30px;margin:8px 0 4px;">Settings</h1>
+        <p class="muted">Signed in as <b>@{me.handle}</b> via GitHub.</p>
+      </div>
+
+      <div style="display:grid;grid-template-columns:200px 1fr;gap:40px;align-items:start;">
+        <nav class="set-nav" style="position:sticky;top:80px;display:flex;flex-direction:column;gap:2px;">
+          <a href="#account" style="padding:8px 12px;border-radius:var(--r-sm);color:var(--text-dim);font-size:14px;font-weight:500;">Account</a>
+          <a href="#preferences" style="padding:8px 12px;border-radius:var(--r-sm);color:var(--text-dim);font-size:14px;font-weight:500;">Preferences</a>
+          <a href="#github" style="padding:8px 12px;border-radius:var(--r-sm);color:var(--text-dim);font-size:14px;font-weight:500;">GitHub access</a>
+          <a href="#danger" style="padding:8px 12px;border-radius:var(--r-sm);color:var(--text-dim);font-size:14px;font-weight:500;">Danger zone</a>
+        </nav>
+
+        <div>
+          <section id="account" style="scroll-margin-top:76px;">
+            <div style="margin-bottom:14px;">
+              <h2 style="font-size:19px;">Account</h2>
+              <p style="color:var(--text-dim);font-size:13.5px;margin-top:4px;">Your androidskills profile is backed by your GitHub identity.</p>
+            </div>
+            <div class="card">
+              <div style="display:flex;align-items:center;gap:16px;">
+                <Avatar name={me.name ?? me.handle} src={me.avatarUrl ?? undefined} size="lg" />
+                <div style="flex:1;min-width:0;">
+                  <div style="font-weight:700;font-size:16px;">{me.name ?? me.handle}</div>
+                  <div class="slug" style="font-family:var(--mono);font-size:12.5px;color:var(--text-faint);">@{me.handle} · {me.role}</div>
+                </div>
+                <span class="badge ok">✓ GitHub verified</span>
+              </div>
+              <div class="field-row" style="display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:center;padding:14px 0;border-top:1px solid var(--border);margin-top:8px;">
+                <div style="font-size:13.5px;color:var(--text-dim);font-weight:600;">Display name</div>
+                <div style="font-size:14px;">{me.name ?? me.handle} <span class="hint">synced from GitHub</span></div>
+              </div>
+              <div class="field-row" style="display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:center;padding:14px 0;border-top:1px solid var(--border);">
+                <div style="font-size:13.5px;color:var(--text-dim);font-weight:600;">Username</div>
+                <div style="font-size:14px;"><span class="mono" style="font-family:var(--mono);font-size:13px;">@{me.handle}</span></div>
+              </div>
+              <div class="field-row" style="display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:center;padding:14px 0;border-top:1px solid var(--border);">
+                <div style="font-size:13.5px;color:var(--text-dim);font-weight:600;">Profile</div>
+                <div style="font-size:14px;"><a class="btn btn-sm btn-outline" href={`/u/${me.handle}`}>View public profile</a></div>
+              </div>
+              <p class="hint" style="margin-top:14px;">Name, avatar and username come from GitHub. <a href="https://github.com/settings/profile" target="_blank" rel="noopener" style="color:var(--accent-text);">Edit them on GitHub →</a></p>
+            </div>
+          </section>
+
+          <section id="preferences" style="scroll-margin-top:76px;margin-top:28px;">
+            <div style="margin-bottom:14px;">
+              <h2 style="font-size:19px;">Preferences</h2>
+              <p style="color:var(--text-dim);font-size:13.5px;margin-top:4px;">Appearance and account settings. Theme/accent/density are stored in this browser; the toggles below sync to your account.</p>
+            </div>
+
+            <div class="card">
+              <div class="kicker" style="margin-bottom:2px;"><span class="tick">//</span> APPEARANCE</div>
+              <div class="pref-row" data-pref="theme" style="display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:center;padding:14px 0;border-top:0;">
+                <div style="font-size:13.5px;color:var(--text-dim);font-weight:600;">Theme</div>
+                <div class="seg" style="display:inline-flex;"><button type="button" data-val="system">System</button><button type="button" data-val="light">Light</button><button type="button" data-val="dark">Dark</button></div>
+              </div>
+              <div class="pref-row" data-pref="accent" style="display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:center;padding:14px 0;border-top:1px solid var(--border);">
+                <div style="font-size:13.5px;color:var(--text-dim);font-weight:600;">Accent</div>
+                <div class="pref-sw" style="display:flex;gap:9px;">
+                  <button type="button" data-val="green" style="width:30px;height:30px;border-radius:9px;border:2px solid transparent;box-shadow:inset 0 0 0 1px var(--border);background:#34d27e;" title="Green" aria-label="Green accent"></button>
+                  <button type="button" data-val="indigo" style="width:30px;height:30px;border-radius:9px;border:2px solid transparent;box-shadow:inset 0 0 0 1px var(--border);background:#6c8cff;" title="Indigo" aria-label="Indigo accent"></button>
+                  <button type="button" data-val="orange" style="width:30px;height:30px;border-radius:9px;border:2px solid transparent;box-shadow:inset 0 0 0 1px var(--border);background:#ff7a45;" title="Orange" aria-label="Orange accent"></button>
+                  <button type="button" data-val="mono" style="width:30px;height:30px;border-radius:9px;border:2px solid transparent;box-shadow:inset 0 0 0 1px var(--border);background:#8b909a;" title="Mono" aria-label="Monochrome accent"></button>
+                </div>
+              </div>
+              <div class="pref-row" data-pref="density" style="display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:center;padding:14px 0;border-top:1px solid var(--border);">
+                <div style="font-size:13.5px;color:var(--text-dim);font-weight:600;">Density</div>
+                <div class="seg" style="display:inline-flex;"><button type="button" data-val="compact">Compact</button><button type="button" data-val="regular">Regular</button><button type="button" data-val="comfy">Comfy</button></div>
+              </div>
+            </div>
+
+            <div class="card" style="margin-top:14px;">
+              <div class="kicker" style="margin-bottom:2px;"><span class="tick">//</span> ACCOUNT TOGGLES</div>
+              <label class="check" style="display:flex;align-items:center;gap:10px;padding:14px 0;">
+                <input type="checkbox" data-setting="emailNotifications" checked={settings.emailNotifications ? true : undefined} />
+                <span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+                <span>Email notifications</span>
+              </label>
+              <label class="check" style="display:flex;align-items:center;gap:10px;padding:14px 0;border-top:1px solid var(--border);">
+                <input type="checkbox" data-setting="publicProfile" checked={settings.publicProfile ? true : undefined} />
+                <span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+                <span>Public profile</span>
+              </label>
+              <div id="settingsStatus" class="hint" style="margin-top:10px;"></div>
+            </div>
+          </section>
+
+          <section id="github" style="scroll-margin-top:76px;margin-top:28px;">
+            <div style="margin-bottom:14px;">
+              <h2 style="font-size:19px;">GitHub access</h2>
+              <p style="color:var(--text-dim);font-size:13.5px;margin-top:4px;">androidskills.dev reads contents only from the repositories you grant, to import and re-sync skills.</p>
+            </div>
+            <div class="card">
+              {repos ? (
+                <div>
+                  <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
+                    <span class="gi" style="width:38px;height:38px;flex:none;display:grid;place-items:center;background:var(--surface-2);border:1px solid var(--border-2);color:var(--text-dim);border-radius:8px;">
+                      <!-- prettier-ignore -->
+                      <svg viewBox="0 0 24 24" fill="currentColor" style="width:20px;height:20px;"><path d="M12 2C6.5 2 2 6.6 2 12.3c0 4.5 2.9 8.3 6.8 9.7.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.4-3.4-1.4-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.3 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5 3.9-1.4 6.8-5.2 6.8-9.7C22 6.6 17.5 2 12 2z"/></svg>
+                    </span>
+                    <div style="min-width:0;">
+                      <div style="font-weight:700;font-size:14.5px;">androidskills GitHub App</div>
+                      <div class="slug" style="font-family:var(--mono);font-size:11.5px;color:var(--text-faint);">installed on @{me.handle}</div>
+                    </div>
+                    <span class="badge ok" style="margin-left:auto;">connected</span>
+                  </div>
+                  <hr class="divider" style="margin:18px 0;" />
+                  <div style="font-family:var(--mono);font-size:11px;color:var(--text-faint);margin-bottom:12px;">{repos.repos.length} repositories granted</div>
+                  <div style="display:flex;flex-direction:column;gap:8px;">
+                    {repos.repos.map((repo) => (
+                      <div style="display:flex;align-items:center;gap:13px;padding:13px 14px;border:1px solid var(--border);border-radius:var(--r-md);">
+                        <span class="gi" style="width:30px;height:30px;border-radius:8px;flex:none;display:grid;place-items:center;background:var(--surface-2);border:1px solid var(--border-2);color:var(--text-dim);">
+                          <!-- prettier-ignore -->
+                          <svg viewBox="0 0 24 24" fill="currentColor" style="width:16px;height:16px;"><path d="M12 2C6.5 2 2 6.6 2 12.3c0 4.5 2.9 8.3 6.8 9.7.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.4-3.4-1.4-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.3 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5 3.9-1.4 6.8-5.2 6.8-9.7C22 6.6 17.5 2 12 2z"/></svg>
+                        </span>
+                        <div style="flex:1;min-width:0;">
+                          <div style="font-family:var(--mono);font-size:13px;word-break:break-all;">{repo.fullName}</div>
+                        </div>
+                        <a href={`https://github.com/${repo.fullName}`} target="_blank" rel="noopener" style="color:var(--accent-text);font-size:13px;">Open →</a>
+                      </div>
+                    ))}
+                  </div>
+                  <div class="callout" style="margin-top:14px;font-size:13px;align-items:flex-start;">
+                    <svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01" stroke-linecap="round"/></svg>
+                    <div>Repository access is controlled on GitHub, not here. We can only read repositories you've granted.</div>
+                  </div>
+                  <div class="row" style="gap:10px;flex-wrap:wrap;margin-top:14px;">
+                    <a class="btn btn-sm btn-primary" href="https://github.com/settings/installations" target="_blank" rel="noopener">Configure access on GitHub</a>
+                  </div>
+                </div>
+              ) : (
+                <div class="callout" style="align-items:flex-start;">
+                  <svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01" stroke-linecap="round"/></svg>
+                  <div>
+                    <b>GitHub App not connected.</b> Install the androidskills GitHub App on your account to import skills from repositories.
+                    <div class="row" style="gap:10px;margin-top:10px;">
+                      <a class="btn btn-sm btn-primary" href="https://github.com/apps/androidskills" target="_blank" rel="noopener">Install on GitHub</a>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section id="danger" style="scroll-margin-top:76px;margin-top:28px;">
+            <div style="margin-bottom:14px;">
+              <h2 style="font-size:19px;color:var(--danger);">Danger zone</h2>
+            </div>
+            <div class="card" style="border-color:color-mix(in oklab, var(--danger) 40%, var(--border));">
+              <div style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;">
+                <div style="max-width:460px;">
+                  <h3 style="font-size:15px;">Delete androidskills account</h3>
+                  <p class="muted" style="font-size:13.5px;margin-top:6px;">Removes your profile and unpublishes your skills from the public index. Your repositories on GitHub are untouched.</p>
+                </div>
+                <button class="btn btn-danger" data-delete-account type="button">Delete account</button>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    (function () {
+      const status = document.getElementById('settingsStatus');
+
+      document.querySelectorAll('[data-setting]').forEach((input) => {
+        const el = input as HTMLInputElement;
+        el.addEventListener('change', async () => {
+          const settings = {
+            emailNotifications: (document.querySelector('[data-setting="emailNotifications"]') as HTMLInputElement | null)?.checked ?? false,
+            publicProfile: (document.querySelector('[data-setting="publicProfile"]') as HTMLInputElement | null)?.checked ?? false,
+          };
+          try {
+            const res = await fetch('/api/me/settings', {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(settings),
+            });
+            if (!res.ok) throw new Error(await res.text());
+            if (status) { status.textContent = 'Saved'; setTimeout(() => status.textContent = '', 2000); }
+          } catch (e) {
+            if (status) { status.textContent = 'Failed to save. Try again.'; }
+            console.error(e);
+          }
+        });
+      });
+
+      document.querySelectorAll('[data-pref]').forEach((row) => {
+        const key = row.getAttribute('data-pref')!;
+        const buttons = row.querySelectorAll('button[data-val]');
+        function reflect() {
+          const s = JSON.parse(localStorage.getItem('androidskills') || '{}');
+          const val = s[key] || (key === 'theme' ? 'system' : key === 'density' ? 'regular' : 'green');
+          buttons.forEach((b) => { b.setAttribute('aria-pressed', String(b.getAttribute('data-val') === val)); });
+        }
+        buttons.forEach((b) => {
+          b.addEventListener('click', () => {
+            const patch = { [key]: b.getAttribute('data-val') };
+            const s = JSON.parse(localStorage.getItem('androidskills') || '{}');
+            Object.assign(s, patch);
+            localStorage.setItem('androidskills', JSON.stringify(s));
+            window.dispatchEvent(new CustomEvent('prefs:apply'));
+            reflect();
+          });
+        });
+        reflect();
+      });
+
+      const delBtn = document.querySelector('[data-delete-account]') as HTMLElement | null;
+      delBtn?.addEventListener('click', async () => {
+        const handle = document.querySelector('.slug')?.textContent?.replace('@', '').trim().split(' ')[0];
+        const input = prompt(`Type your handle (${handle}) to confirm account deletion.`);
+        if (!input || input.trim() !== handle) return;
+        try {
+          const res = await fetch('/api/me', { method: 'DELETE' });
+          if (!res.ok) throw new Error(await res.text());
+          window.location.href = '/';
+        } catch (e) {
+          alert('Account deletion failed. Please try again.');
+          console.error(e);
+        }
+      });
+    })();
+  </script>
+</BaseLayout>

--- a/web/src/pages/settings.astro
+++ b/web/src/pages/settings.astro
@@ -8,11 +8,25 @@ const api = createApiClient(Astro.request);
 let me: Awaited<ReturnType<typeof api.getMe>> | null = null;
 let settings: Awaited<ReturnType<typeof api.getSettings>> | null = null;
 let repos: Awaited<ReturnType<typeof api.getRepos>> | null = null;
+let reposError: string | null = null;
 
 try {
-  [me, settings, repos] = await Promise.all([api.getMe(), api.getSettings(), api.getRepos()]);
-} catch (e) {
+  me = await api.getMe();
+} catch {
   return Astro.redirect('/signin');
+}
+
+try {
+  settings = await api.getSettings();
+} catch {
+  settings = null;
+}
+
+try {
+  repos = await api.getRepos();
+} catch (e) {
+  repos = null;
+  reposError = e instanceof Error ? e.message : 'GitHub App unavailable';
 }
 ---
 
@@ -94,12 +108,12 @@ try {
             <div class="card" style="margin-top:14px;">
               <div class="kicker" style="margin-bottom:2px;"><span class="tick">//</span> ACCOUNT TOGGLES</div>
               <label class="check" style="display:flex;align-items:center;gap:10px;padding:14px 0;">
-                <input type="checkbox" data-setting="emailNotifications" checked={settings.emailNotifications ? true : undefined} />
+                <input type="checkbox" data-setting="emailNotifications" checked={settings?.emailNotifications ? true : undefined} />
                 <span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
                 <span>Email notifications</span>
               </label>
               <label class="check" style="display:flex;align-items:center;gap:10px;padding:14px 0;border-top:1px solid var(--border);">
-                <input type="checkbox" data-setting="publicProfile" checked={settings.publicProfile ? true : undefined} />
+                <input type="checkbox" data-setting="publicProfile" checked={settings?.publicProfile ? true : undefined} />
                 <span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
                 <span>Public profile</span>
               </label>
@@ -154,7 +168,7 @@ try {
                 <div class="callout" style="align-items:flex-start;">
                   <svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01" stroke-linecap="round"/></svg>
                   <div>
-                    <b>GitHub App not connected.</b> Install the androidskills GitHub App on your account to import skills from repositories.
+                    <b>GitHub App not connected.</b> {reposError || 'Install the androidskills GitHub App on your account to import skills from repositories.'}
                     <div class="row" style="gap:10px;margin-top:10px;">
                       <a class="btn btn-sm btn-primary" href="https://github.com/apps/androidskills" target="_blank" rel="noopener">Install on GitHub</a>
                     </div>

--- a/web/src/pages/signin.astro
+++ b/web/src/pages/signin.astro
@@ -1,0 +1,40 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { createApiClient } from '../lib/api';
+
+const api = createApiClient(Astro.request);
+try {
+  await api.getMe();
+  return Astro.redirect('/');
+} catch {
+  // not signed in — render the sign-in page
+}
+---
+
+<BaseLayout title="Sign in — androidskills.dev" description="Sign in with GitHub to contribute skills and manage your account.">
+  <section class="section" style="padding-top:64px;">
+    <div class="wrap" style="max-width:420px;margin:0 auto;text-align:center;">
+      <div class="card" style="padding:36px 28px;">
+        <div class="skill-ico" style="width:64px;height:64px;border-radius:var(--r-lg);margin:0 auto 20px;">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor" style="color:var(--accent-text);">
+            <path d="M12 2C6.5 2 2 6.6 2 12.3c0 4.5 2.9 8.3 6.8 9.7.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.4-3.4-1.4-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.3 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5 3.9-1.4 6.8-5.2 6.8-9.7C22 6.6 17.5 2 12 2z"/>
+          </svg>
+        </div>
+        <h1 style="font-size:26px;">Sign in with GitHub</h1>
+        <p class="muted" style="margin-top:10px;font-size:14px;line-height:1.55;">
+          Contributors sign in with GitHub so we can read skill manifests from the repositories you choose.
+          No password needed.
+        </p>
+        <a class="btn btn-primary btn-lg" href="/api/auth/github/start" style="margin-top:24px;width:100%;justify-content:center;">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style="margin-right:8px;">
+            <path d="M12 2C6.5 2 2 6.6 2 12.3c0 4.5 2.9 8.3 6.8 9.7.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.4-3.4-1.4-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.3 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5 3.9-1.4 6.8-5.2 6.8-9.7C22 6.6 17.5 2 12 2z"/>
+          </svg>
+          Continue with GitHub
+        </a>
+        <p class="hint" style="margin-top:16px;font-size:12.5px;">
+          By signing in, you agree to our <a href="/about" style="color:var(--accent-text);">community guidelines</a>.
+        </p>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/web/src/pages/skill/[slug].astro
+++ b/web/src/pages/skill/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import StarButton from '../../components/StarButton.astro';
 import { createApiClient, type SkillDetail, type FileTreeResponse, type VersionsResponse } from '../../lib/api';
 import { renderMarkdown } from '../../lib/markdown';
 
@@ -9,6 +10,8 @@ const api = createApiClient(Astro.request);
 let skill: SkillDetail | null = null;
 let files: FileTreeResponse | null = null;
 let versions: VersionsResponse | null = null;
+let anonymous = true;
+let starred = false;
 
 try {
   [skill, files, versions] = await Promise.all([
@@ -16,6 +19,13 @@ try {
     api.getSkillFiles(slug),
     api.getSkillVersions(slug),
   ]);
+  try {
+    const stars = await api.getStars();
+    anonymous = false;
+    starred = stars.some((s) => s.slug === slug);
+  } catch {
+    anonymous = true;
+  }
 } catch (e) {
   return Astro.redirect('/404');
 }
@@ -70,6 +80,7 @@ const fileTree = files?.tree ?? [];
               <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
               Download .zip
             </a>
+            <StarButton slug={slug} anonymous={anonymous} starred={starred} size="md" />
           </div>
         </div>
       </div>

--- a/web/src/pages/starred.astro
+++ b/web/src/pages/starred.astro
@@ -1,0 +1,43 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import SkillCard from '../components/SkillCard.astro';
+import { createApiClient } from '../lib/api';
+
+const api = createApiClient(Astro.request);
+
+let stars: Awaited<ReturnType<typeof api.getStars>> | null = null;
+let anonymous = false;
+
+try {
+  stars = await api.getStars();
+} catch {
+  anonymous = true;
+}
+---
+
+<BaseLayout title="Starred skills — androidskills.dev" description="Your starred skills.">
+  <section class="section" style="padding-top:32px;">
+    <div class="wrap">
+      <div class="kicker"><span class="tick">//</span> LIBRARY</div>
+      <h1 style="font-size:30px;margin-top:8px;">Starred skills</h1>
+
+      {anonymous ? (
+        <div class="state" style="margin-top:24px;">
+          <h3>Sign in to see your stars</h3>
+          <p class="muted">Your starred skills are saved to your account.</p>
+          <a class="btn btn-primary" href="/signin" style="margin-top:12px;">Sign in</a>
+        </div>
+      ) : stars && stars.length > 0 ? (
+        <div class="grid grid-skills" style="margin-top:24px;">
+          {stars.map((skill) => <SkillCard skill={skill} />)}
+        </div>
+      ) : (
+        <div class="state" style="margin-top:24px;">
+          <h3>No starred skills yet</h3>
+          <p class="muted">Browse skills and click the star to save them here.</p>
+          <a class="btn btn-primary" href="/search" style="margin-top:12px;">Browse skills</a>
+        </div>
+      )}
+    </div>
+  </section>
+</BaseLayout>

--- a/web/src/pages/submissions.astro
+++ b/web/src/pages/submissions.astro
@@ -1,0 +1,116 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { createApiClient } from '../lib/api';
+
+const api = createApiClient(Astro.request);
+
+let me: Awaited<ReturnType<typeof api.getMe>> | null = null;
+let grouped: Awaited<ReturnType<typeof api.getSubmissions>> | null = null;
+
+try {
+  [me, grouped] = await Promise.all([api.getMe(), api.getSubmissions()]);
+} catch {
+  return Astro.redirect('/signin');
+}
+
+const stateOrder = ['draft', 'in_review', 'changes_requested', 'published', 'rejected'];
+const stateLabels: Record<string, string> = {
+  draft: 'Draft',
+  in_review: 'In review',
+  changes_requested: 'Changes requested',
+  published: 'Published',
+  rejected: 'Rejected',
+};
+const sorted = stateOrder
+  .map((state) => {
+    const g = grouped?.find((x) => x.state === state);
+    return g ? { state, label: stateLabels[state], items: g.items } : null;
+  })
+  .filter(Boolean) as { state: string; label: string; items: typeof grouped[0]['items'] }[];
+---
+
+<BaseLayout title="My submissions — androidskills.dev" description="Track your skill submissions.">
+  <section class="section" style="padding-top:32px;">
+    <div class="wrap" style="max-width:900px;">
+      <div class="between" style="flex-wrap:wrap;gap:12px;margin-bottom:24px;">
+        <div>
+          <div class="kicker"><span class="tick">//</span> CONTRIBUTOR</div>
+          <h1 style="font-size:30px;margin:8px 0 6px;">My submissions</h1>
+          <p class="muted">@{me.handle}</p>
+        </div>
+        <a class="btn btn-sm btn-primary" href="/submit">Submit a skill</a>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:28px;">
+        {sorted.map((g) => (
+          <div class="card">
+            <div class="between" style="margin-bottom:14px;">
+              <h2 style="font-size:17px;">{g.label}</h2>
+              <span class="badge neutral">{g.items.length}</span>
+            </div>
+            {g.items.length > 0 ? (
+              <div style="display:flex;flex-direction:column;gap:10px;">
+                {g.items.map((item) => (
+                  <div class="submission-row" data-submission-id={item.id} data-state={g.state} style="display:flex;align-items:center;gap:12px;padding:12px 14px;border:1px solid var(--border);border-radius:var(--r-md);">
+                    <div style="flex:1;min-width:0;">
+                      <div style="font-weight:600;font-size:14.5px;">{item.slug}</div>
+                      <div style="font-family:var(--mono);font-size:11px;color:var(--text-faint);margin-top:3px;">
+                        updated {new Date(item.updatedAt).toLocaleDateString()}
+                        {item.lintScore != null && <span> · lint {item.lintScore}</span>}
+                      </div>
+                    </div>
+                    <div class="actions" style="display:flex;gap:8px;flex-wrap:wrap;">
+                      {g.state === 'draft' && (
+                        <>
+                          <button class="btn btn-sm btn-primary" data-action="submit" type="button">Submit</button>
+                          <button class="btn btn-sm btn-ghost" data-action="delete" type="button">Delete</button>
+                        </>
+                      )}
+                      {(g.state === 'in_review' || g.state === 'changes_requested') && (
+                        <button class="btn btn-sm btn-ghost" data-action="withdraw" type="button">Withdraw</button>
+                      )}
+                      {(g.state === 'published' || g.state === 'rejected') && (
+                        <span class="tag">{g.state}</span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p class="muted" style="font-size:13.5px;">No submissions in this state.</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <script>
+    (function () {
+      document.querySelectorAll('.submission-row').forEach((row) => {
+        const id = row.getAttribute('data-submission-id');
+        if (!id) return;
+        row.querySelectorAll('[data-action]').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            const action = btn.getAttribute('data-action');
+            if (!action) return;
+            try {
+              if (action === 'submit') {
+                await fetch(`/api/me/submissions/${id}/submit`, { method: 'POST' });
+              } else if (action === 'withdraw') {
+                await fetch(`/api/me/submissions/${id}/withdraw`, { method: 'POST' });
+              } else if (action === 'delete') {
+                if (!confirm('Delete this draft?')) return;
+                await fetch(`/api/me/submissions/${id}`, { method: 'DELETE' });
+              }
+              window.location.reload();
+            } catch (e) {
+              console.error(e);
+              alert('Action failed. Please try again.');
+            }
+          });
+        });
+      });
+    })();
+  </script>
+</BaseLayout>

--- a/web/src/pages/submit.astro
+++ b/web/src/pages/submit.astro
@@ -1,0 +1,117 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { createApiClient } from '../lib/api';
+
+const api = createApiClient(Astro.request);
+try {
+  await api.getMe();
+} catch {
+  return Astro.redirect('/signin');
+}
+---
+
+<BaseLayout title="Submit a skill — androidskills.dev" description="Import skills from a GitHub repository.">
+  <section class="section" style="padding-top:32px;">
+    <div class="wrap" style="max-width:1024px;">
+      <div class="between" style="flex-wrap:wrap;gap:12px;margin-bottom:24px;">
+        <div>
+          <div class="kicker"><span class="tick">//</span> CONTRIBUTE</div>
+          <h1 style="font-size:30px;margin:8px 0 6px;">Submit a skill</h1>
+          <p class="muted" style="max-width:560px;">
+            Import skills straight from a GitHub repository. The skill's <code style="font-family:var(--mono);font-size:12px;">SKILL.md</code> is the source of truth — androidskills.dev reads its metadata, never overrides it.
+          </p>
+        </div>
+        <a class="btn btn-sm btn-outline" href="/submissions">My submissions</a>
+      </div>
+
+      <div class="submit-grid" style="display:grid;grid-template-columns:1fr 320px;gap:36px;align-items:start;">
+        <div class="vsteps" id="vsteps">
+          <div class="vstep" data-step="1">
+            <div class="vno">1</div>
+            <div class="vbody">
+              <div class="vhead"><h3>Repository</h3></div>
+              <div class="vcontent" id="step1content"></div>
+            </div>
+          </div>
+          <div class="vstep" data-step="2">
+            <div class="vno">2</div>
+            <div class="vbody">
+              <div class="vhead"><h3>Detected skills</h3></div>
+              <div class="vcontent" id="step2content"></div>
+            </div>
+          </div>
+          <div class="vstep" data-step="3">
+            <div class="vno">3</div>
+            <div class="vbody">
+              <div class="vhead"><h3>Review & submit</h3></div>
+              <div class="vcontent" id="step3content"></div>
+            </div>
+          </div>
+        </div>
+
+        <aside class="det-side" style="position:sticky;top:80px;display:flex;flex-direction:column;gap:18px;">
+          <div class="card">
+            <div class="kicker" style="margin-bottom:12px;"><span class="tick">//</span> WHAT MAKES A GOOD SKILL</div>
+            <ul class="guide-list" style="list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:11px;font-size:13.5px;color:var(--text-dim);">
+              <li style="display:flex;align-items:flex-start;gap:9px;"><svg viewBox="0 0 24 24" fill="none" stroke="var(--accent-text)" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;margin-top:2px;flex:none;"><path d="M20 6L9 17l-5-5"/></svg><span>A clear <code style="font-family:var(--mono);font-size:12px;">SKILL.md</code> with frontmatter</span></li>
+              <li style="display:flex;align-items:flex-start;gap:9px;"><svg viewBox="0 0 24 24" fill="none" stroke="var(--accent-text)" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;margin-top:2px;flex:none;"><path d="M20 6L9 17l-5-5"/></svg><span>Android / Kotlin scope</span></li>
+              <li style="display:flex;align-items:flex-start;gap:9px;"><svg viewBox="0 0 24 24" fill="none" stroke="var(--accent-text)" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;margin-top:2px;flex:none;"><path d="M20 6L9 17l-5-5"/></svg><span>Concise — under ~8k tokens</span></li>
+              <li style="display:flex;align-items:flex-start;gap:9px;"><svg viewBox="0 0 24 24" fill="none" stroke="var(--accent-text)" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;margin-top:2px;flex:none;"><path d="M20 6L9 17l-5-5"/></svg><span>An open-source license</span></li>
+            </ul>
+            <a class="btn btn-sm btn-outline btn-block" href="/about" style="margin-top:12px;">Read full guidelines</a>
+          </div>
+        </aside>
+      </div>
+    </div>
+  </section>
+
+  <noscript>
+    <div class="wrap" style="max-width:1024px;">
+      <div class="callout" style="margin-top:24px;background:var(--danger-soft);border-color:transparent;align-items:flex-start;">
+        <svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg>
+        <div><b>JavaScript is required</b> to scan a repository and select skills for submission.</div>
+      </div>
+    </div>
+  </noscript>
+
+  <style>
+    .vsteps { display: flex; flex-direction: column; }
+    .vstep { display: grid; grid-template-columns: 32px 1fr; gap: 16px; position: relative; padding-bottom: 26px; }
+    .vstep:last-child { padding-bottom: 0; }
+    .vstep::before { content: ""; position: absolute; left: 15px; top: 36px; bottom: 4px; width: 2px; background: var(--border); }
+    .vstep:last-child::before { display: none; }
+    .vstep.done::before { background: var(--accent); }
+    .vno { width: 32px; height: 32px; border-radius: 999px; display: grid; place-items: center; font-family: var(--mono); font-size: 13px; font-weight: 700; border: 2px solid var(--border-2); color: var(--text-faint); background: var(--surface); z-index: 1; }
+    .vstep.done .vno { background: var(--accent); border-color: transparent; color: var(--accent-ink); }
+    .vstep.active .vno { border-color: var(--accent); color: var(--accent-text); }
+    .vbody { min-width: 0; }
+    .vhead { display: flex; align-items: center; gap: 12px; min-height: 32px; }
+    .vcontent { margin-top: 14px; display: none; }
+    .vstep.active .vcontent { display: block; }
+    .vstep.upcoming { opacity: 0.5; }
+    .repo { display: flex; align-items: center; gap: 12px; padding: 12px 14px; border-bottom: 1px solid var(--border); cursor: pointer; transition: background 0.12s; }
+    .repo:last-child { border-bottom: 0; }
+    .repo:hover { background: var(--surface-2); }
+    .repo .radio { width: 18px; height: 18px; border-radius: 999px; border: 2px solid var(--border-2); flex: none; display: grid; place-items: center; }
+    .repo.sel .radio { border-color: var(--accent); }
+    .repo.sel .radio::after { content: ""; width: 9px; height: 9px; border-radius: 999px; background: var(--accent); }
+    .repo.sel { background: var(--accent-soft); }
+    .acc { border: 1px solid var(--border); border-radius: var(--r-md); overflow: hidden; background: var(--surface); }
+    .acc + .acc { margin-top: 10px; }
+    .acc-h:hover { background: var(--surface-2); }
+    .acc .acc-body { transition: max-height 0.28s ease, opacity 0.22s ease, padding 0.28s ease, border-color 0.28s ease; }
+    .acc.open .acc-body { max-height: 720px; opacity: 1; padding: 2px 14px 12px; border-top-color: var(--border); }
+    .acc.open .chev { transform: rotate(180deg); }
+    .seg { display: inline-flex; border: 1px solid var(--border); border-radius: var(--r-md); overflow: hidden; }
+    .seg button { background: var(--surface); border: 0; border-right: 1px solid var(--border); padding: 6px 12px; font-size: 13px; cursor: pointer; }
+    .seg button:last-child { border-right: 0; }
+    .seg button[aria-pressed="true"] { background: var(--accent-soft); color: var(--accent-text); font-weight: 600; }
+    .pref-sw button[aria-pressed="true"]::after { content: ""; position: absolute; inset: 0; margin: auto; width: 7px; height: 7px; border-radius: 999px; background: #fff; mix-blend-mode: difference; }
+    .pref-sw button { position: relative; }
+    @media (max-width: 880px) { .submit-grid { grid-template-columns: 1fr; } }
+  </style>
+
+  <script>
+    import '../scripts/submit-wizard';
+  </script>
+</BaseLayout>

--- a/web/src/scripts/submit-wizard.test.ts
+++ b/web/src/scripts/submit-wizard.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { esc } from './submit-wizard';
+
+describe('submit-wizard esc()', () => {
+  it('escapes HTML metacharacters', () => {
+    assert.equal(esc('<script>'), '&lt;script&gt;');
+    assert.equal(esc('a & b'), 'a &amp; b');
+    assert.equal(esc('"quoted"'), '&quot;quoted&quot;');
+    assert.equal(esc("it's"), 'it&#39;s');
+  });
+
+  it('neutralizes event-handler payloads', () => {
+    const input = "<img src=x onerror=alert('xss')>";
+    const out = esc(input);
+    assert.ok(out.startsWith('&lt;img'));
+    assert.ok(out.endsWith('&gt;'));
+    assert.ok(!out.includes('<img'));
+  });
+
+  it('neutralizes javascript: URI payloads', () => {
+    const input = '<a href="javascript:alert(1)">click</a>';
+    const out = esc(input);
+    assert.ok(!out.includes('<a'));
+    assert.ok(!out.includes('"'));
+    assert.ok(out.includes('javascript:'));
+  });
+
+  it('handles null/undefined/numbers', () => {
+    assert.equal(esc(null), '');
+    assert.equal(esc(undefined), '');
+    assert.equal(esc(42), '42');
+  });
+});

--- a/web/src/scripts/submit-wizard.ts
+++ b/web/src/scripts/submit-wizard.ts
@@ -1,0 +1,247 @@
+interface Repo {
+  owner: string;
+  name: string;
+  fullName: string;
+  defaultBranch: string | null;
+}
+interface ReposResponse {
+  repos: Repo[];
+}
+interface DetectedSkill {
+  slug: string;
+  name: string;
+  description: string;
+  license: string | null;
+  tags: string[];
+  version: string;
+  tokenUpfront: number;
+  tokenOndemand: number;
+  fileCount: number;
+}
+interface ScanResponse {
+  slug: string;
+  commitSha: string;
+  skills: DetectedSkill[];
+}
+const CHECK = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>';
+const state = {
+  step: 1,
+  repo: null as Repo | null,
+  repos: null as ReposResponse | null,
+  scan: null as ScanResponse | null,
+  error: null as string | null,
+  checking: null as string | null,
+};
+
+const vsteps = document.getElementById('vsteps') as HTMLElement;
+const steps = Array.from(vsteps.querySelectorAll('.vstep')) as HTMLElement[];
+
+async function loadRepos() {
+  const res = await fetch('/api/me/repos');
+  if (!res.ok) throw new Error(await res.text());
+  state.repos = (await res.json()) as ReposResponse;
+}
+
+function renderStep1() {
+  const container = document.getElementById('step1content') as HTMLElement;
+  if (!container) return;
+  if (!state.repos) {
+    container.innerHTML = '<div class="state"><span class="spinner"></span><p>Loading repositories...</p></div>';
+    return;
+  }
+  const repos = state.repos.repos || [];
+  if (repos.length === 0) {
+    container.innerHTML = '<div class="state"><p class="muted">No repositories found. Install the GitHub App and grant access to a repo with a top-level <code>skills/</code> directory.</p></div>';
+    return;
+  }
+  container.innerHTML = `
+    <p class="hint" style="margin-bottom:12px;line-height:1.55;">Pick a repository with one or more skills in a top-level <code style="font-family:var(--mono);font-size:11px;">skills/</code> directory.</p>
+    <div class="tbl-wrap" style="border:1px solid var(--border);border-radius:var(--r-md);overflow:hidden;">
+      <div style="padding:10px 12px;border-bottom:1px solid var(--border);">
+        <div class="search search-sm">
+          <svg class="ic-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.2-3.2" stroke-linecap="round"/></svg>
+          <input id="repoFilter" type="search" placeholder="Filter your repositories…" autocomplete="off" style="width:100%;">
+        </div>
+      </div>
+      <div id="repoList"></div>
+    </div>
+    <div id="repoStatus" style="margin-top:10px;"></div>
+  `;
+  renderRepoList();
+}
+
+function renderRepoList() {
+  const input = document.getElementById('repoFilter') as HTMLInputElement | null;
+  const filter = input?.value?.toLowerCase() || '';
+  const list = document.getElementById('repoList') as HTMLElement;
+  if (!list || !state.repos) return;
+  const repos = state.repos.repos.filter((r) => (r.fullName + ' ' + (r.defaultBranch || '')).toLowerCase().includes(filter));
+  list.innerHTML = repos.map((r) => `
+    <div class="repo ${state.repo?.fullName === r.fullName ? ' sel' : ''}" data-repo="${r.fullName}" role="button" tabindex="0">
+      <span class="radio"></span>
+      <div style="flex:1;min-width:0;">
+        <div style="font-weight:600;font-size:14px;">${r.fullName}</div>
+        <div class="slug" style="font-size:11.5px;">${r.defaultBranch || 'default branch'}</div>
+      </div>
+    </div>
+  `).join('');
+  if (repos.length === 0) {
+    list.innerHTML = '<div class="state" style="padding:20px;"><p class="muted">No repositories match.</p></div>';
+  }
+}
+
+async function scanRepo(repo: Repo) {
+  state.repo = repo;
+  state.error = null;
+  state.checking = repo.fullName;
+  renderStep1();
+  try {
+    const res = await fetch(`/api/me/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/scan`, { method: 'POST' });
+    if (!res.ok) throw new Error(await res.text());
+    state.scan = (await res.json()) as ScanResponse;
+    state.step = 2;
+  } catch (e) {
+    state.error = e instanceof Error ? e.message : 'Scan failed';
+  } finally {
+    state.checking = null;
+  }
+  render();
+}
+
+function renderStep2() {
+  const container = document.getElementById('step2content') as HTMLElement;
+  if (!container) return;
+  if (!state.scan) {
+    container.innerHTML = '<div class="state"><p class="muted">Select a repository to detect skills.</p></div>';
+    return;
+  }
+  const skills = state.scan.skills || [];
+  if (skills.length === 0) {
+    container.innerHTML = '<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>No skill found.</b> A skill is a folder containing a SKILL.md inside a top-level skills/ directory.</div></div></div>';
+    return;
+  }
+  const items = skills.map((s, i) => `
+    <div class="acc" data-acc>
+      <div class="acc-h" data-acc-head style="display:flex;align-items:center;gap:12px;padding:13px 14px;cursor:pointer;">
+        <input type="checkbox" data-skill-idx="${i}" checked style="width:18px;height:18px;flex:none;">
+        <div style="flex:1;min-width:0;">
+          <div class="nm" style="font-weight:600;font-size:14.5px;">${s.name}</div>
+          <div class="sl" style="font-family:var(--mono);font-size:11.5px;color:var(--text-faint);">skills/${s.slug}/</div>
+        </div>
+        <span class="tag" style="flex:none;">${s.tokenUpfront + s.tokenOndemand} tok</span>
+        <svg class="chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
+      </div>
+      <div class="acc-body" style="max-height:0;overflow:hidden;padding:0 14px;border-top:1px solid transparent;">
+        <div style="padding:12px 0;">
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">description</span><span class="v">${s.description}</span></div>
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">version</span><span class="v">${s.version}</span></div>
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">license</span><span class="v">${s.license || '—'}</span></div>
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">tags</span><span class="v">${(s.tags || []).map((t) => `<span class="tag">${t}</span>`).join(' ')}</span></div>
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">contents</span><span class="v">${s.fileCount} files · <span style="color:var(--accent-text);">${s.tokenUpfront + s.tokenOndemand} tokens</span></span></div>
+        </div>
+      </div>
+    </div>
+  `).join('');
+  container.innerHTML = `
+    <div class="callout" style="margin-bottom:16px;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01" stroke-linecap="round"/></svg><div><b>${skills.length} skill${skills.length > 1 ? 's' : ''}</b> found. Everything below is read from each skill's SKILL.md frontmatter.</div></div></div>
+    <div class="accs">${items}</div>
+    <button class="btn btn-primary" data-continue style="margin-top:18px;">Continue with selected skills</button>
+  `;
+}
+
+function renderStep3() {
+  const container = document.getElementById('step3content') as HTMLElement;
+  if (!container) return;
+  const skills = selectedSkills();
+  container.innerHTML = `
+    <p class="hint" style="margin-bottom:14px;">On submit, automated checks run and the selected skills enter the review queue. Drafts you save appear under <a href="/submissions" style="color:var(--accent-text);">My submissions</a>.</p>
+    <div class="card" style="margin-bottom:16px;">
+      <div class="kicker" style="margin-bottom:10px;"><span class="tick">//</span> SELECTED</div>
+      ${skills.map((s) => `<div style="padding:8px 0;border-bottom:1px solid var(--border);"><b>${s.name}</b> <span class="hint">skills/${s.slug}/</span></div>`).join('')}
+    </div>
+    <div class="row" style="gap:10px;">
+      <button class="btn btn-ghost" data-save-draft>Save draft</button>
+      <button class="btn btn-primary btn-lg" data-submit><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;"><path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z"/></svg> Submit for review</button>
+    </div>
+    <div id="submitStatus" class="hint" style="margin-top:10px;"></div>
+  `;
+}
+
+function selectedSkills(): DetectedSkill[] {
+  if (!state.scan) return [];
+  const checked = Array.from(document.querySelectorAll('[data-skill-idx]:checked')) as HTMLInputElement[];
+  return checked.map((cb) => state.scan!.skills[Number(cb.getAttribute('data-skill-idx'))]).filter(Boolean);
+}
+
+function render() {
+  renderStep1();
+  renderStep2();
+  renderStep3();
+  steps.forEach((el) => {
+    const n = Number(el.getAttribute('data-step'));
+    el.classList.remove('done', 'active', 'upcoming');
+    const cls = n < state.step ? 'done' : (n === state.step ? 'active' : 'upcoming');
+    el.classList.add(cls);
+    const no = el.querySelector('.vno') as HTMLElement;
+    no.innerHTML = (cls === 'done') ? CHECK : String(n);
+  });
+  const status = document.getElementById('repoStatus');
+  if (status) {
+    if (state.checking) status.innerHTML = `<div class="callout" style="align-items:center;"><span class="spinner" style="width:16px;height:16px;flex:none;"></span><div>Scanning <b>${state.checking}</b> for SKILL.md files…</div></div>`;
+    else if (state.error) status.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>${state.error}</b></div></div>`;
+    else status.innerHTML = '';
+  }
+}
+
+async function createDrafts(submit: boolean) {
+  const skills = selectedSkills();
+  if (skills.length === 0 || !state.repo || !state.scan) return;
+  const status = document.getElementById('submitStatus');
+  if (status) status.textContent = 'Creating drafts…';
+  const payload = {
+    repoOwner: state.repo.owner,
+    repoName: state.repo.name,
+    ref: state.scan.commitSha,
+    skills: skills.map((s) => ({ slug: s.slug, name: s.name, description: s.description, license: s.license || '', tags: s.tags || [], version: s.version })),
+  };
+  const res = await fetch('/api/me/submissions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+  if (!res.ok) throw new Error(await res.text());
+  const { submissionIds } = (await res.json()) as { submissionIds: string[] };
+  if (submit) {
+    if (status) status.textContent = 'Submitting for review…';
+    for (const id of submissionIds) {
+      const r = await fetch(`/api/me/submissions/${id}/submit`, { method: 'POST' });
+      if (!r.ok) throw new Error(await r.text());
+    }
+  }
+  window.location.href = '/submissions';
+}
+
+vsteps.addEventListener('click', (e) => {
+  const target = e.target as HTMLElement;
+  const repo = target.closest('[data-repo]');
+  if (repo && state.repos) {
+    const fullName = repo.getAttribute('data-repo');
+    const r = state.repos.repos.find((x) => x.fullName === fullName);
+    if (r) scanRepo(r);
+    return;
+  }
+  const acc = target.closest('[data-acc-head]');
+  if (acc) { acc.closest('[data-acc]')?.classList.toggle('open'); return; }
+  const cont = target.closest('[data-continue]');
+  if (cont) { state.step = 3; render(); return; }
+  const save = target.closest('[data-save-draft]');
+  if (save) { createDrafts(false); return; }
+  const sub = target.closest('[data-submit]');
+  if (sub) { createDrafts(true); return; }
+});
+
+vsteps.addEventListener('input', (e) => {
+  const target = e.target as HTMLElement;
+  if (target.id === 'repoFilter') renderRepoList();
+});
+
+loadRepos().then(render).catch((e) => {
+  const el = document.getElementById('step1content');
+  if (el) el.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;"><b>Failed to load repositories:</b> ${e.message}</div>`;
+});

--- a/web/src/scripts/submit-wizard.ts
+++ b/web/src/scripts/submit-wizard.ts
@@ -23,7 +23,8 @@ interface ScanResponse {
   commitSha: string;
   skills: DetectedSkill[];
 }
-const CHECK = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>';
+const CHECK =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>';
 const state = {
   step: 1,
   repo: null as Repo | null,
@@ -46,12 +47,14 @@ function renderStep1() {
   const container = document.getElementById('step1content') as HTMLElement;
   if (!container) return;
   if (!state.repos) {
-    container.innerHTML = '<div class="state"><span class="spinner"></span><p>Loading repositories...</p></div>';
+    container.innerHTML =
+      '<div class="state"><span class="spinner"></span><p>Loading repositories...</p></div>';
     return;
   }
   const repos = state.repos.repos || [];
   if (repos.length === 0) {
-    container.innerHTML = '<div class="state"><p class="muted">No repositories found. Install the GitHub App and grant access to a repo with a top-level <code>skills/</code> directory.</p></div>';
+    container.innerHTML =
+      '<div class="state"><p class="muted">No repositories found. Install the GitHub App and grant access to a repo with a top-level <code>skills/</code> directory.</p></div>';
     return;
   }
   container.innerHTML = `
@@ -71,12 +74,18 @@ function renderStep1() {
 }
 
 function renderRepoList() {
-  const input = document.getElementById('repoFilter') as HTMLInputElement | null;
+  const input = document.getElementById(
+    'repoFilter',
+  ) as HTMLInputElement | null;
   const filter = input?.value?.toLowerCase() || '';
   const list = document.getElementById('repoList') as HTMLElement;
   if (!list || !state.repos) return;
-  const repos = state.repos.repos.filter((r) => (r.fullName + ' ' + (r.defaultBranch || '')).toLowerCase().includes(filter));
-  list.innerHTML = repos.map((r) => `
+  const repos = state.repos.repos.filter((r) =>
+    (r.fullName + ' ' + (r.defaultBranch || '')).toLowerCase().includes(filter),
+  );
+  list.innerHTML = repos
+    .map(
+      (r) => `
     <div class="repo ${state.repo?.fullName === r.fullName ? ' sel' : ''}" data-repo="${r.fullName}" role="button" tabindex="0">
       <span class="radio"></span>
       <div style="flex:1;min-width:0;">
@@ -84,9 +93,12 @@ function renderRepoList() {
         <div class="slug" style="font-size:11.5px;">${r.defaultBranch || 'default branch'}</div>
       </div>
     </div>
-  `).join('');
+  `,
+    )
+    .join('');
   if (repos.length === 0) {
-    list.innerHTML = '<div class="state" style="padding:20px;"><p class="muted">No repositories match.</p></div>';
+    list.innerHTML =
+      '<div class="state" style="padding:20px;"><p class="muted">No repositories match.</p></div>';
   }
 }
 
@@ -96,7 +108,10 @@ async function scanRepo(repo: Repo) {
   state.checking = repo.fullName;
   renderStep1();
   try {
-    const res = await fetch(`/api/me/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/scan`, { method: 'POST' });
+    const res = await fetch(
+      `/api/me/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/scan`,
+      { method: 'POST' },
+    );
     if (!res.ok) throw new Error(await res.text());
     state.scan = (await res.json()) as ScanResponse;
     state.step = 2;
@@ -112,15 +127,19 @@ function renderStep2() {
   const container = document.getElementById('step2content') as HTMLElement;
   if (!container) return;
   if (!state.scan) {
-    container.innerHTML = '<div class="state"><p class="muted">Select a repository to detect skills.</p></div>';
+    container.innerHTML =
+      '<div class="state"><p class="muted">Select a repository to detect skills.</p></div>';
     return;
   }
   const skills = state.scan.skills || [];
   if (skills.length === 0) {
-    container.innerHTML = '<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>No skill found.</b> A skill is a folder containing a SKILL.md inside a top-level skills/ directory.</div></div></div>';
+    container.innerHTML =
+      '<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>No skill found.</b> A skill is a folder containing a SKILL.md inside a top-level skills/ directory.</div></div></div>';
     return;
   }
-  const items = skills.map((s, i) => `
+  const items = skills
+    .map(
+      (s, i) => `
     <div class="acc" data-acc>
       <div class="acc-h" data-acc-head style="display:flex;align-items:center;gap:12px;padding:13px 14px;cursor:pointer;">
         <input type="checkbox" data-skill-idx="${i}" checked style="width:18px;height:18px;flex:none;">
@@ -141,7 +160,9 @@ function renderStep2() {
         </div>
       </div>
     </div>
-  `).join('');
+  `,
+    )
+    .join('');
   container.innerHTML = `
     <div class="callout" style="margin-bottom:16px;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01" stroke-linecap="round"/></svg><div><b>${skills.length} skill${skills.length > 1 ? 's' : ''}</b> found. Everything below is read from each skill's SKILL.md frontmatter.</div></div></div>
     <div class="accs">${items}</div>
@@ -169,8 +190,12 @@ function renderStep3() {
 
 function selectedSkills(): DetectedSkill[] {
   if (!state.scan) return [];
-  const checked = Array.from(document.querySelectorAll('[data-skill-idx]:checked')) as HTMLInputElement[];
-  return checked.map((cb) => state.scan!.skills[Number(cb.getAttribute('data-skill-idx'))]).filter(Boolean);
+  const checked = Array.from(
+    document.querySelectorAll('[data-skill-idx]:checked'),
+  ) as HTMLInputElement[];
+  return checked
+    .map((cb) => state.scan!.skills[Number(cb.getAttribute('data-skill-idx'))])
+    .filter(Boolean);
 }
 
 function render() {
@@ -180,15 +205,18 @@ function render() {
   steps.forEach((el) => {
     const n = Number(el.getAttribute('data-step'));
     el.classList.remove('done', 'active', 'upcoming');
-    const cls = n < state.step ? 'done' : (n === state.step ? 'active' : 'upcoming');
+    const cls =
+      n < state.step ? 'done' : n === state.step ? 'active' : 'upcoming';
     el.classList.add(cls);
     const no = el.querySelector('.vno') as HTMLElement;
-    no.innerHTML = (cls === 'done') ? CHECK : String(n);
+    no.innerHTML = cls === 'done' ? CHECK : String(n);
   });
   const status = document.getElementById('repoStatus');
   if (status) {
-    if (state.checking) status.innerHTML = `<div class="callout" style="align-items:center;"><span class="spinner" style="width:16px;height:16px;flex:none;"></span><div>Scanning <b>${state.checking}</b> for SKILL.md files…</div></div>`;
-    else if (state.error) status.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>${state.error}</b></div></div>`;
+    if (state.checking)
+      status.innerHTML = `<div class="callout" style="align-items:center;"><span class="spinner" style="width:16px;height:16px;flex:none;"></span><div>Scanning <b>${state.checking}</b> for SKILL.md files…</div></div>`;
+    else if (state.error)
+      status.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>${state.error}</b></div></div>`;
     else status.innerHTML = '';
   }
 }
@@ -202,15 +230,28 @@ async function createDrafts(submit: boolean) {
     repoOwner: state.repo.owner,
     repoName: state.repo.name,
     ref: state.scan.commitSha,
-    skills: skills.map((s) => ({ slug: s.slug, name: s.name, description: s.description, license: s.license || '', tags: s.tags || [], version: s.version })),
+    skills: skills.map((s) => ({
+      slug: s.slug,
+      name: s.name,
+      description: s.description,
+      license: s.license || '',
+      tags: s.tags || [],
+      version: s.version,
+    })),
   };
-  const res = await fetch('/api/me/submissions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+  const res = await fetch('/api/me/submissions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
   if (!res.ok) throw new Error(await res.text());
   const { submissionIds } = (await res.json()) as { submissionIds: string[] };
   if (submit) {
     if (status) status.textContent = 'Submitting for review…';
     for (const id of submissionIds) {
-      const r = await fetch(`/api/me/submissions/${id}/submit`, { method: 'POST' });
+      const r = await fetch(`/api/me/submissions/${id}/submit`, {
+        method: 'POST',
+      });
       if (!r.ok) throw new Error(await r.text());
     }
   }
@@ -227,13 +268,26 @@ vsteps.addEventListener('click', (e) => {
     return;
   }
   const acc = target.closest('[data-acc-head]');
-  if (acc) { acc.closest('[data-acc]')?.classList.toggle('open'); return; }
+  if (acc) {
+    acc.closest('[data-acc]')?.classList.toggle('open');
+    return;
+  }
   const cont = target.closest('[data-continue]');
-  if (cont) { state.step = 3; render(); return; }
+  if (cont) {
+    state.step = 3;
+    render();
+    return;
+  }
   const save = target.closest('[data-save-draft]');
-  if (save) { createDrafts(false); return; }
+  if (save) {
+    createDrafts(false);
+    return;
+  }
   const sub = target.closest('[data-submit]');
-  if (sub) { createDrafts(true); return; }
+  if (sub) {
+    createDrafts(true);
+    return;
+  }
 });
 
 vsteps.addEventListener('input', (e) => {
@@ -241,7 +295,10 @@ vsteps.addEventListener('input', (e) => {
   if (target.id === 'repoFilter') renderRepoList();
 });
 
-loadRepos().then(render).catch((e) => {
-  const el = document.getElementById('step1content');
-  if (el) el.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;"><b>Failed to load repositories:</b> ${e.message}</div>`;
-});
+loadRepos()
+  .then(render)
+  .catch((e) => {
+    const el = document.getElementById('step1content');
+    if (el)
+      el.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;"><b>Failed to load repositories:</b> ${e.message}</div>`;
+  });

--- a/web/src/scripts/submit-wizard.ts
+++ b/web/src/scripts/submit-wizard.ts
@@ -25,6 +25,21 @@ interface ScanResponse {
 }
 const CHECK =
   '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>';
+
+/**
+ * Escape a string for safe insertion into HTML via template literals.
+ * Exported so the unit test can lock the invariant.
+ */
+export function esc(raw: string | number | null | undefined): string {
+  const s = String(raw ?? '');
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 const state = {
   step: 1,
   repo: null as Repo | null,
@@ -34,8 +49,13 @@ const state = {
   checking: null as string | null,
 };
 
-const vsteps = document.getElementById('vsteps') as HTMLElement;
-const steps = Array.from(vsteps.querySelectorAll('.vstep')) as HTMLElement[];
+const vsteps =
+  typeof document !== 'undefined'
+    ? (document.getElementById('vsteps') as HTMLElement)
+    : null;
+const steps = vsteps
+  ? (Array.from(vsteps.querySelectorAll('.vstep')) as HTMLElement[])
+  : [];
 
 async function loadRepos() {
   const res = await fetch('/api/me/repos');
@@ -86,11 +106,11 @@ function renderRepoList() {
   list.innerHTML = repos
     .map(
       (r) => `
-    <div class="repo ${state.repo?.fullName === r.fullName ? ' sel' : ''}" data-repo="${r.fullName}" role="button" tabindex="0">
+    <div class="repo ${state.repo?.fullName === r.fullName ? ' sel' : ''}" data-repo="${esc(r.fullName)}" role="button" tabindex="0">
       <span class="radio"></span>
       <div style="flex:1;min-width:0;">
-        <div style="font-weight:600;font-size:14px;">${r.fullName}</div>
-        <div class="slug" style="font-size:11.5px;">${r.defaultBranch || 'default branch'}</div>
+        <div style="font-weight:600;font-size:14px;">${esc(r.fullName)}</div>
+        <div class="slug" style="font-size:11.5px;">${esc(r.defaultBranch || 'default branch')}</div>
       </div>
     </div>
   `,
@@ -144,19 +164,19 @@ function renderStep2() {
       <div class="acc-h" data-acc-head style="display:flex;align-items:center;gap:12px;padding:13px 14px;cursor:pointer;">
         <input type="checkbox" data-skill-idx="${i}" checked style="width:18px;height:18px;flex:none;">
         <div style="flex:1;min-width:0;">
-          <div class="nm" style="font-weight:600;font-size:14.5px;">${s.name}</div>
-          <div class="sl" style="font-family:var(--mono);font-size:11.5px;color:var(--text-faint);">skills/${s.slug}/</div>
+          <div class="nm" style="font-weight:600;font-size:14.5px;">${esc(s.name)}</div>
+          <div class="sl" style="font-family:var(--mono);font-size:11.5px;color:var(--text-faint);">skills/${esc(s.slug)}/</div>
         </div>
-        <span class="tag" style="flex:none;">${s.tokenUpfront + s.tokenOndemand} tok</span>
+        <span class="tag" style="flex:none;">${esc(s.tokenUpfront + s.tokenOndemand)} tok</span>
         <svg class="chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
       </div>
       <div class="acc-body" style="max-height:0;overflow:hidden;padding:0 14px;border-top:1px solid transparent;">
         <div style="padding:12px 0;">
-          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">description</span><span class="v">${s.description}</span></div>
-          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">version</span><span class="v">${s.version}</span></div>
-          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">license</span><span class="v">${s.license || '—'}</span></div>
-          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">tags</span><span class="v">${(s.tags || []).map((t) => `<span class="tag">${t}</span>`).join(' ')}</span></div>
-          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">contents</span><span class="v">${s.fileCount} files · <span style="color:var(--accent-text);">${s.tokenUpfront + s.tokenOndemand} tokens</span></span></div>
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">description</span><span class="v">${esc(s.description)}</span></div>
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">version</span><span class="v">${esc(s.version)}</span></div>
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">license</span><span class="v">${esc(s.license) || '—'}</span></div>
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">tags</span><span class="v">${(s.tags || []).map((t) => `<span class="tag">${esc(t)}</span>`).join(' ')}</span></div>
+          <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">contents</span><span class="v">${esc(s.fileCount)} files · <span style="color:var(--accent-text);">${esc(s.tokenUpfront + s.tokenOndemand)} tokens</span></span></div>
         </div>
       </div>
     </div>
@@ -164,7 +184,7 @@ function renderStep2() {
     )
     .join('');
   container.innerHTML = `
-    <div class="callout" style="margin-bottom:16px;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01" stroke-linecap="round"/></svg><div><b>${skills.length} skill${skills.length > 1 ? 's' : ''}</b> found. Everything below is read from each skill's SKILL.md frontmatter.</div></div></div>
+    <div class="callout" style="margin-bottom:16px;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01" stroke-linecap="round"/></svg><div><b>${esc(skills.length)} skill${skills.length > 1 ? 's' : ''}</b> found. Everything below is read from each skill's SKILL.md frontmatter.</div></div></div>
     <div class="accs">${items}</div>
     <button class="btn btn-primary" data-continue style="margin-top:18px;">Continue with selected skills</button>
   `;
@@ -178,7 +198,7 @@ function renderStep3() {
     <p class="hint" style="margin-bottom:14px;">On submit, automated checks run and the selected skills enter the review queue. Drafts you save appear under <a href="/submissions" style="color:var(--accent-text);">My submissions</a>.</p>
     <div class="card" style="margin-bottom:16px;">
       <div class="kicker" style="margin-bottom:10px;"><span class="tick">//</span> SELECTED</div>
-      ${skills.map((s) => `<div style="padding:8px 0;border-bottom:1px solid var(--border);"><b>${s.name}</b> <span class="hint">skills/${s.slug}/</span></div>`).join('')}
+      ${skills.map((s) => `<div style="padding:8px 0;border-bottom:1px solid var(--border);"><b>${esc(s.name)}</b> <span class="hint">skills/${esc(s.slug)}/</span></div>`).join('')}
     </div>
     <div class="row" style="gap:10px;">
       <button class="btn btn-ghost" data-save-draft>Save draft</button>
@@ -214,9 +234,9 @@ function render() {
   const status = document.getElementById('repoStatus');
   if (status) {
     if (state.checking)
-      status.innerHTML = `<div class="callout" style="align-items:center;"><span class="spinner" style="width:16px;height:16px;flex:none;"></span><div>Scanning <b>${state.checking}</b> for SKILL.md files…</div></div>`;
+      status.innerHTML = `<div class="callout" style="align-items:center;"><span class="spinner" style="width:16px;height:16px;flex:none;"></span><div>Scanning <b>${esc(state.checking)}</b> for SKILL.md files…</div></div>`;
     else if (state.error)
-      status.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>${state.error}</b></div></div>`;
+      status.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>${esc(state.error)}</b></div></div>`;
     else status.innerHTML = '';
   }
 }
@@ -258,47 +278,49 @@ async function createDrafts(submit: boolean) {
   window.location.href = '/submissions';
 }
 
-vsteps.addEventListener('click', (e) => {
-  const target = e.target as HTMLElement;
-  const repo = target.closest('[data-repo]');
-  if (repo && state.repos) {
-    const fullName = repo.getAttribute('data-repo');
-    const r = state.repos.repos.find((x) => x.fullName === fullName);
-    if (r) scanRepo(r);
-    return;
-  }
-  const acc = target.closest('[data-acc-head]');
-  if (acc) {
-    acc.closest('[data-acc]')?.classList.toggle('open');
-    return;
-  }
-  const cont = target.closest('[data-continue]');
-  if (cont) {
-    state.step = 3;
-    render();
-    return;
-  }
-  const save = target.closest('[data-save-draft]');
-  if (save) {
-    createDrafts(false);
-    return;
-  }
-  const sub = target.closest('[data-submit]');
-  if (sub) {
-    createDrafts(true);
-    return;
-  }
-});
-
-vsteps.addEventListener('input', (e) => {
-  const target = e.target as HTMLElement;
-  if (target.id === 'repoFilter') renderRepoList();
-});
-
-loadRepos()
-  .then(render)
-  .catch((e) => {
-    const el = document.getElementById('step1content');
-    if (el)
-      el.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;"><b>Failed to load repositories:</b> ${e.message}</div>`;
+if (vsteps) {
+  vsteps.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    const repo = target.closest('[data-repo]');
+    if (repo && state.repos) {
+      const fullName = repo.getAttribute('data-repo');
+      const r = state.repos.repos.find((x) => x.fullName === fullName);
+      if (r) scanRepo(r);
+      return;
+    }
+    const acc = target.closest('[data-acc-head]');
+    if (acc) {
+      acc.closest('[data-acc]')?.classList.toggle('open');
+      return;
+    }
+    const cont = target.closest('[data-continue]');
+    if (cont) {
+      state.step = 3;
+      render();
+      return;
+    }
+    const save = target.closest('[data-save-draft]');
+    if (save) {
+      createDrafts(false);
+      return;
+    }
+    const sub = target.closest('[data-submit]');
+    if (sub) {
+      createDrafts(true);
+      return;
+    }
   });
+
+  vsteps.addEventListener('input', (e) => {
+    const target = e.target as HTMLElement;
+    if (target.id === 'repoFilter') renderRepoList();
+  });
+
+  loadRepos()
+    .then(render)
+    .catch((e) => {
+      const el = document.getElementById('step1content');
+      if (el)
+        el.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;"><b>Failed to load repositories:</b> ${esc(e.message)}</div>`;
+    });
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Astro frontend build: authenticated contributor surfaces.

## What changed

| Page | Notes |
|------|-------|
| **Auth-aware header** | `/api/me` fetched on every render; shows avatar + dropdown when signed in, otherwise "Sign in". |
| **Sign in (`/signin`)** | GitHub OAuth start page; redirects to `/` if already signed in. |
| **Settings (`/settings`)** | Account info, localStorage appearance prefs (theme/accent/density), syncable account toggles (`emailNotifications`/`publicProfile`), GitHub repo list, delete account. |
| **Submit wizard (`/submit`)** | 3-step client-side wizard: pick repo → scan → select skills → save draft or submit for review. JS required; noscript fallback. |
| **My submissions (`/submissions`)** | Grouped by the five real API states: `draft`, `in_review`, `changes_requested`, `published`, `rejected`, with correct per-state actions. |
| **Starred (`/starred`)** | Grid of starred skills for signed-in users. |
| **Star buttons** | Added to `SkillCard` and `/skill/[slug]`; anonymous users see sign-in link, authenticated users toggle via fetch. |

## Backend contract alignment

- Submission states match the API exactly: `draft/in_review/changes_requested/published/rejected` (no `approved`).
- Only `emailNotifications` and `publicProfile` are persisted via `PUT /api/me/settings`; theme/accent/density are localStorage-only.
- All mutations (logout, delete account, delete submission, withdraw, star/unstar) use same-origin JS `fetch`, not forms (DELETE is not supported by HTML forms).
- CSRF protection correctly attributed to the `SameSite=Lax` session cookie.

## Security

- No `set:html` on user-controlled data outside the already-tested `renderMarkdown` path.
- `SkillCard` refactor uses an overlay link so the star button is independently clickable without nesting interactive elements.

## Verified

- `npm run format:check` ✅
- `npm run lint` ✅
- `npx astro check` ✅
- `npx tsc --noEmit` ✅
- `npm test` (markdown sanitizer) ✅
- `npm run build` ✅
- `./gradlew test` ✅
- Two-service smoke test: anonymous paths (`/`, `/search`, `/signin`, `/starred`) render `200`; authed paths (`/settings`, `/submit`, `/submissions`) redirect to `/signin` (`302`) when not signed in.

## Not verified in this environment

- **Live authed-SSR smoke test** with a real session. OAuth is not configured here, so I could not obtain a valid session cookie to confirm that `/settings` or `/submissions` renders as the signed-in user. I verified the redirect behavior and that cookie forwarding is implemented, but the actual signed-in render needs a configured OAuth flow or a seeded session.
- **Malicious scan-fixture smoke test** through the real API scan/submit path. This requires a GitHub App installation pointing at a repo with a malicious `SKILL.md`, which is not available in this sandbox.

These are the two cross-seam checks that need a real environment; everything else is green.