### PR TITLE
feat(ingest): discover skills at any depth, excluding dot-dirs

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
@@ -5,15 +5,19 @@ import java.io.ByteArrayInputStream
 import java.util.zip.ZipInputStream
 
 /**
- * Read-only skill discovery from a fetched archive (spec §5 core; the *write* half — file
- * mirroring, skill/version upsert, review enqueue — is deferred to step 5 per the plan's issue B,
- * so this writes nothing: no DB, no FileStore).
+ * Read-only skill discovery from a fetched archive (spec §5 core; no DB / FileStore writes here).
+ *
+ * A **skill** is any directory that directly contains a `SKILL.md`, at ANY depth — real-world skill
+ * repos vary in layout (`skills/mvi/`, `jetpack-compose/adaptive/`, `recomposition/debugging/`), so
+ * discovery is layout-agnostic. Two exclusions keep tooling and stray files out of the scan:
+ * - **dot-directories** — any path segment starting with `.` (`.github`, `.claude`, `.agents`,
+ *   `.codex-plugin`, …) is never a skill;
+ * - **the archive root** — a bare top-level `SKILL.md` (no containing directory) is ignored.
  *
  * Shared by repo scans and uploaded-zip scans. Extraction is one JDK-native `java.util.zip` path
  * for both sources (deviation A: GitHub `/zipball`, not `/tarball`); **root-normalization differs
  * by source** (gotcha #1): a GitHub zipball wraps the repo in a single `{owner}-{repo}-{sha}/` dir,
- * so a literal top-level `skills/` lookup matches nothing. `RepoZipball` peels exactly one leading
- * segment; `UploadedZip` peels one only if `skills/` isn't already at the root.
+ * which is peeled; `UploadedZip` peels one leading segment only if `skills/` isn't already at root.
  *
  * Security guards: the compressed body is size-bounded by the caller; here we bound the
  * **inflated** stream (count bytes as read, never trust entry sizes), cap entry count, and reject
@@ -60,6 +64,10 @@ sealed interface ArchiveSource {
 /** The read-only metadata for one detected skill (§9: "Detected metadata (read-only)"). */
 data class DetectedSkill(
   val slug: String,
+  /**
+   * Archive-relative directory the skill lives in, e.g. "skills/mvi" or "jetpack-compose/adaptive".
+   */
+  val sourceDir: String,
   val name: String,
   val description: String,
   val license: String?,
@@ -92,14 +100,26 @@ object Discovery {
 
   fun discover(source: ArchiveSource): ScanResult {
     val entries = extract(source) // guarded + root-normalized per-source
-    if (entries.none { it.path.startsWith("skills/") }) return ScanResult.NoSkillsDir
-    val grouped =
+    // Every directory that directly holds a SKILL.md is a skill, at any depth — minus dot-dirs and
+    // the archive root (a bare "SKILL.md" has no '/', so it drops out of the endsWith filter).
+    val skillDirs =
       entries
-        .filter { it.path.startsWith("skills/") }
-        .groupBy { topDir(it.path) } // "skills/<slug>" -> all files under it
-    val detected = grouped.mapNotNull { (dir, files) -> buildDetected(dir, files, source) }
+        .asSequence()
+        .filter { it.path.endsWith("/SKILL.md") }
+        .map { it.path.substringBeforeLast('/') }
+        .filter { dir -> dir.isNotEmpty() && dir.split('/').none { seg -> seg.startsWith(".") } }
+        .toSet()
+    if (skillDirs.isEmpty()) return ScanResult.NoSkillsDir
+    // Assign each file to its DEEPEST containing skill dir (a skill can nest inside another).
+    val byDir = skillDirs.associateWith { mutableListOf<Extracted>() }
+    for (e in entries) ownerDir(e.path, skillDirs)?.let { byDir.getValue(it).add(e) }
+    val detected = byDir.entries.mapNotNull { (dir, files) -> buildDetected(dir, files, source) }
     return ScanResult.Found(detected)
   }
+
+  /** The deepest skill dir in [skillDirs] that contains [path] (or IS its SKILL.md), else null. */
+  internal fun ownerDir(path: String, skillDirs: Collection<String>): String? =
+    skillDirs.filter { path == "$it/SKILL.md" || path.startsWith("$it/") }.maxByOrNull { it.length }
 
   /** Extracts + applies the source-specific root-normalization (gotcha #1). */
   internal fun extract(source: ArchiveSource): List<Extracted> {
@@ -149,7 +169,7 @@ object Discovery {
   /**
    * Root-normalize (gotcha #1):
    * - RepoZipball: GitHub wraps the repo in `{owner}-{repo}-{sha}/`. Peel exactly one leading
-   *   segment unconditionally → `skills/...` lands at the root.
+   *   segment unconditionally → the real tree lands at the root.
    * - UploadedZip: may be rooted at `skills/...` (no peel) OR under a single wrapper dir (peel
    *   one). Peel only if `skills/` is NOT already at the root.
    */
@@ -164,15 +184,16 @@ object Discovery {
   }
 
   /**
-   * `dir` is "skills/<slug>". Files are the entries under it. Returns null if the directory has no
-   * SKILL.md (not a skill) or the slug is malformed.
+   * [dir] is the skill's archive-relative directory (any depth); [files] are the entries assigned
+   * to it. The slug is the leaf directory name. Returns null if the directory has no SKILL.md (not
+   * a skill) or the leaf name isn't a valid slug.
    */
   private fun buildDetected(
     dir: String,
     files: List<Extracted>,
     source: ArchiveSource,
   ): DetectedSkill? {
-    val slug = dir.removePrefix("skills/")
+    val slug = dir.substringAfterLast('/')
     if (slug.isEmpty() || !SLUG.matches(slug)) return null
     val skillMd = files.firstOrNull { it.path == "$dir/SKILL.md" } ?: return null
     val manifest = SkillManifestParser.parse(String(skillMd.bytes, Charsets.UTF_8))
@@ -204,6 +225,7 @@ object Discovery {
         }
     return DetectedSkill(
       slug = slug,
+      sourceDir = dir,
       name = manifest.name,
       description = manifest.description,
       license = manifest.license,
@@ -222,13 +244,6 @@ object Discovery {
   private fun isOnDemand(path: String, dir: String): Boolean {
     val rel = path.removePrefix("$dir/").substringBefore('/', "")
     return rel in setOf("references", "examples", "scripts")
-  }
-
-  internal fun topDir(path: String): String {
-    // path is normalized like "skills/foo/bar.md"; top dir under skills/ is "skills/foo".
-    val after = path.removePrefix("skills/")
-    val next = after.indexOf('/')
-    return if (next >= 0) "skills/${after.substring(0, next)}" else "skills/$after"
   }
 
   private fun isProbablyBinary(bytes: ByteArray): Boolean {

--- a/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
@@ -60,9 +60,10 @@ object IngestPipeline {
     val extracted = Discovery.extract(source) // raw file bytes for mirroring + zip
     val ingested = mutableListOf<IngestedSkill>()
 
+    val skillDirs = detected.map { it.sourceDir }
     for (skill in detected) {
-      val skillDir = "skills/${skill.slug}"
-      val files = extracted.filter { Discovery.topDir(it.path) == skillDir }
+      val skillDir = skill.sourceDir
+      val files = extracted.filter { Discovery.ownerDir(it.path, skillDirs) == skillDir }
       val skillMd = files.firstOrNull { it.path == "$skillDir/SKILL.md" }
       val body = skillMd?.bytes?.toString(Charsets.UTF_8) ?: ""
 
@@ -271,7 +272,6 @@ object IngestPipeline {
       transaction { Skills.selectAll().where { Skills.id eq skillId }.singleOrNull() }
         ?: throw IllegalStateException("Skill $skillId not found for promotion")
     val slug = skillRow[Skills.slug]
-    val skillDir = "skills/$slug"
 
     val detectedSkill =
       detected.firstOrNull { it.slug == slug }
@@ -280,7 +280,9 @@ object IngestPipeline {
           "slug_mismatch",
         )
 
-    val files = extracted.filter { Discovery.topDir(it.path) == skillDir }
+    val skillDir = detectedSkill.sourceDir
+    val skillDirs = detected.map { it.sourceDir }
+    val files = extracted.filter { Discovery.ownerDir(it.path, skillDirs) == skillDir }
     val skillMd = files.firstOrNull { it.path == "$skillDir/SKILL.md" }
     val body = skillMd?.bytes?.toString(Charsets.UTF_8) ?: ""
     val fileEntries = files.map { it.path.removePrefix("$skillDir/") to it.bytes }

--- a/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
@@ -18,7 +18,7 @@ class DiscoveryTest {
     // every entry is under the wrapper and a literal top-level skills/ lookup fails.
     val zip =
       zip(
-        "alice-repo-abc123/.github/SKILL.md" to ignored, // ignored (not under skills/)
+        "alice-repo-abc123/.github/SKILL.md" to ignored, // ignored (dot-directory)
         "alice-repo-abc123/.claude/SKILL.md" to ignored,
         "alice-repo-abc123/.agents/SKILL.md" to ignored,
         "alice-repo-abc123/SKILL.md" to ignored, // ignored (repo root)
@@ -65,7 +65,7 @@ class DiscoveryTest {
 
   @Test
   fun `all four ignored locations are not treated as skills`() {
-    // §3.1: SKILL.md anywhere but under top-level skills/ is ignored.
+    // Dot-directories (.github/.claude/.agents) and a bare root SKILL.md are never skills.
     val zip =
       zip(
         "o-r-s/.github/SKILL.md" to ignored,
@@ -159,6 +159,65 @@ class DiscoveryTest {
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
       )
     assertTrue(found.skills.isEmpty(), "Bad_Slug is not a valid slug; got ${found.skills}")
+  }
+
+  @Test
+  fun `skills are discovered at any depth, not only under a skills dir`() {
+    // Real repos vary: android/skills groups by category dir; skydoves puts skill dirs at the root.
+    val zip =
+      zip(
+        "o-r-s/jetpack-compose/adaptive/SKILL.md" to skillMd("adaptive", "Adaptive UI."),
+        "o-r-s/jetpack-compose/adaptive/references/grid.md" to "Grid API notes.\n",
+        "o-r-s/recomposition/debugging-recompositions/SKILL.md" to
+          skillMd("debug", "Find recompositions."),
+        "o-r-s/testing/deep/SKILL.md" to skillMd("deep", "Deeply nested."),
+      )
+    val found =
+      assertIs<ScanResult.Found>(
+        Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha1234567890ab"))
+      )
+    assertEquals(
+      setOf("adaptive", "debugging-recompositions", "deep"),
+      found.skills.map { it.slug }.toSet(),
+    )
+    val adaptive = found.skills.first { it.slug == "adaptive" }
+    assertEquals("jetpack-compose/adaptive", adaptive.sourceDir)
+    assertTrue(adaptive.fileCount >= 2, "SKILL.md + references counted")
+  }
+
+  @Test
+  fun `dot-directories at any depth are excluded`() {
+    val zip =
+      zip(
+        "o-r-s/.claude-plugin/foo/SKILL.md" to ignored, // dot-dir ancestor
+        "o-r-s/.opencode/SKILL.md" to ignored,
+        "o-r-s/tools/.hidden/SKILL.md" to ignored, // dot segment mid-path
+        "o-r-s/lists/optimizing-layouts/SKILL.md" to skillMd("opt", "Real one."),
+      )
+    val found =
+      assertIs<ScanResult.Found>(
+        Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
+      )
+    assertEquals(listOf("optimizing-layouts"), found.skills.map { it.slug })
+  }
+
+  @Test
+  fun `a skill nested inside another assigns files to the deepest skill dir`() {
+    val zip =
+      zip(
+        "o-r-s/outer/SKILL.md" to skillMd("outer", "Outer."),
+        "o-r-s/outer/notes.md" to "outer notes\n",
+        "o-r-s/outer/inner/SKILL.md" to skillMd("inner", "Inner."),
+        "o-r-s/outer/inner/refs.md" to "inner refs\n",
+      )
+    val found =
+      assertIs<ScanResult.Found>(
+        Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
+      )
+    assertEquals(setOf("outer", "inner"), found.skills.map { it.slug }.toSet())
+    // outer keeps SKILL.md + notes.md; inner's two files are NOT double-counted under outer.
+    assertEquals(2, found.skills.first { it.slug == "outer" }.fileCount)
+    assertEquals(2, found.skills.first { it.slug == "inner" }.fileCount)
   }
 
   // ---- helpers ----

--- a/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
@@ -88,6 +88,37 @@ class IngestPipelineTest {
   }
 
   @Test
+  fun `ingests a skill from a non-skills layout (any-depth discovery)`() {
+    val (bundleId, userId) = seedBundle()
+    // android/skills-style: skill under a category dir, not under a top-level skills/.
+    val body =
+      "---\nname: adaptive\ndescription: Adaptive UI.\nlicense: Apache-2.0\ntags: [android]\n---\n# Adaptive\n"
+    val zipBytes =
+      zip(
+        "owner-repo-sha/jetpack-compose/adaptive/SKILL.md" to body,
+        "owner-repo-sha/jetpack-compose/adaptive/references/grid.md" to "grid notes\n",
+      )
+    val result =
+      IngestPipeline.ingest(
+        ArchiveSource.RepoZipball(zipBytes, "owner", "repo", "abcdef1234567890"),
+        bundleId,
+        store,
+        userId,
+      )
+    assertEquals(1, result.skills.size)
+    assertEquals("adaptive", result.skills[0].slug)
+    val skillId = result.skills[0].skillId
+    val files = transaction {
+      SkillFiles.selectAll().where { SkillFiles.skillId eq skillId }.toList()
+    }
+    assertTrue(
+      files.size >= 2,
+      "SKILL.md + references mirrored under the real dir; got ${files.size}",
+    )
+    assertTrue(skillRow("adaptive")[Skills.readmeMd]?.contains("Adaptive") == true)
+  }
+
+  @Test
   fun `new skill - writes everything`() {
     val (bundleId, userId) = seedBundle()
     val zipBytes = skillZip("test-mvi", "MVI Scaffold", "A baseline.", "1.0.0")


### PR DESCRIPTION
Phase-2 Follow-up A (see `.plans/STAGING-ROADMAP.md`). Unblocks repo-scan on real skill repos.

## Problem
The ingest pipeline only found skills under a **top-level `skills/` dir**. Of the real repos we index, only **chrisbanes/skills** and **hamen** use that layout — **android/skills** (category-grouped: `jetpack-compose/adaptive/…`) and both **skydoves** repos (skill dirs at the repo root) would scan **empty**. So repo-scan couldn't ingest the very repos we want.

## Change
- **`Discovery`**: a skill is now **any directory that directly contains a `SKILL.md`, at any depth**. Two exclusions keep tooling out:
  - **dot-directories** — any `.`-prefixed path segment (`.github`, `.claude`, `.agents`, `.codex-plugin`, …);
  - **the archive root** — a bare top-level `SKILL.md`.
  Files are assigned to their **deepest** containing skill dir (a skill can nest inside another). `DetectedSkill` now carries its real `sourceDir`; the old `skills/`-only `topDir` grouping → an `ownerDir` helper.
- **`IngestPipeline`** (ingest + promote): mirror files via `sourceDir`/`ownerDir` instead of reconstructing `"skills/<slug>"`.
- **Tests**: +3 `DiscoveryTest` (any-depth detection, dot-dir exclusion at depth, nested-skill file assignment), +1 `IngestPipelineTest` (ingest from a non-`skills/` layout). Existing tests unchanged in behaviour — their "ignored" cases are dot-dirs/root, still excluded.

## Notes
- Slug = leaf directory name (validated by the existing kebab regex). `Skills.slug` is globally unique, so cross-bundle leaf-name collisions remain a pre-existing concern (unchanged by this PR) — worth a follow-up if it bites.
- Deferred: LLM review worker (categorisation) — separate track.

Green: `./gradlew build` (spotless, detekt, full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
