### PR TITLE
Fix a11y: card-link names + footer heading order

### DIFF
--- a/web/src/components/SkillCard.astro
+++ b/web/src/components/SkillCard.astro
@@ -18,7 +18,7 @@ const initials = skill.name
 ---
 
 <div class="card skill-card" style="position:relative;">
-  <a class="card-link" href={`/skill/${skill.slug}`} style="position:absolute;inset:0;z-index:1;"
+  <a class="card-link" href={`/skill/${skill.slug}`} aria-label={skill.name || skill.slug} style="position:absolute;inset:0;z-index:1;"
 ></a>
   <div class="top">
     <div class="skill-ico">{initials}</div>

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -109,21 +109,21 @@ const pageTitle = title === 'androidskills.dev' ? title : `${title} · androidsk
                   </p>
                 </div>
                 <div>
-                  <h5>Explore</h5>
+                  <h2 class="foot-title">Explore</h2>
                   <a href="/search">Browse skills</a>
                   <a href="/bundles">Bundles</a>
                   <a href="/timeline">Timeline</a>
                   <a href="/cli">CLI tool</a>
                 </div>
                 <div>
-                  <h5>Contribute</h5>
+                  <h2 class="foot-title">Contribute</h2>
                   <a href="/submit">Submit a skill</a>
                   <a href="/signin">Sign in</a>
                   <a href="/about">Guidelines</a>
                   <a href="/contact">Contact</a>
                 </div>
                 <div>
-                  <h5>Project</h5>
+                  <h2 class="foot-title">Project</h2>
                   <a href="/about">About</a>
                   <a href="https://github.com/code-with-the-italians/androidskills.dev" target="_blank" rel="noopener">GitHub</a>
                 </div>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1547,13 +1547,14 @@ kbd,
   gap: 40px;
   padding-block: 48px;
 }
-.site-foot h5 {
+.site-foot .foot-title {
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--text-faint);
   margin-bottom: 14px;
+  font-weight: 600;
 }
 .site-foot a {
   display: block;
@@ -2016,7 +2017,7 @@ kbd,
     grid-template-columns: 1fr;
     gap: 8px;
   }
-  .site-foot h5 {
+  .site-foot .foot-title {
     margin-top: 18px;
   }
   .search input {


### PR DESCRIPTION
## What

Fixes two concrete Lighthouse accessibility failures on the home page (mobile).

## Changes

- **SkillCard.astro:** Added `aria-label={skill.name || skill.slug}` to the stretched whole-card link, giving screen readers a discernible name for every skill card.
- **BaseLayout.astro:** Changed footer column labels from `<h5>` to `<h2 class="foot-title">` so the page outline does not skip heading levels.
- **global.css:** Updated `.site-foot h5` selectors to `.site-foot .foot-title` and added `font-weight: 600`, preserving the exact visual style.

## Verification

- `npm run format:check` ✅
- `npm run lint` ✅
- `npx astro check` ✅
- `npx tsc --noEmit` ✅
- `npm test` ✅
- `npm run build` ✅

Lighthouse re-check should now report:
- Links do not have a discernible name — resolved
- Heading elements are not in a sequentially-descending order — resolved
