### PR TITLE
fix(a11y): search category chip aria-labels start with visible text

### DIFF
--- a/web/src/pages/search.astro
+++ b/web/src/pages/search.astro
@@ -108,7 +108,7 @@ const activeFilters = [
                   <a
                     class="check"
                     href={`/search?${qs.toString()}`}
-                    aria-label={`${cat.name} (${cat.count} skills) — ${active ? 'Remove' : 'Add'} filter`}
+                    aria-label={`${cat.name} ${cat.count} — ${active ? 'Remove' : 'Add'} filter`}
                   >
                     <span class="box" aria-hidden="true" style={active ? 'background:var(--accent);border-color:var(--accent);' : ''}>
                       {active && <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>}


### PR DESCRIPTION
fix(a11y): search category chip aria-labels start with visible text

The category filter chips on `/search` used `aria-label` values like `Accessibility (1 skills) — Add filter`, which reworded the visible text and tripped WCAG 2.5.3 "Label in Name." The accessible name now begins with the exact visible tokens (`Accessibility 1 — Add filter`), so speech-input and accessible name calculations stay aligned with the visible label.

- web: format:check, lint, astro check, tsc --noEmit, tests, and build all pass.
