### PR TITLE
Security + a11y batch: headers, uniform 404, dark contrast, proxy XFF

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/api/Errors.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Errors.kt
@@ -113,6 +113,9 @@ fun Application.installApiErrorMapping() {
         ErrorResponse(ErrorBody(ex.code, ex.message ?: "Bad gateway")),
       )
     }
+    status(HttpStatusCode.NotFound) { call, _ ->
+      call.respond(HttpStatusCode.NotFound, ErrorResponse(ErrorBody("not_found", "Not found")))
+    }
     status(HttpStatusCode.TooManyRequests) { call, status ->
       val retryAfter = call.response.headers["Retry-After"] ?: "60"
       if (!call.response.headers.contains("Retry-After")) {

--- a/api/src/test/kotlin/dev/androidskills/api/AdminRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminRoutesTest.kt
@@ -50,6 +50,17 @@ class AdminRoutesTest {
     }
 
   @Test
+  fun `unknown admin route returns 404 identical to gated real route`() = testApplication {
+    val token = setupUser(Role.member)
+    application { module(TestSupport.newConfig(dir), oauth = fakeOAuth()) }
+    val real = client.get("/api/admin/queue") { header("Cookie", "as_session=$token") }
+    val unknown = client.get("/api/admin/xxx") { header("Cookie", "as_session=$token") }
+    assertEquals(HttpStatusCode.NotFound, real.status)
+    assertEquals(HttpStatusCode.NotFound, unknown.status)
+    assertEquals(real.bodyAsText(), unknown.bodyAsText())
+  }
+
+  @Test
   fun `admin queue returns 404 for non admin`() = testApplication {
     val token = setupUser(Role.member)
     application { module(TestSupport.newConfig(dir), oauth = fakeOAuth()) }

--- a/web/src/lib/proxy.ts
+++ b/web/src/lib/proxy.ts
@@ -20,8 +20,18 @@ export function createProxy(prefix: string): APIRoute {
 async function proxy(upstream: URL, request: Request): Promise<Response> {
   const headers = new Headers(request.headers);
   headers.delete('host');
+
+  // The edge proxy (Cloudflare) tells us the real client IP. If we trust it,
+  // rewrite X-Forwarded-For so the API can't be spoofed by a client-supplied
+  // header. Keep this in sync with the API's TRUSTED_PROXY_COUNT for the
+  // actual CF -> kamal -> web -> api hop chain.
+  const trustedIp = headers.get('cf-connecting-ip') || headers.get('x-real-ip');
   headers.delete('cf-connecting-ip');
   headers.delete('x-real-ip');
+  if (trustedIp) {
+    headers.set('x-forwarded-for', trustedIp);
+    headers.set('x-real-ip', trustedIp);
+  }
 
   const init: RequestInit & { duplex?: 'half' } = {
     method: request.method,

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,13 @@
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware(async (_ctx, next) => {
+  const res = await next();
+  res.headers.set('X-Frame-Options', 'DENY');
+  res.headers.set('X-Content-Type-Options', 'nosniff');
+  res.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  res.headers.set(
+    'Content-Security-Policy',
+    "frame-ancestors 'none'; object-src 'none'; base-uri 'none'",
+  );
+  return res;
+});

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -19,7 +19,7 @@
   --border-2: light-dark(#d8dade, #343a44);
   --text: light-dark(#15171c, #f1f3f6);
   --text-dim: light-dark(#565c67, #a6adb8);
-  --text-faint: light-dark(#6b7280, #69707c);
+  --text-faint: light-dark(#6b7280, #868d99);
 
   /* Accent — green (default) */
   --accent: #34d27e;


### PR DESCRIPTION
## What

Small batch of security and accessibility fixes.

## Changes

1. **Security response headers (web/src/middleware.ts)**
   - `X-Frame-Options: DENY`
   - `X-Content-Type-Options: nosniff`
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Content-Security-Policy: frame-ancestors 'none'; object-src 'none'; base-uri 'none'`
   - Deliberately does **not** add a restrictive `script-src`/`style-src` because the app relies on inline `<script is:inline>`, Astro-inlined modules, and inline `style="..."` attributes.

2. **API uniform 404 envelope (api/src/main/kotlin/dev/androidskills/api/Errors.kt)**
   - Added a `status(HttpStatusCode.NotFound)` handler so unknown paths return the same JSON `{"error":{"code":"not_found","message":"Not found"}}` envelope that gated admin routes already return.
   - This removes the observable difference between a real-but-gated admin route and a non-existent route.

3. **Dark-theme muted-text contrast (web/src/styles/global.css)**
   - `--text-faint` dark value: `#69707c` → `#868d99`.
   - Now passes WCAG AA (≥4.5:1) on `#0e1014`, `#16191f`, and `#1b1f26`.
   - Light value and `--text-dim` unchanged.

4. **Proxy X-Forwarded-For (web/src/lib/proxy.ts)**
   - When `cf-connecting-ip` or `x-real-ip` is present from the trusted edge, the proxy now rewrites `x-forwarded-for` (and sets `x-real-ip`) from that trusted IP instead of forwarding a client-supplied spoofed header.
   - Added a comment noting that the API's `TRUSTED_PROXY_COUNT` must stay in sync with the real `CF → kamal → web → api` hop chain.

## Verification

- web/: format, lint, astro check, tsc --noEmit, tests, build ✅
- api/: full `./gradlew test` ✅
- Live smoke test (API + built SSR):
  - HTML and proxied `/api/*` responses carry all four security headers ✅
  - `/api/admin/queue` (gated, no session) and `/api/admin/xxx` (unknown) return identical 404 bodies ✅

## Out of scope

Per instructions, the `npm audit` Astro / @astrojs/node advisories are left for a separate planned maintenance PR.
