### PR TITLE
feat(ingest): discover skills at any depth (dot-dirs excluded, stable leaf slugs)

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -155,9 +155,7 @@ private suspend fun scan(call: ApplicationCall, gh: GitHubAppClient) {
         )
       ScanResult.NoSkillsDir ->
         throw ApiValidationException(
-          mapOf(
-            "repo" to "no top-level 'skills/' directory found; SKILL.md must live under skills/"
-          ),
+          mapOf("repo" to "no SKILL.md found; add a skill directory containing a SKILL.md"),
           code = "no_skills_dir",
         )
     }

--- a/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
@@ -115,11 +115,40 @@ object Discovery {
     // BOTH detection AND file assignment, so their files fall to a valid ancestor consistently with
     // IngestPipeline (which assigns from the same detected set) — no fileCount/tree mismatch.
     val skillDirs = candidateDirs.filterTo(HashSet()) { SLUG.matches(it.substringAfterLast('/')) }
+    // Unique, valid-kebab slug per skill dir: the validated leaf, disambiguated with `-N` on a
+    // same-leaf collision within the archive (deterministic via sorted dir order).
+    val slugByDir = assignSlugs(skillDirs)
     // Assign each file to its DEEPEST containing skill dir (a skill can nest inside another).
     val byDir = skillDirs.associateWith { mutableListOf<Extracted>() }
     for (e in entries) ownerDir(e.path, skillDirs)?.let { byDir.getValue(it).add(e) }
-    val detected = byDir.entries.mapNotNull { (dir, files) -> buildDetected(dir, files, source) }
+    val detected =
+      byDir.entries.mapNotNull { (dir, files) ->
+        buildDetected(dir, slugByDir.getValue(dir), files, source)
+      }
     return ScanResult.Found(detected)
+  }
+
+  /**
+   * Assigns a unique, kebab-valid slug to each skill dir. The base is the dir's leaf (already
+   * validated against [SLUG] by [discover]); a same-leaf collision within the archive gets a `-2`,
+   * `-3`, … suffix. Deterministic: dirs are processed in sorted order, so a given archive always
+   * yields the same slugs. Suffixing the validated leaf keeps every slug kebab-valid (unlike
+   * flattening the full path, which could both collide and produce non-kebab segments).
+   */
+  private fun assignSlugs(skillDirs: Set<String>): Map<String, String> {
+    val used = HashSet<String>()
+    val out = HashMap<String, String>()
+    for (dir in skillDirs.sorted()) {
+      val base = dir.substringAfterLast('/')
+      var slug = base
+      var n = 1
+      while (!used.add(slug)) {
+        n++
+        slug = "$base-$n"
+      }
+      out[dir] = slug
+    }
+    return out
   }
 
   /** The deepest skill dir in [skillDirs] that contains [path] (or IS its SKILL.md), else null. */
@@ -190,16 +219,15 @@ object Discovery {
 
   /**
    * [dir] is the skill's archive-relative directory (any depth, already validated by [discover]);
-   * [files] are the entries assigned to it. The slug is the path (minus a leading `skills/`) with
-   * separators flattened to `-`, so two same-named leaves in different parents never share a slug.
+   * [slug] is its resolved unique slug (see [assignSlugs]); [files] are the entries assigned to it.
    * Returns null only if the directory somehow has no SKILL.md.
    */
   private fun buildDetected(
     dir: String,
+    slug: String,
     files: List<Extracted>,
     source: ArchiveSource,
   ): DetectedSkill? {
-    val slug = dir.removePrefix("skills/").replace('/', '-')
     val skillMd = files.firstOrNull { it.path == "$dir/SKILL.md" } ?: return null
     val manifest = SkillManifestParser.parse(String(skillMd.bytes, Charsets.UTF_8))
     val onDemandFiles = files.filter { isOnDemand(it.path, dir) && !it.binary }

--- a/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
@@ -115,40 +115,29 @@ object Discovery {
     // BOTH detection AND file assignment, so their files fall to a valid ancestor consistently with
     // IngestPipeline (which assigns from the same detected set) — no fileCount/tree mismatch.
     val skillDirs = candidateDirs.filterTo(HashSet()) { SLUG.matches(it.substringAfterLast('/')) }
-    // Unique, valid-kebab slug per skill dir: the validated leaf, disambiguated with `-N` on a
-    // same-leaf collision within the archive (deterministic via sorted dir order).
-    val slugByDir = assignSlugs(skillDirs)
     // Assign each file to its DEEPEST containing skill dir (a skill can nest inside another).
     val byDir = skillDirs.associateWith { mutableListOf<Extracted>() }
     for (e in entries) ownerDir(e.path, skillDirs)?.let { byDir.getValue(it).add(e) }
-    val detected =
-      byDir.entries.mapNotNull { (dir, files) ->
-        buildDetected(dir, slugByDir.getValue(dir), files, source)
+    val detected = byDir.entries.mapNotNull { (dir, files) -> buildDetected(dir, files, source) }
+    // Slug is the leaf name (stable, natural). Two skills sharing a leaf within one archive would
+    // silently merge at ingest (same bundle+slug = resync), so FLAG them here (surfaced by the
+    // scan); IngestPipeline skips them rather than merging. Cross-bundle uniqueness is a separate,
+    // pre-existing concern (the global slug index), out of scope here.
+    val dupSlugs = detected.groupingBy { it.slug }.eachCount().filterValues { it > 1 }.keys
+    val flagged =
+      detected.map { s ->
+        if (s.slug in dupSlugs) {
+          s.copy(
+            parseErrors =
+              s.parseErrors +
+                FieldError(
+                  "slug",
+                  "duplicate skill directory name '${s.slug}'; rename so each skill is unique",
+                )
+          )
+        } else s
       }
-    return ScanResult.Found(detected)
-  }
-
-  /**
-   * Assigns a unique, kebab-valid slug to each skill dir. The base is the dir's leaf (already
-   * validated against [SLUG] by [discover]); a same-leaf collision within the archive gets a `-2`,
-   * `-3`, … suffix. Deterministic: dirs are processed in sorted order, so a given archive always
-   * yields the same slugs. Suffixing the validated leaf keeps every slug kebab-valid (unlike
-   * flattening the full path, which could both collide and produce non-kebab segments).
-   */
-  private fun assignSlugs(skillDirs: Set<String>): Map<String, String> {
-    val used = HashSet<String>()
-    val out = HashMap<String, String>()
-    for (dir in skillDirs.sorted()) {
-      val base = dir.substringAfterLast('/')
-      var slug = base
-      var n = 1
-      while (!used.add(slug)) {
-        n++
-        slug = "$base-$n"
-      }
-      out[dir] = slug
-    }
-    return out
+    return ScanResult.Found(flagged)
   }
 
   /** The deepest skill dir in [skillDirs] that contains [path] (or IS its SKILL.md), else null. */
@@ -219,15 +208,15 @@ object Discovery {
 
   /**
    * [dir] is the skill's archive-relative directory (any depth, already validated by [discover]);
-   * [slug] is its resolved unique slug (see [assignSlugs]); [files] are the entries assigned to it.
-   * Returns null only if the directory somehow has no SKILL.md.
+   * [files] are the entries assigned to it. The slug is the leaf directory name (stable). Returns
+   * null only if the directory somehow has no SKILL.md.
    */
   private fun buildDetected(
     dir: String,
-    slug: String,
     files: List<Extracted>,
     source: ArchiveSource,
   ): DetectedSkill? {
+    val slug = dir.substringAfterLast('/')
     val skillMd = files.firstOrNull { it.path == "$dir/SKILL.md" } ?: return null
     val manifest = SkillManifestParser.parse(String(skillMd.bytes, Charsets.UTF_8))
     val onDemandFiles = files.filter { isOnDemand(it.path, dir) && !it.binary }

--- a/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
@@ -100,16 +100,21 @@ object Discovery {
 
   fun discover(source: ArchiveSource): ScanResult {
     val entries = extract(source) // guarded + root-normalized per-source
-    // Every directory that directly holds a SKILL.md is a skill, at any depth — minus dot-dirs and
-    // the archive root (a bare "SKILL.md" has no '/', so it drops out of the endsWith filter).
-    val skillDirs =
+    // Candidate skill dirs: every dir that directly holds a SKILL.md, at any depth, minus
+    // dot-directories and the archive root (a bare "SKILL.md" has no '/', so the endsWith drops
+    // it).
+    val candidateDirs =
       entries
         .asSequence()
         .filter { it.path.endsWith("/SKILL.md") }
         .map { it.path.substringBeforeLast('/') }
         .filter { dir -> dir.isNotEmpty() && dir.split('/').none { seg -> seg.startsWith(".") } }
         .toSet()
-    if (skillDirs.isEmpty()) return ScanResult.NoSkillsDir
+    if (candidateDirs.isEmpty()) return ScanResult.NoSkillsDir
+    // A candidate is a *skill* only if its leaf is a valid slug. Bad-slug dirs are excluded from
+    // BOTH detection AND file assignment, so their files fall to a valid ancestor consistently with
+    // IngestPipeline (which assigns from the same detected set) — no fileCount/tree mismatch.
+    val skillDirs = candidateDirs.filterTo(HashSet()) { SLUG.matches(it.substringAfterLast('/')) }
     // Assign each file to its DEEPEST containing skill dir (a skill can nest inside another).
     val byDir = skillDirs.associateWith { mutableListOf<Extracted>() }
     for (e in entries) ownerDir(e.path, skillDirs)?.let { byDir.getValue(it).add(e) }
@@ -184,17 +189,17 @@ object Discovery {
   }
 
   /**
-   * [dir] is the skill's archive-relative directory (any depth); [files] are the entries assigned
-   * to it. The slug is the leaf directory name. Returns null if the directory has no SKILL.md (not
-   * a skill) or the leaf name isn't a valid slug.
+   * [dir] is the skill's archive-relative directory (any depth, already validated by [discover]);
+   * [files] are the entries assigned to it. The slug is the path (minus a leading `skills/`) with
+   * separators flattened to `-`, so two same-named leaves in different parents never share a slug.
+   * Returns null only if the directory somehow has no SKILL.md.
    */
   private fun buildDetected(
     dir: String,
     files: List<Extracted>,
     source: ArchiveSource,
   ): DetectedSkill? {
-    val slug = dir.substringAfterLast('/')
-    if (slug.isEmpty() || !SLUG.matches(slug)) return null
+    val slug = dir.removePrefix("skills/").replace('/', '-')
     val skillMd = files.firstOrNull { it.path == "$dir/SKILL.md" } ?: return null
     val manifest = SkillManifestParser.parse(String(skillMd.bytes, Charsets.UTF_8))
     val onDemandFiles = files.filter { isOnDemand(it.path, dir) && !it.binary }

--- a/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
@@ -52,7 +52,7 @@ object IngestPipeline {
   ): IngestResult {
     val scanResult = Discovery.discover(source)
     if (scanResult is ScanResult.NoSkillsDir) {
-      throw IllegalStateException("No top-level 'skills/' directory in archive")
+      throw IllegalStateException("No SKILL.md found in the archive")
     }
     val detected = (scanResult as ScanResult.Found).skills
     if (detected.isEmpty()) throw IllegalStateException("No valid skills discovered")
@@ -60,8 +60,13 @@ object IngestPipeline {
     val extracted = Discovery.extract(source) // raw file bytes for mirroring + zip
     val ingested = mutableListOf<IngestedSkill>()
 
+    // Skip skills whose slug collides within this archive: ingesting both would silently merge the
+    // second onto the first (same bundle+slug is treated as a resync). Discovery flags them via a
+    // parse error so the contributor can rename and re-submit.
+    val dupSlugs = detected.groupingBy { it.slug }.eachCount().filterValues { it > 1 }.keys
     val skillDirs = detected.map { it.sourceDir }
     for (skill in detected) {
+      if (skill.slug in dupSlugs) continue
       val skillDir = skill.sourceDir
       val files = extracted.filter { Discovery.ownerDir(it.path, skillDirs) == skillDir }
       val skillMd = files.firstOrNull { it.path == "$skillDir/SKILL.md" }
@@ -263,7 +268,7 @@ object IngestPipeline {
   ): PromoteResult {
     val scanResult = Discovery.discover(source)
     if (scanResult is ScanResult.NoSkillsDir) {
-      throw IllegalStateException("No top-level 'skills/' directory in archive")
+      throw IllegalStateException("No SKILL.md found in the archive")
     }
     val detected = (scanResult as ScanResult.Found).skills
     val extracted = Discovery.extract(source)
@@ -273,8 +278,15 @@ object IngestPipeline {
         ?: throw IllegalStateException("Skill $skillId not found for promotion")
     val slug = skillRow[Skills.slug]
 
+    val matches = detected.filter { it.slug == slug }
+    if (matches.size > 1) {
+      throw ApiConflictException(
+        "Skill '$slug' is ambiguous: ${matches.size} skills in the archive share this directory name",
+        "duplicate_slug",
+      )
+    }
     val detectedSkill =
-      detected.firstOrNull { it.slug == slug }
+      matches.firstOrNull()
         ?: throw ApiConflictException(
           "Skill '$slug' not found in the archive; contributor may have removed or renamed it",
           "slug_mismatch",

--- a/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
@@ -203,28 +203,25 @@ class DiscoveryTest {
   }
 
   @Test
-  fun `duplicate leaf names get distinct, kebab-valid slugs`() {
-    // Two skills sharing a leaf must NOT silently merge. Leaf + -N keeps them distinct AND
-    // kebab-valid. Also covers Bugbot's path-flatten collisions: foo-bar/baz, foo/bar-baz and
-    // foo/bar/baz all flatten to the same string, but leaf + -N does not.
+  fun `duplicate leaf names keep the leaf slug but are flagged`() {
+    // Same leaf in different dirs is NOT renumbered or merged: the slug stays the natural leaf and
+    // every colliding skill is flagged with a `slug` parse error (surfaced by the scan; the ingest
+    // pipeline skips them). Unique slugs are not flagged.
     val zip =
       zip(
         "o-r-s/foo-bar/baz/SKILL.md" to skillMd("a", "A."),
-        "o-r-s/foo/bar-baz/SKILL.md" to skillMd("b", "B."),
-        "o-r-s/foo/bar/baz/SKILL.md" to skillMd("c", "C."),
-        "o-r-s/material/styles/SKILL.md" to skillMd("d", "D."),
+        "o-r-s/foo/bar/baz/SKILL.md" to skillMd("b", "B."), // same leaf 'baz'
+        "o-r-s/material/styles/SKILL.md" to skillMd("c", "C."), // unique
       )
     val found =
       assertIs<ScanResult.Found>(
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
       )
-    val slugs = found.skills.map { it.slug }
-    assertEquals(4, slugs.size)
-    assertEquals(slugs.size, slugs.toSet().size, "slugs must be unique: $slugs")
-    val kebab = Regex("^[a-z0-9]+(-[a-z0-9]+)*$")
-    assertTrue(slugs.all { kebab.matches(it) }, "slugs must be kebab-valid: $slugs")
-    // leaves baz / bar-baz / baz / styles → the two `baz` become baz + baz-2 (sorted dir order).
-    assertEquals(setOf("baz", "bar-baz", "baz-2", "styles"), slugs.toSet())
+    val bazes = found.skills.filter { it.slug == "baz" }
+    assertEquals(2, bazes.size)
+    assertTrue(bazes.all { s -> s.parseErrors.any { it.field == "slug" } }, "both 'baz' flagged")
+    val styles = found.skills.first { it.slug == "styles" }
+    assertTrue(styles.parseErrors.none { it.field == "slug" }, "unique slug not flagged")
   }
 
   @Test

--- a/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
@@ -176,12 +176,12 @@ class DiscoveryTest {
       assertIs<ScanResult.Found>(
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha1234567890ab"))
       )
-    // Slug is the path (minus a leading skills/) flattened with '-', so it is unique per path.
+    // Slug is the leaf name (unique here) — short and stable.
     assertEquals(
-      setOf("jetpack-compose-adaptive", "recomposition-debugging-recompositions", "testing-deep"),
+      setOf("adaptive", "debugging-recompositions", "deep"),
       found.skills.map { it.slug }.toSet(),
     )
-    val adaptive = found.skills.first { it.slug == "jetpack-compose-adaptive" }
+    val adaptive = found.skills.first { it.slug == "adaptive" }
     assertEquals("jetpack-compose/adaptive", adaptive.sourceDir)
     assertTrue(adaptive.fileCount >= 2, "SKILL.md + references counted")
   }
@@ -199,25 +199,32 @@ class DiscoveryTest {
       assertIs<ScanResult.Found>(
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
       )
-    assertEquals(listOf("lists-optimizing-layouts"), found.skills.map { it.slug })
+    assertEquals(listOf("optimizing-layouts"), found.skills.map { it.slug })
   }
 
   @Test
-  fun `duplicate leaf names in different parents get distinct slugs`() {
-    // Regression: leaf-only slugs silently merged two different skills. Path-based slugs don't.
+  fun `duplicate leaf names get distinct, kebab-valid slugs`() {
+    // Two skills sharing a leaf must NOT silently merge. Leaf + -N keeps them distinct AND
+    // kebab-valid. Also covers Bugbot's path-flatten collisions: foo-bar/baz, foo/bar-baz and
+    // foo/bar/baz all flatten to the same string, but leaf + -N does not.
     val zip =
       zip(
-        "o-r-s/jetpack-compose/theming/styles/SKILL.md" to skillMd("styles", "Compose styles."),
-        "o-r-s/material/styles/SKILL.md" to skillMd("styles", "Material styles."),
+        "o-r-s/foo-bar/baz/SKILL.md" to skillMd("a", "A."),
+        "o-r-s/foo/bar-baz/SKILL.md" to skillMd("b", "B."),
+        "o-r-s/foo/bar/baz/SKILL.md" to skillMd("c", "C."),
+        "o-r-s/material/styles/SKILL.md" to skillMd("d", "D."),
       )
     val found =
       assertIs<ScanResult.Found>(
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
       )
-    assertEquals(
-      setOf("jetpack-compose-theming-styles", "material-styles"),
-      found.skills.map { it.slug }.toSet(),
-    )
+    val slugs = found.skills.map { it.slug }
+    assertEquals(4, slugs.size)
+    assertEquals(slugs.size, slugs.toSet().size, "slugs must be unique: $slugs")
+    val kebab = Regex("^[a-z0-9]+(-[a-z0-9]+)*$")
+    assertTrue(slugs.all { kebab.matches(it) }, "slugs must be kebab-valid: $slugs")
+    // leaves baz / bar-baz / baz / styles → the two `baz` become baz + baz-2 (sorted dir order).
+    assertEquals(setOf("baz", "bar-baz", "baz-2", "styles"), slugs.toSet())
   }
 
   @Test
@@ -233,10 +240,10 @@ class DiscoveryTest {
       assertIs<ScanResult.Found>(
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
       )
-    assertEquals(setOf("outer", "outer-inner"), found.skills.map { it.slug }.toSet())
+    assertEquals(setOf("outer", "inner"), found.skills.map { it.slug }.toSet())
     // outer keeps SKILL.md + notes.md; inner's two files are NOT double-counted under outer.
     assertEquals(2, found.skills.first { it.slug == "outer" }.fileCount)
-    assertEquals(2, found.skills.first { it.slug == "outer-inner" }.fileCount)
+    assertEquals(2, found.skills.first { it.slug == "inner" }.fileCount)
   }
 
   @Test
@@ -253,7 +260,7 @@ class DiscoveryTest {
       assertIs<ScanResult.Found>(
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
       )
-    assertEquals(listOf("tools-valid-skill"), found.skills.map { it.slug })
+    assertEquals(listOf("valid-skill"), found.skills.map { it.slug })
     assertEquals(3, found.skills[0].fileCount) // all 3 files under the one valid skill
   }
 

--- a/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
@@ -176,11 +176,12 @@ class DiscoveryTest {
       assertIs<ScanResult.Found>(
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha1234567890ab"))
       )
+    // Slug is the path (minus a leading skills/) flattened with '-', so it is unique per path.
     assertEquals(
-      setOf("adaptive", "debugging-recompositions", "deep"),
+      setOf("jetpack-compose-adaptive", "recomposition-debugging-recompositions", "testing-deep"),
       found.skills.map { it.slug }.toSet(),
     )
-    val adaptive = found.skills.first { it.slug == "adaptive" }
+    val adaptive = found.skills.first { it.slug == "jetpack-compose-adaptive" }
     assertEquals("jetpack-compose/adaptive", adaptive.sourceDir)
     assertTrue(adaptive.fileCount >= 2, "SKILL.md + references counted")
   }
@@ -198,7 +199,25 @@ class DiscoveryTest {
       assertIs<ScanResult.Found>(
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
       )
-    assertEquals(listOf("optimizing-layouts"), found.skills.map { it.slug })
+    assertEquals(listOf("lists-optimizing-layouts"), found.skills.map { it.slug })
+  }
+
+  @Test
+  fun `duplicate leaf names in different parents get distinct slugs`() {
+    // Regression: leaf-only slugs silently merged two different skills. Path-based slugs don't.
+    val zip =
+      zip(
+        "o-r-s/jetpack-compose/theming/styles/SKILL.md" to skillMd("styles", "Compose styles."),
+        "o-r-s/material/styles/SKILL.md" to skillMd("styles", "Material styles."),
+      )
+    val found =
+      assertIs<ScanResult.Found>(
+        Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
+      )
+    assertEquals(
+      setOf("jetpack-compose-theming-styles", "material-styles"),
+      found.skills.map { it.slug }.toSet(),
+    )
   }
 
   @Test
@@ -214,10 +233,28 @@ class DiscoveryTest {
       assertIs<ScanResult.Found>(
         Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
       )
-    assertEquals(setOf("outer", "inner"), found.skills.map { it.slug }.toSet())
+    assertEquals(setOf("outer", "outer-inner"), found.skills.map { it.slug }.toSet())
     // outer keeps SKILL.md + notes.md; inner's two files are NOT double-counted under outer.
     assertEquals(2, found.skills.first { it.slug == "outer" }.fileCount)
-    assertEquals(2, found.skills.first { it.slug == "inner" }.fileCount)
+    assertEquals(2, found.skills.first { it.slug == "outer-inner" }.fileCount)
+  }
+
+  @Test
+  fun `an invalid-slug nested dir is not a skill and its files stay with the parent`() {
+    // Fix: bad-slug dirs are excluded from BOTH detection and file assignment, so Discovery's
+    // fileCount matches what IngestPipeline mirrors (which assigns from the same detected set).
+    val zip =
+      zip(
+        "o-r-s/tools/valid-skill/SKILL.md" to skillMd("valid", "Valid."),
+        "o-r-s/tools/valid-skill/Bad_Slug/SKILL.md" to ignored, // invalid leaf → not a skill
+        "o-r-s/tools/valid-skill/Bad_Slug/extra.md" to "extra\n",
+      )
+    val found =
+      assertIs<ScanResult.Found>(
+        Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
+      )
+    assertEquals(listOf("tools-valid-skill"), found.skills.map { it.slug })
+    assertEquals(3, found.skills[0].fileCount) // all 3 files under the one valid skill
   }
 
   // ---- helpers ----

--- a/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
@@ -106,7 +106,7 @@ class IngestPipelineTest {
         userId,
       )
     assertEquals(1, result.skills.size)
-    assertEquals("adaptive", result.skills[0].slug)
+    assertEquals("jetpack-compose-adaptive", result.skills[0].slug)
     val skillId = result.skills[0].skillId
     val files = transaction {
       SkillFiles.selectAll().where { SkillFiles.skillId eq skillId }.toList()
@@ -115,7 +115,7 @@ class IngestPipelineTest {
       files.size >= 2,
       "SKILL.md + references mirrored under the real dir; got ${files.size}",
     )
-    assertTrue(skillRow("adaptive")[Skills.readmeMd]?.contains("Adaptive") == true)
+    assertTrue(skillRow("jetpack-compose-adaptive")[Skills.readmeMd]?.contains("Adaptive") == true)
   }
 
   @Test

--- a/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
@@ -119,6 +119,30 @@ class IngestPipelineTest {
   }
 
   @Test
+  fun `duplicate-slug skills within an archive are skipped, not merged`() {
+    val (bundleId, userId) = seedBundle()
+    fun md(name: String) =
+      "---\nname: $name\ndescription: d\nlicense: MIT\ntags: [android]\n---\n# $name\n"
+    // Dir leaf is the slug: a/baz and b/baz both → "baz"; c/keep → "keep".
+    val zipBytes =
+      zip(
+        "o-r/a/baz/SKILL.md" to md("baz"),
+        "o-r/b/baz/SKILL.md" to md("baz"),
+        "o-r/c/keep/SKILL.md" to md("keep"),
+      )
+    val result =
+      IngestPipeline.ingest(
+        ArchiveSource.RepoZipball(zipBytes, "o", "r", "sha1234567890"),
+        bundleId,
+        store,
+        userId,
+      )
+    // Only the unique-slug skill is ingested; the two colliding "baz" are skipped (not merged).
+    assertEquals(listOf("keep"), result.skills.map { it.slug })
+    assertEquals(0L, transaction { Skills.selectAll().where { Skills.slug eq "baz" }.count() })
+  }
+
+  @Test
   fun `new skill - writes everything`() {
     val (bundleId, userId) = seedBundle()
     val zipBytes = skillZip("test-mvi", "MVI Scaffold", "A baseline.", "1.0.0")

--- a/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
@@ -106,7 +106,7 @@ class IngestPipelineTest {
         userId,
       )
     assertEquals(1, result.skills.size)
-    assertEquals("jetpack-compose-adaptive", result.skills[0].slug)
+    assertEquals("adaptive", result.skills[0].slug)
     val skillId = result.skills[0].skillId
     val files = transaction {
       SkillFiles.selectAll().where { SkillFiles.skillId eq skillId }.toList()
@@ -115,7 +115,7 @@ class IngestPipelineTest {
       files.size >= 2,
       "SKILL.md + references mirrored under the real dir; got ${files.size}",
     )
-    assertTrue(skillRow("jetpack-compose-adaptive")[Skills.readmeMd]?.contains("Adaptive") == true)
+    assertTrue(skillRow("adaptive")[Skills.readmeMd]?.contains("Adaptive") == true)
   }
 
   @Test


### PR DESCRIPTION
Broadens repo-scan discovery to real-world skill layouts, and resolves the Bugbot findings within an agreed **narrowed scope**.

## What it does
- **Any-depth discovery:** a skill is any directory that directly contains a `SKILL.md`, at any depth (android/skills groups by category dir; skydoves puts skill dirs at the repo root; only chrisbanes/hamen used the old top-level `skills/`).
- **Exclusions:** dot-directories (`.github`, `.claude`, `.agents`, `.codex-plugin`, …) and a bare archive-root `SKILL.md`.
- **Consistent file assignment (Bugbot #2):** `discover` splits *candidate* dirs (drive the `NoSkillsDir` signal) from *valid* skill dirs (leaf is a real slug); file assignment uses only valid dirs, matching the set `IngestPipeline` assigns from — no `fileCount`/tree mismatch. Files go to their **deepest** containing skill dir.

## Slugs (Bugbot #1) — narrowed
Slug = the **stable leaf** directory name. I do **not** synthesize globally-unique slugs in Discovery — the earlier attempts were unsound (path-flatten collided: `foo-bar/baz` = `foo/bar-baz`; `-N` disambiguation renumbered when siblings changed, breaking durable slugs).

Instead, a same-leaf collision **within one archive** is **surfaced, not silently merged or renumbered**:
- `Discovery` attaches a `slug` parse error to each colliding skill (shown by the scan),
- `IngestPipeline` **skips** dup-slug skills (never treats the 2nd as a resync of the 1st); `promote` guards the ambiguous case.

**Deferred (agreed follow-up):** cross-*bundle* slug uniqueness — two different repos with the same skill name — remains the pre-existing global-slug-index concern (a per-bundle-scope redesign touches schema + routes + frontend URLs).

## Tests
- Any-depth detection; dot-dir exclusion at depth; deepest-ancestor file assignment.
- Duplicate leaf → **flagged** (not renumbered/merged); unique slug not flagged.
- `IngestPipeline` **skips** dup-slug skills (no silent merge).

Green: `./gradlew build` (spotless, detekt, full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
