### PR TITLE
Fix light-theme color-contrast a11y failures

### DIFF
--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -19,13 +19,13 @@
   --border-2: light-dark(#d8dade, #343a44);
   --text: light-dark(#15171c, #f1f3f6);
   --text-dim: light-dark(#565c67, #a6adb8);
-  --text-faint: light-dark(#878d99, #69707c);
+  --text-faint: light-dark(#6b7280, #69707c);
 
   /* Accent — green (default) */
   --accent: #34d27e;
   --accent-strong: light-dark(#1f9d5b, #5be39a);
   --accent-soft: light-dark(#e7f8ee, #112318);
-  --accent-text: light-dark(#0c8c4d, #46e08f);
+  --accent-text: light-dark(#0b7a43, #46e08f);
   --accent-ink: #04130a;
 
   /* Status */


### PR DESCRIPTION
## What

Fixes two Lighthouse WCAG AA color-contrast failures in **light theme** only.

## Changes

- `--text-faint`: light value changed from `#878d99` → `#6b7280` (4.83:1 on white, passes AA).
- `--accent-text`: light value changed from `#0c8c4d` → `#0b7a43` (4.91:1 on `--accent-soft` mint, 5.23:1 on `--bg` off-white, passes AA).
- Dark theme values left unchanged.

## Verification

- `npm run format:check` ✅
- `npm run lint` ✅
- `npx astro check` ✅
- `npx tsc --noEmit` ✅
- `npm test` ✅
- `npm run build` ✅

Contrast ratios (WCAG AA normal text ≥ 4.5:1):

| Token | Light value | Background | Ratio |
|---|---|---|---|
| `--text-faint` | `#6b7280` | white | 4.83 |
| `--accent-text` | `#0b7a43` | `#e7f8ee` | 4.91 |
| `--accent-text` | `#0b7a43` | `#fbfbfc` | 5.23 |

## Design-system note

This is the minimal token-only change. Dark-theme values are untouched; `--text-faint` dark (`#69707c`) on the darkest body background is below 4.5:1 on paper, but the original report flagged only light theme, so I left the dark side unchanged pending design-system owner review.
