### PR TITLE
fix(web): address 3 low-priority audit findings

### DIFF
--- a/web/src/components/BarChart.astro
+++ b/web/src/components/BarChart.astro
@@ -11,7 +11,7 @@ const { title, data, max } = Astro.props;
 const top = max ?? Math.max(...data.map((d) => d.count), 1);
 ---
 <div class="card">
-  <h2 style="font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--text-faint);margin-bottom:16px;">{title}</h2>
+  <span class="section-label" style="margin-bottom:16px;">{title}</span>
   <div style="display:flex;flex-direction:column;gap:10px;">
     {data.slice(0, 10).map((item) => (
       <div class="bar-row" style="display:flex;align-items:center;gap:12px;">

--- a/web/src/pages/admin/queue.astro
+++ b/web/src/pages/admin/queue.astro
@@ -15,10 +15,10 @@ const detail = selectedId ? await api.getQueueDetail(selectedId).catch(() => nul
 
 <AdminLayout title="Review queue" me={me}>
   <div class="between" style="margin-bottom: 18px; flex-wrap: wrap; gap: 12px;">
-    <div class="tabs" style="border: 0; gap: 6px;" data-queue-tabs role="tablist" aria-label="Queue filter">
-      <button data-filter="all" aria-selected="true" role="tab" class="queue-tab">All</button>
-      <button data-filter="in_review" role="tab" class="queue-tab">Pending</button>
-      <button data-filter="changes_requested" role="tab" class="queue-tab">Changes requested</button>
+    <div class="tabs" style="border: 0; gap: 6px;" data-queue-tabs role="group" aria-label="Queue filter">
+      <button data-filter="all" aria-pressed="true" class="queue-tab">All</button>
+      <button data-filter="in_review" aria-pressed="false" class="queue-tab">Pending</button>
+      <button data-filter="changes_requested" aria-pressed="false" class="queue-tab">Changes requested</button>
     </div>
     <form class="search search-sm" onsubmit="return false;" role="search" style="max-width: 260px;">
       <svg class="ic-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -63,7 +63,7 @@ const detail = selectedId ? await api.getQueueDetail(selectedId).catch(() => nul
             <div class="stat"><span class="n">{detail.sourceRef.slice(0, 7)}</span><span class="l">Ref</span></div>
           </div>
 
-          <h4 style="font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: var(--text-faint); margin-bottom: 10px;">Files</h4>
+          <span class="section-label" style="margin-bottom: 10px;">Files</span>
           <div class="tbl-wrap" style="margin-bottom: 24px;">
             <div class="scroll">
               <table class="tbl">
@@ -189,7 +189,7 @@ const detail = selectedId ? await api.getQueueDetail(selectedId).catch(() => nul
                 <div class="stat"><span class="n">${esc(d.provenance)}</span><span class="l">Source</span></div>
                 <div class="stat"><span class="n">${esc(d.sourceRef.slice(0, 7))}</span><span class="l">Ref</span></div>
               </div>
-              <h4 style="font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: var(--text-faint); margin-bottom: 10px;">Files</h4>
+              <span class="section-label" style="margin-bottom: 10px;">Files</span>
               <div class="tbl-wrap" style="margin-bottom: 24px;">
                 <div class="scroll">
                   <table class="tbl">
@@ -254,8 +254,8 @@ const detail = selectedId ? await api.getQueueDetail(selectedId).catch(() => nul
       tabs?.addEventListener('click', (e) => {
         const btn = (e.target as HTMLElement).closest('[data-filter]');
         if (!btn) return;
-        tabs.querySelectorAll('[data-filter]').forEach((b) => b.setAttribute('aria-selected', 'false'));
-        btn.setAttribute('aria-selected', 'true');
+        tabs.querySelectorAll('[data-filter]').forEach((b) => b.setAttribute('aria-pressed', 'false'));
+        btn.setAttribute('aria-pressed', 'true');
         currentFilter = btn.getAttribute('data-filter') || 'all';
         loadQueue();
       });

--- a/web/src/pages/contact.astro
+++ b/web/src/pages/contact.astro
@@ -56,7 +56,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <!-- Channels -->
         <aside class="stack">
           <div class="card">
-            <h4 style="font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--text-faint);margin-bottom:14px;">Channels</h4>
+            <span class="section-label" style="margin-bottom:14px;">Channels</span>
             <div class="stack" style="gap:14px;">
               <div>
                 <div class="faint" style="font-size:12px;font-family:var(--mono);">Email</div>

--- a/web/src/pages/skill/[slug].astro
+++ b/web/src/pages/skill/[slug].astro
@@ -112,7 +112,7 @@ const fileTree = files?.tree ?? [];
           {fileTree.length > 0 && (
             <div class="card" style="padding:0;overflow:hidden;" role="region" aria-label="File tree">
               <div style="padding:14px 18px;border-bottom:1px solid var(--border);">
-                <h4 style="font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--text-faint);">Files</h4>
+                <span class="section-label">Files</span>
               </div>
               <div style="padding:8px;" role="list">
                 {fileTree.map((node) => (
@@ -138,7 +138,7 @@ const fileTree = files?.tree ?? [];
 
           {versions && versions.versions.length > 0 && (
             <div class="card">
-              <h4 style="font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--text-faint);margin-bottom:12px;">Versions</h4>
+              <span class="section-label" style="margin-bottom:12px;">Versions</span>
               {versions.versions.map((v) => (
                 <div style="display:flex;align-items:center;gap:10px;padding:8px 0;border-bottom:1px solid var(--border);">
                   <span style="font-family:var(--mono);font-size:13px;font-weight:600;">v{v.version}</span>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -403,6 +403,18 @@ textarea {
   color: var(--accent-text);
 }
 
+/* Section label — mono metadata, not a document heading */
+.section-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
 /* ---------- Header ---------- */
 .site-head {
   position: sticky;
@@ -1258,7 +1270,7 @@ kbd,
 .tabs button:hover {
   color: var(--text);
 }
-.tabs button[aria-selected='true'] {
+.tabs button[aria-pressed='true'] {
   color: var(--text);
   border-bottom-color: var(--accent);
 }
@@ -1494,6 +1506,9 @@ kbd,
 .drawer-panel .close {
   margin-left: auto;
   padding: 8px;
+}
+.drawer-panel .icon-btn {
+  justify-content: center;
 }
 
 /* ---------- Toast ---------- */


### PR DESCRIPTION
- Queue filter: switch from tablist/aria-selected to aria-pressed button group
- Section labels: replace mono-styled headings with shared `.section-label` spans
- Drawer close: center icon-btn glyph inside drawer panel

All web checks (format, lint, astro check, tsc, tests, build) pass.