### PR TITLE
fix(a11y): address Lighthouse findings across key templates

### DIFF
--- a/web/src/components/BarChart.astro
+++ b/web/src/components/BarChart.astro
@@ -11,7 +11,7 @@ const { title, data, max } = Astro.props;
 const top = max ?? Math.max(...data.map((d) => d.count), 1);
 ---
 <div class="card">
-  <h4 style="font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--text-faint);margin-bottom:16px;">{title}</h4>
+  <h2 style="font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--text-faint);margin-bottom:16px;">{title}</h2>
   <div style="display:flex;flex-direction:column;gap:10px;">
     {data.slice(0, 10).map((item) => (
       <div class="bar-row" style="display:flex;align-items:center;gap:12px;">

--- a/web/src/components/EmptyState.astro
+++ b/web/src/components/EmptyState.astro
@@ -17,7 +17,7 @@ const { title, body, class: className = '' } = Astro.props;
       </svg>
     </slot>
   </div>
-  <h3>{title}</h3>
+  <h2 class="empty-title">{title}</h2>
   {body && <p>{body}</p>}
   <slot name="action" />
 </div>
@@ -31,8 +31,10 @@ const { title, body, class: className = '' } = Astro.props;
     text-align: center;
     gap: 8px;
   }
-  .empty-state h3 {
+  .empty-title {
     font-size: 16px;
+    font-weight: 600;
+    margin: 0;
   }
   .empty-state p {
     font-size: 13px;

--- a/web/src/components/SkillCard.astro
+++ b/web/src/components/SkillCard.astro
@@ -23,7 +23,7 @@ const initials = skill.name
   <div class="top">
     <div class="skill-ico">{initials}</div>
     <div style="flex:1;min-width:0;">
-      <h3>{skill.name}</h3>
+      <h2 class="card-title">{skill.name}</h2>
       <div class="slug">{skill.slug}</div>
     </div>
     {skill.verified && <span class="badge ok">Verified</span>}

--- a/web/src/components/TimelineEvent.astro
+++ b/web/src/components/TimelineEvent.astro
@@ -31,7 +31,7 @@ const labels: Record<string, string> = {
       <span class="badge neutral" style="font-size:10px;">{labels[event.type] ?? event.type}</span>
     </div>
     <div style="font-family:var(--mono);font-size:11.5px;color:var(--text-faint);margin-top:3px;">
-      {event.authorHandle && <span>by <a href={`/u/${event.authorHandle}`} style="color:var(--accent-text);">{event.authorHandle}</a> · </span>}
+      {event.authorHandle && <span>by <a href={`/u/${event.authorHandle}`} style="color:var(--accent-text);text-decoration:underline;">{event.authorHandle}</a> · </span>}
       {new Date(event.at).toLocaleString()}
     </div>
   </div>

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -4,6 +4,14 @@ import rehypeParse from 'rehype-parse';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
 
+interface RenderOptions {
+  /**
+   * Shift heading levels down by one (h1→h2, h2→h3, etc.) so the page title
+   * remains the only h1. Useful for embedded readme content.
+   */
+  shiftHeadings?: boolean;
+}
+
 /**
  * Render markdown to sanitized HTML.
  *
@@ -12,7 +20,10 @@ import rehypeStringify from 'rehype-stringify';
  * `rehype-sanitize` to strip `<script>`, `onerror`, `javascript:` URIs, etc.
  * The result is safe for `set:html`.
  */
-export async function renderMarkdown(markdown: string): Promise<string> {
+export async function renderMarkdown(
+  markdown: string,
+  options: RenderOptions = {},
+): Promise<string> {
   const rawHtml = await marked.parse(markdown, { async: true });
 
   const sanitized = await unified()
@@ -21,5 +32,15 @@ export async function renderMarkdown(markdown: string): Promise<string> {
     .use(rehypeStringify)
     .process(rawHtml);
 
-  return String(sanitized);
+  let html = String(sanitized);
+  if (options.shiftHeadings) {
+    // shift headings down by one level: h1→h2, h2→h3, ... h6→h6 (can't go higher)
+    for (let level = 5; level >= 1; level--) {
+      const from = new RegExp(`<h${level}\\b([^>]*)>(.*?)</h${level}>`, 'g');
+      const to = `<h${level + 1}$1>$2</h${level + 1}>`;
+      html = html.replace(from, to);
+    }
+  }
+
+  return html;
 }

--- a/web/src/pages/admin/categories.astro
+++ b/web/src/pages/admin/categories.astro
@@ -43,9 +43,9 @@ const items = categories ?? [];
         <table class="tbl">
           <thead>
             <tr>
-              <th scope="col">Category</th>
-              <th scope="col">Slug</th>
-              <th scope="col"></th>
+              <th scope="col" id="cat-cat">Category</th>
+              <th scope="col" id="cat-slug">Slug</th>
+              <th scope="col" id="cat-actions">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -58,14 +58,14 @@ const items = categories ?? [];
             ) : (
               items.map((cat) => (
                 <tr data-category-slug={cat.slug}>
-                  <td>
+                  <td headers="cat-cat">
                     <div class="row" style="gap: 10px;">
-                      <span class="cat-sw" style="background: var(--accent);"></span>
+                      <span class="cat-sw" aria-hidden="true" style="background: var(--accent);"></span>
                       <span style="font-weight: 600;">{cat.name}</span>
                     </div>
                   </td>
-                  <td class="slug" style="font-size: 12.5px;">{cat.slug}</td>
-                  <td>
+                  <td class="slug" headers="cat-slug" style="font-size: 12.5px;">{cat.slug}</td>
+                  <td headers="cat-actions">
                     <button class="btn btn-sm btn-outline" data-rename={cat.slug} data-name={cat.name}>Rename</button>
                     <button class="btn btn-sm btn-danger" data-delete={cat.slug}>Merge</button>
                   </td>
@@ -81,7 +81,7 @@ const items = categories ?? [];
   <div class="scrim" id="addCat" style="display: none;">
     <div class="modal" role="dialog" aria-modal="true" aria-labelledby="addCatTitle" style="max-width: 440px;">
       <div class="mhd">
-        <b id="addCatTitle" style="font-size: 16px;">Add a category</b>
+        <b id="addCatTitle" style="font-size: 16px;" tabindex="-1">Add a category</b>
         <button class="icon-btn" data-modal-close aria-label="Close">×</button>
       </div>
       <div class="mbd stack" style="gap: 14px;">
@@ -104,7 +104,7 @@ const items = categories ?? [];
   <div class="scrim" id="renameCat" style="display: none;">
     <div class="modal" role="dialog" aria-modal="true" aria-labelledby="renameCatTitle" style="max-width: 440px;">
       <div class="mhd">
-        <b id="renameCatTitle" style="font-size: 16px;">Rename category</b>
+        <b id="renameCatTitle" style="font-size: 16px;" tabindex="-1">Rename category</b>
         <button class="icon-btn" data-modal-close aria-label="Close">×</button>
       </div>
       <div class="mbd stack" style="gap: 14px;">
@@ -133,7 +133,11 @@ const items = categories ?? [];
     btn.addEventListener('click', () => {
       const id = btn.getAttribute('data-modal-open');
       const scrim = id ? document.querySelector(id) : null;
-      if (scrim) (scrim as HTMLElement).style.display = 'flex';
+      if (scrim) {
+        (scrim as HTMLElement).style.display = 'flex';
+        const title = (scrim as HTMLElement).querySelector('b[id$="Title"]') as HTMLElement | null;
+        title?.focus({ preventScroll: true });
+      }
     });
   });
 

--- a/web/src/pages/admin/queue.astro
+++ b/web/src/pages/admin/queue.astro
@@ -32,8 +32,8 @@ const detail = selectedId ? await api.getQueueDetail(selectedId).catch(() => nul
   <div class="admin-split" data-queue-shell>
     <div class="queue-list" data-queue-list>
       {queue.map((item) => (
-        <div class="queue-item" data-queue-id={item.id} data-state={item.state} data-slug={item.slug} data-submitter={item.submitterHandle}>
-          <span class="avatar sm" style="color: var(--accent-text);">{item.submitterHandle.slice(0, 2).toUpperCase()}</span>
+        <div class="queue-item" data-queue-id={item.id} data-state={item.state} data-slug={item.slug} data-submitter={item.submitterHandle} role="button" tabindex="0" aria-label={`Review ${item.slug} by ${item.submitterHandle}, ${item.state}`}>
+          <span class="avatar sm" style="color: var(--accent-text);" aria-hidden="true">{item.submitterHandle.slice(0, 2).toUpperCase()}</span>
           <div style="flex: 1; min-width: 0;">
             <div class="between">
               <b style="font-size: 14px;">{item.slug}</b>
@@ -105,8 +105,8 @@ const detail = selectedId ? await api.getQueueDetail(selectedId).catch(() => nul
   const shell = document.querySelector('[data-queue-shell]');
   if (shell) {
     (async () => {
-      const list = shell.querySelector('[data-queue-list]');
-      const detail = shell.querySelector('[data-queue-detail]');
+      const list = shell.querySelector('[data-queue-list]') as HTMLElement | null;
+      const detail = shell.querySelector('[data-queue-detail]') as HTMLElement | null;
       const tabs = document.querySelector('[data-queue-tabs]');
       const search = document.querySelector('#queueSearch') as HTMLInputElement | null;
 
@@ -141,8 +141,8 @@ const detail = selectedId ? await api.getQueueDetail(selectedId).catch(() => nul
         list.innerHTML = filtered
           .map(
             (item) => `
-              <div class="queue-item ${selectedId === item.id ? 'active' : ''}" data-queue-id="${esc(item.id)}" data-state="${esc(item.state)}" data-slug="${esc(item.slug)}" data-submitter="${esc(item.submitterHandle)}" role="button" tabindex="0">
-                <span class="avatar sm" style="color: var(--accent-text);">${esc(item.submitterHandle.slice(0, 2).toUpperCase())}</span>
+              <div class="queue-item ${selectedId === item.id ? 'active' : ''}" data-queue-id="${esc(item.id)}" data-state="${esc(item.state)}" data-slug="${esc(item.slug)}" data-submitter="${esc(item.submitterHandle)}" role="button" tabindex="0" aria-label="Review ${esc(item.slug)} by ${esc(item.submitterHandle)}, ${esc(item.state)}">
+                <span class="avatar sm" style="color: var(--accent-text);" aria-hidden="true">${esc(item.submitterHandle.slice(0, 2).toUpperCase())}</span>
                 <div style="flex: 1; min-width: 0;">
                   <div class="between">
                     <b style="font-size: 14px;">${esc(item.slug)}</b>
@@ -221,6 +221,11 @@ const detail = selectedId ? await api.getQueueDetail(selectedId).catch(() => nul
               </div>
             </div>
           `;
+          const heading = detail.querySelector('h2');
+          if (heading) {
+            heading.setAttribute('tabindex', '-1');
+            heading.focus({ preventScroll: true });
+          }
         }
         renderList(Array.from(document.querySelectorAll('[data-queue-id]')).map((el) => ({
           id: el.getAttribute('data-queue-id')!,
@@ -233,6 +238,15 @@ const detail = selectedId ? await api.getQueueDetail(selectedId).catch(() => nul
       list?.addEventListener('click', (e) => {
         const item = (e.target as HTMLElement).closest('[data-queue-id]');
         if (!item) return;
+        const id = item.getAttribute('data-queue-id');
+        if (id) loadDetail(id);
+      });
+
+      list?.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        const item = (e.target as HTMLElement).closest('[data-queue-id]');
+        if (!item) return;
+        e.preventDefault();
         const id = item.getAttribute('data-queue-id');
         if (id) loadDetail(id);
       });

--- a/web/src/pages/admin/skills.astro
+++ b/web/src/pages/admin/skills.astro
@@ -37,13 +37,13 @@ const items = skills ?? [];
         </svg>
         <input name="q" type="search" value={q} placeholder="Search skills…">
       </div>
-      <select name="filter" class="select" style="width: auto; height: 36px; font-size: 13px;" onchange="this.form.submit()">
+      <select name="filter" class="select" aria-label="Filter skills" style="width: auto; height: 36px; font-size: 13px;" onchange="this.form.submit()">
         <option value="" selected={!filter}>All statuses</option>
         <option value="published" selected={filter === 'published'}>Published</option>
         <option value="unlisted" selected={filter === 'unlisted'}>Unlisted</option>
         <option value="flagged" selected={filter === 'flagged'}>Flagged</option>
       </select>
-      <select name="sort" class="select" style="width: auto; height: 36px; font-size: 13px;" onchange="this.form.submit()">
+      <select name="sort" class="select" aria-label="Sort skills" style="width: auto; height: 36px; font-size: 13px;" onchange="this.form.submit()">
         <option value="updated" selected={sort === 'updated'}>Sort: Updated</option>
         <option value="installs" selected={sort === 'installs'}>Installs</option>
         <option value="created" selected={sort === 'created'}>Created</option>
@@ -62,13 +62,13 @@ const items = skills ?? [];
         <table class="tbl">
           <thead>
             <tr>
-              <th scope="col">Skill</th>
-              <th scope="col">Category</th>
-              <th scope="col">Installs</th>
-              <th scope="col">Status</th>
-              <th scope="col">Featured</th>
-              <th scope="col">Updated</th>
-              <th scope="col"></th>
+              <th scope="col" id="sk-skill">Skill</th>
+              <th scope="col" id="sk-cat">Category</th>
+              <th scope="col" id="sk-installs">Installs</th>
+              <th scope="col" id="sk-status">Status</th>
+              <th scope="col" id="sk-featured">Featured</th>
+              <th scope="col" id="sk-updated">Updated</th>
+              <th scope="col" id="sk-actions">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -81,7 +81,7 @@ const items = skills ?? [];
             ) : (
               items.map((skill) => (
                 <tr data-skill-id={skill.id}>
-                  <td>
+                  <td headers="sk-skill">
                     <div class="row" style="gap: 10px;">
                       <span class="skill-ico" style="width: 30px; height: 30px; border-radius: 8px;">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" width="16" height="16">
@@ -97,12 +97,12 @@ const items = skills ?? [];
                       </div>
                     </div>
                   </td>
-                  <td>{skill.categorySlug ? <span class="tag">{skill.categorySlug}</span> : '—'}</td>
-                  <td class="num">{skill.installs.toLocaleString()}</td>
-                  <td><span class={`badge ${skill.status === 'published' ? 'ok' : skill.status === 'flagged' ? 'danger' : 'neutral'}`}>{skill.status}</span></td>
-                  <td>{skill.featured ? '★' : '—'}</td>
-                  <td class="faint" style="font-size: 12.5px;">{skill.updatedAt}</td>
-                  <td>
+                  <td headers="sk-cat">{skill.categorySlug ? <span class="tag">{skill.categorySlug}</span> : '—'}</td>
+                  <td headers="sk-installs" class="num">{skill.installs.toLocaleString()}</td>
+                  <td headers="sk-status"><span class={`badge ${skill.status === 'published' ? 'ok' : skill.status === 'flagged' ? 'danger' : 'neutral'}`}>{skill.status}</span></td>
+                  <td headers="sk-featured">{skill.featured ? '★' : '—'}</td>
+                  <td headers="sk-updated" class="faint" style="font-size: 12.5px;">{skill.updatedAt}</td>
+                  <td headers="sk-actions">
                     <select class="select select-sm" data-action style="width: auto; height: 32px; font-size: 13px;" aria-label={`Actions for ${skill.name}`}>
                       <option value="">Actions</option>
                       <option value={`feature:${skill.id}`}>{skill.featured ? 'Unfeature' : 'Feature'}</option>
@@ -124,7 +124,7 @@ const items = skills ?? [];
       <span class="faint" style="font-family: var(--mono); font-size: 12px;">Page {page}</span>
       <div class="pager">
         <a href={`?page=${Math.max(1, page - 1)}${filter ? `&filter=${filter}` : ''}${q ? `&q=${q}` : ''}${sort ? `&sort=${sort}` : ''}`} aria-label="Previous">←</a>
-        <a href={`?page=${page + 1}${filter ? `&filter=${filter}` : ''}${q ? `&q=${q}` : ''}${sort ? `&sort=${sort}` : ''}`}>→</a>
+        <a href={`?page=${page + 1}${filter ? `&filter=${filter}` : ''}${q ? `&q=${q}` : ''}${sort ? `&sort=${sort}` : ''}`} aria-label="Next page">→</a>
       </div>
     </div>
   )}

--- a/web/src/pages/admin/users.astro
+++ b/web/src/pages/admin/users.astro
@@ -36,7 +36,7 @@ const items = users ?? [];
         </svg>
         <input name="q" type="search" value={q} placeholder="Search by handle…">
       </div>
-      <select name="filter" class="select" style="width: auto; height: 36px; font-size: 13px;" onchange="this.form.submit()">
+      <select name="filter" class="select" aria-label="Filter users" style="width: auto; height: 36px; font-size: 13px;" onchange="this.form.submit()">
         <option value="" selected={!filter}>All statuses</option>
         <option value="active" selected={filter === 'active'}>Active</option>
         <option value="suspended" selected={filter === 'suspended'}>Suspended</option>
@@ -55,12 +55,12 @@ const items = users ?? [];
         <table class="tbl">
           <thead>
             <tr>
-              <th scope="col">User</th>
-              <th scope="col">Role</th>
-              <th scope="col">Skills</th>
-              <th scope="col">Joined</th>
-              <th scope="col">Status</th>
-              <th scope="col"></th>
+              <th scope="col" id="u-user">User</th>
+              <th scope="col" id="u-role">Role</th>
+              <th scope="col" id="u-skills">Skills</th>
+              <th scope="col" id="u-joined">Joined</th>
+              <th scope="col" id="u-status">Status</th>
+              <th scope="col" id="u-actions">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -73,7 +73,7 @@ const items = users ?? [];
             ) : (
               items.map((user) => (
                 <tr data-user-id={user.id}>
-                  <td>
+                  <td headers="u-user">
                     <div class="row" style="gap: 11px;">
                       <span class="avatar sm" style="color: var(--accent-text);">{user.handle.slice(0, 2).toUpperCase()}</span>
                       <div>
@@ -82,18 +82,18 @@ const items = users ?? [];
                       </div>
                     </div>
                   </td>
-                  <td>
+                  <td headers="u-role">
                     <span class={`badge ${user.role === 'admin' ? 'danger' : user.role === 'contributor' ? 'ok' : 'neutral'}`}>{user.role}</span>
                   </td>
-                  <td class="num">{user.skillCount}</td>
-                  <td class="faint" style="font-size: 12.5px;">{user.createdAt}</td>
-                  <td>
+                  <td headers="u-skills" class="num">{user.skillCount}</td>
+                  <td headers="u-joined" class="faint" style="font-size: 12.5px;">{user.createdAt}</td>
+                  <td headers="u-status">
                     <span class={`row ${user.status === 'suspended' ? 'danger' : ''}`} style="gap: 6px; font-size: 13px;">
                       <span class="pill-dot" style={user.status === 'suspended' ? 'background: var(--danger);' : ''}></span>
                       {user.status}
                     </span>
                   </td>
-                  <td>
+                  <td headers="u-actions">
                     <select class="select select-sm" data-user-action style="width: auto; height: 32px; font-size: 13px;" aria-label={`Actions for ${user.handle}`}>
                       <option value="">Actions</option>
                       <option value={`role:${user.id}:admin`}>Make admin</option>
@@ -117,7 +117,7 @@ const items = users ?? [];
       <span class="faint" style="font-family: var(--mono); font-size: 12px;">Page {page}</span>
       <div class="pager">
         <a href={`?page=${Math.max(1, page - 1)}${filter ? `&filter=${filter}` : ''}${q ? `&q=${q}` : ''}`} aria-label="Previous">←</a>
-        <a href={`?page=${page + 1}${filter ? `&filter=${filter}` : ''}${q ? `&q=${q}` : ''}`}>→</a>
+        <a href={`?page=${page + 1}${filter ? `&filter=${filter}` : ''}${q ? `&q=${q}` : ''}`} aria-label="Next page">→</a>
       </div>
     </div>
   )}

--- a/web/src/pages/search.astro
+++ b/web/src/pages/search.astro
@@ -80,14 +80,19 @@ const activeFilters = [
           ) : null}
 
           <div class="filter-grp">
-            <h4>Sort</h4>
-            <div class="seg" role="radiogroup" aria-label="Sort">
-              {['relevance', 'installs', 'updated', 'tokens'].map((s) => (
-                <a href={`/search?${new URLSearchParams({ ...Object.fromEntries(params), sort: s }).toString()}`}>
-                  <button aria-checked={sort === s} role="radio">{s}</button>
-                </a>
-              ))}
-            </div>
+            <label for="sort" class="h4">Sort</label>
+            <form action="/search" method="get" id="sortForm">
+              {Array.from(params.entries()).map(([k, v]) =>
+                k !== 'sort' ? <input type="hidden" name={k} value={v} /> : null
+              )}
+              <select id="sort" name="sort" class="select" onchange="this.form.submit()" aria-label="Sort results">
+                <option value="relevance" selected={sort === 'relevance'}>Most relevant</option>
+                <option value="installs" selected={sort === 'installs'}>Most installed</option>
+                <option value="updated" selected={sort === 'updated'}>Recently updated</option>
+                <option value="tokens" selected={sort === 'tokens'}>Fewest tokens</option>
+              </select>
+              <noscript><button type="submit" class="btn btn-sm btn-primary" style="margin-top:8px;">Apply</button></noscript>
+            </form>
           </div>
 
           {categories.length > 0 && (
@@ -100,11 +105,15 @@ const activeFilters = [
                 qs.delete('cat');
                 newCats.forEach((c) => qs.append('cat', c));
                 return (
-                  <a class="check" href={`/search?${qs.toString()}`}>
-                    <span class="box" style={active ? 'background:var(--accent);border-color:var(--accent);' : ''}>
+                  <a
+                    class="check"
+                    href={`/search?${qs.toString()}`}
+                    aria-label={`${cat.name} (${cat.count} skills) — ${active ? 'Remove' : 'Add'} filter`}
+                  >
+                    <span class="box" aria-hidden="true" style={active ? 'background:var(--accent);border-color:var(--accent);' : ''}>
                       {active && <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>}
                     </span>
-                    {cat.name}
+                    <span>{cat.name}</span>
                     <span class="ct">{cat.count}</span>
                   </a>
                 );
@@ -119,11 +128,15 @@ const activeFilters = [
               const qs = new URLSearchParams({ ...Object.fromEntries(params.entries()) });
               if (active) qs.delete('size'); else qs.set('size', s);
               return (
-                <a class="check" href={`/search?${qs.toString()}`}>
-                  <span class="box" style={active ? 'background:var(--accent);border-color:var(--accent);' : ''}>
+                <a
+                  class="check"
+                  href={`/search?${qs.toString()}`}
+                  aria-label={`${s} — ${active ? 'Remove' : 'Add'} token-size filter`}
+                >
+                  <span class="box" aria-hidden="true" style={active ? 'background:var(--accent);border-color:var(--accent);' : ''}>
                     {active && <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>}
                   </span>
-                  {s}
+                  <span>{s}</span>
                 </a>
               );
             })}
@@ -138,7 +151,7 @@ const activeFilters = [
 
           {!error && total > 0 && (
             <div class="between" style="margin-bottom:16px;">
-              <span class="muted" style="font-size:13.5px;">
+              <span class="muted" style="font-size:13.5px;" aria-live="polite" aria-atomic="true">
                 {total} skill{total !== 1 ? 's' : ''}
                 {q && <> for “<strong>{q}</strong>”</>}
               </span>
@@ -174,12 +187,12 @@ const activeFilters = [
             <div style="display:flex;justify-content:center;margin-top:32px;">
               <div class="pager">
                 {page > 1 && (
-                  <a href={`/search?${new URLSearchParams({ ...Object.fromEntries(params), page: String(page - 1) }).toString()}`}>←</a>
+                  <a href={`/search?${new URLSearchParams({ ...Object.fromEntries(params), page: String(page - 1) }).toString()}`} aria-label="Previous page">←</a>
                 )}
-                <span class="cur">{page}</span>
+                <span class="cur" aria-current="page">{page}</span>
                 <span class="faint">/ {totalPages}</span>
                 {page < totalPages && (
-                  <a href={`/search?${new URLSearchParams({ ...Object.fromEntries(params), page: String(page + 1) }).toString()}`}>→</a>
+                  <a href={`/search?${new URLSearchParams({ ...Object.fromEntries(params), page: String(page + 1) }).toString()}`} aria-label="Next page">→</a>
                 )}
               </div>
             </div>

--- a/web/src/pages/settings.astro
+++ b/web/src/pages/settings.astro
@@ -88,7 +88,7 @@ try {
               <div class="kicker" style="margin-bottom:2px;"><span class="tick">//</span> APPEARANCE</div>
               <div class="pref-row" data-pref="theme" style="display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:center;padding:14px 0;border-top:0;">
                 <div style="font-size:13.5px;color:var(--text-dim);font-weight:600;">Theme</div>
-                <div class="seg" style="display:inline-flex;"><button type="button" data-val="system">System</button><button type="button" data-val="light">Light</button><button type="button" data-val="dark">Dark</button></div>
+                <div class="seg" style="display:inline-flex;"><button type="button" data-val="system" aria-pressed="false">System</button><button type="button" data-val="light" aria-pressed="false">Light</button><button type="button" data-val="dark" aria-pressed="false">Dark</button></div>
               </div>
               <div class="pref-row" data-pref="accent" style="display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:center;padding:14px 0;border-top:1px solid var(--border);">
                 <div style="font-size:13.5px;color:var(--text-dim);font-weight:600;">Accent</div>
@@ -101,7 +101,7 @@ try {
               </div>
               <div class="pref-row" data-pref="density" style="display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:center;padding:14px 0;border-top:1px solid var(--border);">
                 <div style="font-size:13.5px;color:var(--text-dim);font-weight:600;">Density</div>
-                <div class="seg" style="display:inline-flex;"><button type="button" data-val="compact">Compact</button><button type="button" data-val="regular">Regular</button><button type="button" data-val="comfy">Comfy</button></div>
+                <div class="seg" style="display:inline-flex;"><button type="button" data-val="compact" aria-pressed="false">Compact</button><button type="button" data-val="regular" aria-pressed="false">Regular</button><button type="button" data-val="comfy" aria-pressed="false">Comfy</button></div>
               </div>
             </div>
 
@@ -117,7 +117,7 @@ try {
                 <span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
                 <span>Public profile</span>
               </label>
-              <div id="settingsStatus" class="hint" style="margin-top:10px;"></div>
+              <div id="settingsStatus" class="hint" style="margin-top:10px;" aria-live="polite" aria-atomic="true"></div>
             </div>
           </section>
 

--- a/web/src/pages/signin.astro
+++ b/web/src/pages/signin.astro
@@ -32,7 +32,7 @@ try {
           Continue with GitHub
         </a>
         <p class="hint" style="margin-top:16px;font-size:12.5px;">
-          By signing in, you agree to our <a href="/about" style="color:var(--accent-text);">community guidelines</a>.
+          By signing in, you agree to our <a href="/about" style="color:var(--accent-text);text-decoration:underline;">community guidelines</a>.
         </p>
       </div>
     </div>

--- a/web/src/pages/skill/[slug].astro
+++ b/web/src/pages/skill/[slug].astro
@@ -30,7 +30,7 @@ try {
   return Astro.redirect('/404');
 }
 
-const readmeHtml = skill.readmeMd ? await renderMarkdown(skill.readmeMd) : '';
+const readmeHtml = skill.readmeMd ? await renderMarkdown(skill.readmeMd, { shiftHeadings: true }) : '';
 const fileTree = files?.tree ?? [];
 ---
 
@@ -110,20 +110,27 @@ const fileTree = files?.tree ?? [];
         <!-- Sidebar: file tree + versions -->
         <aside class="stack">
           {fileTree.length > 0 && (
-            <div class="card" style="padding:0;overflow:hidden;">
+            <div class="card" style="padding:0;overflow:hidden;" role="region" aria-label="File tree">
               <div style="padding:14px 18px;border-bottom:1px solid var(--border);">
                 <h4 style="font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--text-faint);">Files</h4>
               </div>
-              <div style="padding:8px;">
+              <div style="padding:8px;" role="list">
                 {fileTree.map((node) => (
-                  <a
-                    href={node.type === 'file' ? `/skill/${slug}/files/${node.path}` : '#'}
-                    class="file-row"
-                    style={node.type === 'dir' ? 'font-weight:600;' : ''}
-                  >
-                    <span class="nm">{node.name}</span>
-                    {node.type === 'file' && <span class="sz">{node.size}B</span>}
-                  </a>
+                  node.type === 'file' ? (
+                    <a
+                      href={`/skill/${slug}/files/${node.path}`}
+                      class="file-row"
+                      role="listitem"
+                      aria-label={`File ${node.name} (${node.size} bytes)`}
+                    >
+                      <span class="nm">{node.name}</span>
+                      <span class="sz">{node.size}B</span>
+                    </a>
+                  ) : (
+                    <span class="file-row" role="listitem" style="font-weight:600;" aria-label={`Directory ${node.name}`}>
+                      <span class="nm">{node.name}</span>
+                    </span>
+                  )
                 ))}
               </div>
             </div>

--- a/web/src/pages/submissions.astro
+++ b/web/src/pages/submissions.astro
@@ -83,12 +83,12 @@ const totalSubmissions = sorted.reduce((sum, g) => sum + g.items.length, 0);
                       <div class="actions" style="display:flex;gap:8px;flex-wrap:wrap;">
                         {g.state === 'draft' && (
                           <>
-                            <button class="btn btn-sm btn-primary" data-action="submit" type="button">Submit</button>
-                            <button class="btn btn-sm btn-ghost" data-action="delete" type="button">Delete</button>
+                            <button class="btn btn-sm btn-primary" data-action="submit" type="button" aria-label={`Submit ${item.slug} for review`}>Submit</button>
+                            <button class="btn btn-sm btn-ghost" data-action="delete" type="button" aria-label={`Delete ${item.slug} draft`}>Delete</button>
                           </>
                         )}
                         {(g.state === 'in_review' || g.state === 'changes_requested') && (
-                          <button class="btn btn-sm btn-ghost" data-action="withdraw" type="button">Withdraw</button>
+                          <button class="btn btn-sm btn-ghost" data-action="withdraw" type="button" aria-label={`Withdraw ${item.slug}`}>Withdraw</button>
                         )}
                         {(g.state === 'published' || g.state === 'rejected') && (
                           <span class="tag">{g.state}</span>

--- a/web/src/pages/submit.astro
+++ b/web/src/pages/submit.astro
@@ -25,25 +25,25 @@ try {
       </div>
 
       <div class="submit-grid" style="display:grid;grid-template-columns:1fr 320px;gap:36px;align-items:start;">
-        <div class="vsteps" id="vsteps">
-          <div class="vstep" data-step="1">
-            <div class="vno">1</div>
+        <div class="vsteps" id="vsteps" aria-label="Submission steps">
+          <div class="vstep active" data-step="1" aria-current="step">
+            <div class="vno" aria-hidden="true">1</div>
             <div class="vbody">
-              <div class="vhead"><h3>Repository</h3></div>
+              <div class="vhead"><h2 class="vtitle">Repository</h2></div>
               <div class="vcontent" id="step1content"></div>
             </div>
           </div>
           <div class="vstep" data-step="2">
-            <div class="vno">2</div>
+            <div class="vno" aria-hidden="true">2</div>
             <div class="vbody">
-              <div class="vhead"><h3>Detected skills</h3></div>
+              <div class="vhead"><h2 class="vtitle">Detected skills</h2></div>
               <div class="vcontent" id="step2content"></div>
             </div>
           </div>
           <div class="vstep" data-step="3">
-            <div class="vno">3</div>
+            <div class="vno" aria-hidden="true">3</div>
             <div class="vbody">
-              <div class="vhead"><h3>Review & submit</h3></div>
+              <div class="vhead"><h2 class="vtitle">Review & submit</h2></div>
               <div class="vcontent" id="step3content"></div>
             </div>
           </div>
@@ -75,6 +75,8 @@ try {
   </noscript>
 
   <style>
+    .vtitle { font-size: 16.5px; font-weight: 600; margin: 0; }
+    .vtitle { font-size: 16.5px; font-weight: 600; margin: 0; }
     .vsteps { display: flex; flex-direction: column; }
     .vstep { display: grid; grid-template-columns: 32px 1fr; gap: 16px; position: relative; padding-bottom: 26px; }
     .vstep:last-child { padding-bottom: 0; }
@@ -98,7 +100,9 @@ try {
     .repo.sel { background: var(--accent-soft); }
     .acc { border: 1px solid var(--border); border-radius: var(--r-md); overflow: hidden; background: var(--surface); }
     .acc + .acc { margin-top: 10px; }
-    .acc-h:hover { background: var(--surface-2); }
+    .acc-h { display: flex; align-items: center; gap: 12px; padding: 13px 14px; cursor: pointer; }
+    .acc-h:hover, .acc-h:focus-visible { background: var(--surface-2); outline: none; }
+    .acc.open .acc-h { background: var(--surface-2); }
     .acc .acc-body { transition: max-height 0.28s ease, opacity 0.22s ease, padding 0.28s ease, border-color 0.28s ease; }
     .acc.open .acc-body { max-height: 720px; opacity: 1; padding: 2px 14px 12px; border-top-color: var(--border); }
     .acc.open .chev { transform: rotate(180deg); }

--- a/web/src/pages/timeline.astro
+++ b/web/src/pages/timeline.astro
@@ -44,10 +44,10 @@ const totalPages = result?.totalPages ?? 0;
           {totalPages > 1 && (
             <div style="display:flex;justify-content:center;margin-top:24px;">
               <div class="pager">
-                {page > 1 && <a href={`/timeline?page=${page - 1}`}>←</a>}
-                <span class="cur">{page}</span>
+                {page > 1 && <a href={`/timeline?page=${page - 1}`} aria-label="Previous page">←</a>}
+                <span class="cur" aria-current="page">{page}</span>
                 <span class="faint">/ {totalPages}</span>
-                {page < totalPages && <a href={`/timeline?page=${page + 1}`}>→</a>}
+                {page < totalPages && <a href={`/timeline?page=${page + 1}`} aria-label="Next page">→</a>}
               </div>
             </div>
           )}

--- a/web/src/scripts/submit-wizard.ts
+++ b/web/src/scripts/submit-wizard.ts
@@ -99,8 +99,8 @@ function renderRepoList() {
   list.innerHTML = repos
     .map(
       (r) => `
-    <div class="repo ${state.repo?.fullName === r.fullName ? ' sel' : ''}" data-repo="${esc(r.fullName)}" role="button" tabindex="0">
-      <span class="radio"></span>
+    <div class="repo ${state.repo?.fullName === r.fullName ? ' sel' : ''}" data-repo="${esc(r.fullName)}" role="button" tabindex="0" aria-pressed="${state.repo?.fullName === r.fullName ? 'true' : 'false'}" aria-label="Select repository ${esc(r.fullName)}">
+      <span class="radio" aria-hidden="true"></span>
       <div style="flex:1;min-width:0;">
         <div style="font-weight:600;font-size:14px;">${esc(r.fullName)}</div>
         <div class="slug" style="font-size:11.5px;">${esc(r.defaultBranch || 'default branch')}</div>
@@ -154,8 +154,8 @@ function renderStep2() {
     .map(
       (s, i) => `
     <div class="acc" data-acc>
-      <div class="acc-h" data-acc-head style="display:flex;align-items:center;gap:12px;padding:13px 14px;cursor:pointer;">
-        <input type="checkbox" data-skill-idx="${i}" checked style="width:18px;height:18px;flex:none;">
+      <div class="acc-h" data-acc-head role="button" tabindex="0" aria-expanded="true" aria-label="${esc(s.name)} skill details">
+        <input type="checkbox" data-skill-idx="${i}" checked style="width:18px;height:18px;flex:none;" aria-label="Select ${esc(s.name)} for submission">
         <div style="flex:1;min-width:0;">
           <div class="nm" style="font-weight:600;font-size:14.5px;">${esc(s.name)}</div>
           <div class="sl" style="font-family:var(--mono);font-size:11.5px;color:var(--text-faint);">skills/${esc(s.slug)}/</div>
@@ -163,7 +163,7 @@ function renderStep2() {
         <span class="tag" style="flex:none;">${esc(s.tokenUpfront + s.tokenOndemand)} tok</span>
         <svg class="chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
       </div>
-      <div class="acc-body" style="max-height:0;overflow:hidden;padding:0 14px;border-top:1px solid transparent;">
+      <div class="acc-body" style="max-height:0;overflow:hidden;padding:0 14px;border-top:1px solid transparent;" role="region" aria-label="${esc(s.name)} metadata">
         <div style="padding:12px 0;">
           <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">description</span><span class="v">${esc(s.description)}</span></div>
           <div class="kv" style="display:grid;grid-template-columns:130px 1fr;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:14px;"><span class="k" style="font-family:var(--mono);font-size:12px;color:var(--text-faint);">version</span><span class="v">${esc(s.version)}</span></div>
@@ -177,7 +177,7 @@ function renderStep2() {
     )
     .join('');
   container.innerHTML = `
-    <div class="callout" style="margin-bottom:16px;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01" stroke-linecap="round"/></svg><div><b>${esc(skills.length)} skill${skills.length > 1 ? 's' : ''}</b> found. Everything below is read from each skill's SKILL.md frontmatter.</div></div></div>
+    <div class="callout" style="margin-bottom:16px;" aria-live="polite" aria-atomic="true"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01" stroke-linecap="round"/></svg><div><b>${esc(skills.length)} skill${skills.length > 1 ? 's' : ''}</b> found. Everything below is read from each skill's SKILL.md frontmatter.</div></div></div>
     <div class="accs">${items}</div>
     <button class="btn btn-primary" data-continue style="margin-top:18px;">Continue with selected skills</button>
   `;
@@ -195,9 +195,9 @@ function renderStep3() {
     </div>
     <div class="row" style="gap:10px;">
       <button class="btn btn-ghost" data-save-draft>Save draft</button>
-      <button class="btn btn-primary btn-lg" data-submit><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;"><path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z"/></svg> Submit for review</button>
+      <button class="btn btn-primary btn-lg" data-submit aria-busy="false"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;"><path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z"/></svg> Submit for review</button>
     </div>
-    <div id="submitStatus" class="hint" style="margin-top:10px;"></div>
+    <div id="submitStatus" class="hint" style="margin-top:10px;" aria-live="polite" aria-atomic="true"></div>
   `;
 }
 
@@ -221,9 +221,15 @@ function render() {
     const cls =
       n < state.step ? 'done' : n === state.step ? 'active' : 'upcoming';
     el.classList.add(cls);
+    el.setAttribute('aria-current', cls === 'active' ? 'step' : 'false');
     const no = el.querySelector('.vno') as HTMLElement;
     no.innerHTML = cls === 'done' ? CHECK : String(n);
   });
+  const activeStep = steps.find((s) => s.classList.contains('active'));
+  if (activeStep) {
+    const title = activeStep.querySelector('.vtitle') as HTMLElement | null;
+    title?.focus({ preventScroll: true });
+  }
   const status = document.getElementById('repoStatus');
   if (status) {
     if (state.checking)
@@ -238,7 +244,16 @@ async function createDrafts(submit: boolean) {
   const skills = selectedSkills();
   if (skills.length === 0 || !state.repo || !state.scan) return;
   const status = document.getElementById('submitStatus');
+  const submitBtn = document.querySelector(
+    '[data-submit]',
+  ) as HTMLButtonElement | null;
+  const saveBtn = document.querySelector(
+    '[data-save-draft]',
+  ) as HTMLButtonElement | null;
   if (status) status.textContent = 'Creating drafts…';
+  submitBtn?.setAttribute('aria-busy', 'true');
+  submitBtn?.setAttribute('disabled', 'true');
+  saveBtn?.setAttribute('disabled', 'true');
   const payload = {
     repoOwner: state.repo.owner,
     repoName: state.repo.name,
@@ -277,6 +292,10 @@ async function createDrafts(submit: boolean) {
     const msg = e instanceof Error ? e.message : 'Submission failed';
     if (status) status.textContent = msg;
     showError(msg);
+  } finally {
+    submitBtn?.setAttribute('aria-busy', 'false');
+    submitBtn?.removeAttribute('disabled');
+    saveBtn?.removeAttribute('disabled');
   }
 }
 
@@ -291,8 +310,10 @@ if (vsteps) {
       return;
     }
     const acc = target.closest('[data-acc-head]');
-    if (acc) {
-      acc.closest('[data-acc]')?.classList.toggle('open');
+    if (acc && !target.closest('input[type="checkbox"]')) {
+      const panel = acc.closest('[data-acc]') as HTMLElement | null;
+      const expanded = panel?.classList.toggle('open');
+      acc.setAttribute('aria-expanded', String(expanded));
       return;
     }
     const cont = target.closest('[data-continue]');
@@ -310,6 +331,20 @@ if (vsteps) {
     if (sub) {
       createDrafts(true);
       return;
+    }
+  });
+
+  vsteps.addEventListener('keydown', (e) => {
+    const target = e.target as HTMLElement;
+    const repo = target.closest('[data-repo]');
+    if (repo && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
+      repo.dispatchEvent(new Event('click', { bubbles: true }));
+    }
+    const acc = target.closest('[data-acc-head]');
+    if (acc && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
+      acc.dispatchEvent(new Event('click', { bubbles: true }));
     }
   });
 

--- a/web/src/scripts/submit-wizard.ts
+++ b/web/src/scripts/submit-wizard.ts
@@ -154,7 +154,7 @@ function renderStep2() {
     .map(
       (s, i) => `
     <div class="acc" data-acc>
-      <div class="acc-h" data-acc-head role="button" tabindex="0" aria-expanded="true" aria-label="${esc(s.name)} skill details">
+      <div class="acc-h" data-acc-head role="button" tabindex="0" aria-expanded="false" aria-label="${esc(s.name)} skill details">
         <input type="checkbox" data-skill-idx="${i}" checked style="width:18px;height:18px;flex:none;" aria-label="Select ${esc(s.name)} for submission">
         <div style="flex:1;min-width:0;">
           <div class="nm" style="font-weight:600;font-size:14.5px;">${esc(s.name)}</div>
@@ -342,7 +342,11 @@ if (vsteps) {
       repo.dispatchEvent(new Event('click', { bubbles: true }));
     }
     const acc = target.closest('[data-acc-head]');
-    if (acc && (e.key === 'Enter' || e.key === ' ')) {
+    if (
+      acc &&
+      !target.closest('input[type="checkbox"]') &&
+      (e.key === 'Enter' || e.key === ' ')
+    ) {
       e.preventDefault();
       acc.dispatchEvent(new Event('click', { bubbles: true }));
     }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1275,7 +1275,8 @@ kbd,
   border: 1px solid var(--border);
   border-radius: var(--r-md);
 }
-.seg-item {
+.seg-item,
+.seg > button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1292,7 +1293,8 @@ kbd,
   min-height: 24px;
   min-width: 24px;
 }
-.seg-item[aria-checked='true'] {
+.seg-item[aria-checked='true'],
+.seg > button[aria-pressed='true'] {
   background: var(--surface);
   color: var(--text);
   box-shadow: var(--shadow-1);

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -31,8 +31,8 @@
   /* Status */
   --ok: light-dark(#1f9d5b, #46e08f);
   --warn: light-dark(#b5820a, #e7b53d);
-  --danger: light-dark(#cf3b3b, #ff6b6b);
-  --info: light-dark(#2f6fd6, #6c8cff);
+  --danger: light-dark(#b83030, #ff6b6b);
+  --info: light-dark(#2d69ce, #6c8cff);
   --warn-soft: light-dark(#fbf2da, #2a230f);
   --danger-soft: light-dark(#fbe6e6, #2a1212);
   --info-soft: light-dark(#e8f0fd, #111a2e);
@@ -422,6 +422,7 @@ textarea {
   font-weight: 800;
   letter-spacing: -0.03em;
   font-size: 19px;
+  min-height: 24px;
 }
 .brand .glyph {
   width: 26px;
@@ -460,6 +461,7 @@ textarea {
   align-items: center;
   gap: 2px;
   margin-left: 8px;
+  min-height: 24px;
 }
 .nav a {
   padding: 7px 11px;
@@ -467,6 +469,9 @@ textarea {
   color: var(--text-dim);
   font-size: 14px;
   font-weight: 500;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
 }
 .nav a:hover {
   color: var(--text);
@@ -551,6 +556,7 @@ textarea {
   padding: 0 12px;
   font-size: 13px;
   border-radius: var(--r-sm);
+  min-height: 24px;
 }
 .btn-lg {
   --h: 50px;
@@ -571,6 +577,8 @@ textarea {
 .icon-btn {
   width: 36px;
   height: 36px;
+  min-width: 36px;
+  min-height: 36px;
   border-radius: var(--r-sm);
   border: 1px solid var(--border);
   background: var(--surface);
@@ -722,8 +730,10 @@ kbd,
 .chip {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
   height: 28px;
+  min-height: 24px;
   padding: 0 11px;
   border-radius: 999px;
   font-size: 12.5px;
@@ -734,6 +744,7 @@ kbd,
   cursor: pointer;
   transition: 0.12s;
   white-space: nowrap;
+  vertical-align: middle;
 }
 .chip:hover {
   border-color: var(--border-2);
@@ -856,7 +867,8 @@ kbd,
   width: 22px;
   height: 22px;
 }
-.skill-card h3 {
+.skill-card h3,
+.skill-card .card-title {
   font-size: 16.5px;
   letter-spacing: -0.02em;
 }
@@ -1263,18 +1275,24 @@ kbd,
   border: 1px solid var(--border);
   border-radius: var(--r-md);
 }
-.seg button {
+.seg-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   appearance: none;
   border: 0;
   background: transparent;
-  padding: 6px 12px;
+  padding: 8px 14px;
   font-size: 13px;
   font-weight: 600;
   color: var(--text-dim);
   border-radius: 7px;
   cursor: pointer;
+  text-decoration: none;
+  min-height: 24px;
+  min-width: 24px;
 }
-.seg button[aria-pressed='true'] {
+.seg-item[aria-checked='true'] {
   background: var(--surface);
   color: var(--text);
   box-shadow: var(--shadow-1);
@@ -1293,13 +1311,16 @@ kbd,
 .filter-grp:first-child {
   padding-top: 0;
 }
-.filter-grp > h4 {
+.filter-grp > h4,
+.filter-grp > .h4 {
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-faint);
   margin-bottom: 12px;
+  display: block;
+  font-weight: 700;
 }
 .check {
   display: flex;
@@ -1324,7 +1345,15 @@ kbd,
   transition: 0.12s;
 }
 .check input {
-  display: none;
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+.check input:focus-visible + .box {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .check input:checked + .box {
   background: var(--accent);
@@ -1462,6 +1491,7 @@ kbd,
   border: 0;
   cursor: pointer;
   color: var(--text);
+  min-height: 24px;
 }
 .drawer-panel a:hover,
 .drawer-panel button:hover {


### PR DESCRIPTION
## Summary

Closes the remaining automated accessibility gaps found by Lighthouse/axe-core across the public surfaces and admin shell.

## What changed

| Area | Fix |
|------|-----|
| **Color contrast (light)** | `--danger` light darkened to `#b83030` and `--info` light darkened to `#2d69ce`, so `.btn-danger`, `.badge.danger`, and `.badge.info` now exceed 4.5:1 on their soft backgrounds. |
| **Touch targets** | Added `min-height`/`min-width` to `.brand`, `.nav a`, `.icon-btn`, `.btn-sm`, `.chip`, `.seg-item`, and drawer/mobile links so repeated target-size failures resolve. |
| **Search sort** | Replaced the sort segmented control with a labelled `<select>` inside a GET form; removes the last target-size issue and the label-content-name-mismatch on category filters by including visible text in `aria-label`. |
| **Admin category table** | Added `id` to `<th>` elements and `headers` to every `<td>` so the action column is also programmatically associated. |
| **Links in text blocks** | Added underline to author links in `TimelineEvent` and the community-guidelines link on `signin` so they pass `link-in-text-block` in both themes. |
| **Heading order** | `EmptyState` now renders `h2`, preserving sequential heading order on pages that use it after an `h1`. |

## Verification

- **Lighthouse accessibility** = 1.0 on home, search, skill, submit, submissions, settings, timeline, trends, bundles, author, and all admin surfaces.
- **Dark-mode smoke checks** pass for home, search, skill, settings, timeline, admin-skills, and admin-queue.
- **Web checks**: `npm run format:check`, `npm run lint`, `npx astro check`, `npx tsc --noEmit`, `npm test`, and `npm run build` all pass.
- **API checks**: `./gradlew test` and `./gradlew spotlessCheck` pass.

## Security/constraint notes

- No security invariants changed: toast still uses `textContent`, `404.astro` remains static and path-independent, and `robots.txt` still omits `/admin`.
- All changes are against existing API endpoints and CSS tokens; no backend features were invented.
