### PR TITLE
fix(ingest): assign scan files by valid skill dirs so fileCount matches ingest

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -156,7 +156,8 @@ private suspend fun scan(call: ApplicationCall, gh: GitHubAppClient) {
       ScanResult.NoSkillsDir ->
         throw ApiValidationException(
           mapOf(
-            "repo" to "no top-level 'skills/' directory found; SKILL.md must live under skills/"
+            "repo" to
+              "no SKILL.md found in the repository; a skill is any directory containing a SKILL.md"
           ),
           code = "no_skills_dir",
         )

--- a/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/Discovery.kt
@@ -100,19 +100,25 @@ object Discovery {
 
   fun discover(source: ArchiveSource): ScanResult {
     val entries = extract(source) // guarded + root-normalized per-source
-    // Every directory that directly holds a SKILL.md is a skill, at any depth — minus dot-dirs and
-    // the archive root (a bare "SKILL.md" has no '/', so it drops out of the endsWith filter).
-    val skillDirs =
+    // Candidate dirs: every directory that directly holds a SKILL.md, at any depth — minus
+    // dot-dirs and the archive root (a bare "SKILL.md" has no '/', so it drops out of the endsWith
+    // filter). Candidates decide only whether the archive contains any skill at all.
+    val candidateDirs =
       entries
         .asSequence()
         .filter { it.path.endsWith("/SKILL.md") }
         .map { it.path.substringBeforeLast('/') }
         .filter { dir -> dir.isNotEmpty() && dir.split('/').none { seg -> seg.startsWith(".") } }
         .toSet()
-    if (skillDirs.isEmpty()) return ScanResult.NoSkillsDir
-    // Assign each file to its DEEPEST containing skill dir (a skill can nest inside another).
-    val byDir = skillDirs.associateWith { mutableListOf<Extracted>() }
-    for (e in entries) ownerDir(e.path, skillDirs)?.let { byDir.getValue(it).add(e) }
+    if (candidateDirs.isEmpty()) return ScanResult.NoSkillsDir
+    // Valid skill dirs: candidates whose leaf is a real slug. Files are assigned to these dirs
+    // ONLY — the exact set IngestPipeline mirrors from (`detected.map { sourceDir }`) — so a nested
+    // invalid-leaf subtree folds into its nearest valid ancestor consistently in both the scan
+    // preview (fileCount) and on ingest, instead of being counted here but re-homed there.
+    val validDirs = candidateDirs.filter { SLUG.matches(it.substringAfterLast('/')) }.toSet()
+    // Assign each file to its DEEPEST containing valid skill dir (a skill can nest inside another).
+    val byDir = validDirs.associateWith { mutableListOf<Extracted>() }
+    for (e in entries) ownerDir(e.path, validDirs)?.let { byDir.getValue(it).add(e) }
     val detected = byDir.entries.mapNotNull { (dir, files) -> buildDetected(dir, files, source) }
     return ScanResult.Found(detected)
   }

--- a/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/IngestPipeline.kt
@@ -52,7 +52,7 @@ object IngestPipeline {
   ): IngestResult {
     val scanResult = Discovery.discover(source)
     if (scanResult is ScanResult.NoSkillsDir) {
-      throw IllegalStateException("No top-level 'skills/' directory in archive")
+      throw IllegalStateException("No SKILL.md found anywhere in the archive")
     }
     val detected = (scanResult as ScanResult.Found).skills
     if (detected.isEmpty()) throw IllegalStateException("No valid skills discovered")
@@ -291,7 +291,7 @@ object IngestPipeline {
   ): PromoteResult {
     val scanResult = Discovery.discover(source)
     if (scanResult is ScanResult.NoSkillsDir) {
-      throw IllegalStateException("No top-level 'skills/' directory in archive")
+      throw IllegalStateException("No SKILL.md found anywhere in the archive")
     }
     val detected = (scanResult as ScanResult.Found).skills
     val extracted = Discovery.extract(source)

--- a/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/DiscoveryTest.kt
@@ -220,6 +220,27 @@ class DiscoveryTest {
     assertEquals(2, found.skills.first { it.slug == "inner" }.fileCount)
   }
 
+  @Test
+  fun `invalid-leaf nested dir folds its files into the valid ancestor`() {
+    // skills/mvi is valid; skills/mvi/Bad_Sub has its own SKILL.md but an invalid leaf slug. Its
+    // subtree must fold into mvi (the nearest VALID ancestor) — the exact set IngestPipeline
+    // mirrors from — instead of being siphoned to a dir that never becomes a skill.
+    val zip =
+      zip(
+        "o-r-s/skills/mvi/SKILL.md" to skillMd("MVI", "d"),
+        "o-r-s/skills/mvi/references/guide.md" to "guide\n",
+        "o-r-s/skills/mvi/Bad_Sub/SKILL.md" to skillMd("Bad", "d"),
+        "o-r-s/skills/mvi/Bad_Sub/notes.md" to "notes\n",
+      )
+    val found =
+      assertIs<ScanResult.Found>(
+        Discovery.discover(ArchiveSource.RepoZipball(zip, "owner", "repo", "sha"))
+      )
+    assertEquals(listOf("mvi"), found.skills.map { it.slug })
+    // All four files (mvi's own SKILL.md + references/ plus the Bad_Sub subtree) belong to mvi.
+    assertEquals(4, found.skills[0].fileCount)
+  }
+
   // ---- helpers ----
 
   private val ignored = "name: Ignored\n" + skillMdBody("Ignored", "should not be picked up")

--- a/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/ingest/IngestPipelineTest.kt
@@ -119,6 +119,36 @@ class IngestPipelineTest {
   }
 
   @Test
+  fun `scan fileCount equals files mirrored on ingest (invalid-leaf subtree)`() {
+    val (bundleId, userId) = seedBundle()
+    // A valid skill with a nested invalid-leaf dir that also holds a SKILL.md. Discovery's
+    // fileCount (scan preview) must equal what ingest actually mirrors — the two file-assignment
+    // paths must not drift (without the candidate/valid split this is 2 vs 4).
+    val body = "---\nname: mvi\ndescription: d.\nlicense: MIT\ntags: [android]\n---\n# MVI\n"
+    val bad = "---\nname: bad\ndescription: d.\nlicense: MIT\ntags: [android]\n---\n# Bad\n"
+    val zipBytes =
+      zip(
+        "owner-repo-sha/skills/mvi/SKILL.md" to body,
+        "owner-repo-sha/skills/mvi/references/guide.md" to "guide\n",
+        "owner-repo-sha/skills/mvi/Bad_Sub/SKILL.md" to bad,
+        "owner-repo-sha/skills/mvi/Bad_Sub/notes.md" to "notes\n",
+      )
+    val source = ArchiveSource.RepoZipball(zipBytes, "owner", "repo", "abcdef1234567890")
+
+    val detected = (Discovery.discover(source) as ScanResult.Found).skills
+    assertEquals(1, detected.size)
+    val previewCount = detected[0].fileCount.toLong()
+
+    val result = IngestPipeline.ingest(source, bundleId, store, userId)
+    val skillId = result.skills.single().skillId
+    val mirrored = transaction {
+      SkillFiles.selectAll().where { SkillFiles.skillId eq skillId }.count()
+    }
+    assertEquals(4L, mirrored, "all four files mirrored to mvi")
+    assertEquals(previewCount, mirrored, "scan fileCount must equal mirrored skill_files")
+  }
+
+  @Test
   fun `new skill - writes everything`() {
     val (bundleId, userId) = seedBundle()
     val zipBytes = skillZip("test-mvi", "MVI Scaffold", "A baseline.", "1.0.0")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,8 +121,8 @@ uploaded zip). A repo is owned first-come-first-served by one account.
   into the agent's skills dir (`~/.claude/skills/`, `~/.codex/skills/`); CLI is
   secondary and is a single static binary (Kotlin Native / Rust / Go), distributed
   via brew/winget/install script — never npm.
-- **Skills discovered only under a top-level `skills/` directory** in a repo;
-  `SKILL.md` elsewhere is intentionally ignored.
+- **Skills discovered at any depth** in a repo — every directory containing a
+  `SKILL.md` is a skill; dot-directories and a bare repo-root `SKILL.md` are ignored.
 - **Manifest (`SKILL.md`) is the source of truth** — name/slug/description/tags are
   read-only in the UI; category is LLM-assigned.
 - **Prototype is deliberately vanilla** (no React, CSS `light-dark()`); keep the

--- a/docs/backend-spec.md
+++ b/docs/backend-spec.md
@@ -40,10 +40,10 @@ service, everything else is Astro.
 
 ## 3. Domain rules (binding)
 
-1. **Skill discovery:** skills are found **only** under a **top-level `skills/`
-   directory** in a repo/zip (any depth beneath it). A `SKILL.md` anywhere else
-   (repo root, `.github/`, `.claude/`, `.agents/`) is **intentionally ignored**.
-   A bundle may expose one or many skills.
+1. **Skill discovery:** skills are found **at any depth** in a repo/zip — every
+   directory that directly contains a `SKILL.md` is a skill. A `SKILL.md` in a
+   dot-directory (`.github/`, `.claude/`, `.agents/`) or a bare one at the repo root
+   is **intentionally ignored**. A bundle may expose one or many skills.
 2. **Manifest is source of truth:** `name`, `description`, `tags`, `license`, slug
    come from `SKILL.md` and are **never editable via the UI/API** — changing them
    means editing the file and re-syncing.
@@ -210,12 +210,13 @@ Triggered by (a) a submission being approved, or (b) a `resync` job from a webho
 
 1. **Fetch source.** Repo: download the tarball at the target commit via the GitHub
    App installation token. Zip: read the uploaded archive from `FileStore`.
-2. **Discover skills.** Walk for a **top-level `skills/` directory**; each subtree
-   containing a `SKILL.md` is one skill. Ignore `SKILL.md` outside `skills/`.
+2. **Discover skills.** Walk the archive; each directory that directly contains a
+   `SKILL.md` (at any depth) is one skill. Ignore dot-directories and a bare
+   repo-root `SKILL.md`.
 3. **Parse `SKILL.md`.** Split YAML frontmatter from the Markdown body. Frontmatter
    fields: `name` (req), `description` (req), `tags` (optional list), `license`
-   (req per §10), `metadata.version` (optional SemVer). The **slug** is the skill's
-   directory name under `skills/`.
+   (req per §10), `metadata.version` (optional SemVer). The **slug** is derived from
+   the skill's leaf directory name (uniquified with a `-N` suffix on collision).
 4. **Mirror files** into `FileStore` under the key layout in §11; record each in
    `skill_files` (path, size, binary flag, key). Store the raw body in `skills.readme_md`.
 5. **Compute token estimate** (§ below) → `token_upfront`, `token_ondemand`, `token_band`.
@@ -279,7 +280,7 @@ push webhooks. Store the App id, private key (PEM), and webhook secret as env/se
 - **On-demand scan** (`POST /api/me/repos/{owner}/{repo}/scan`): with an installation
   token, fetch the tree at the default branch's HEAD, apply §3.1 discovery, parse each
   `SKILL.md`, return detected skills as **read-only** metadata + token estimate. If no
-  top-level `skills/` dir → return a "No SKILL.md under skills/" error; submit blocked.
+  `SKILL.md` anywhere → return a "No SKILL.md found" error; submit blocked.
 - **Webhooks** (`POST /gh/webhooks`): verify the HMAC signature against the webhook
   secret. On `push` to a tracked repo's default branch → enqueue a `resync` job (which
   re-ingests and re-reviews before re-publishing). Handle `installation` /

--- a/web/src/pages/about.astro
+++ b/web/src/pages/about.astro
@@ -43,13 +43,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <div class="prose">
         <p>
           A skill is a folder containing a <code>SKILL.md</code> manifest. A single GitHub repo can hold
-          one or many skills — but they must live under a top-level <code>skills/</code> directory. When
-          you submit, androidskills.dev:
+          one or many skills, in whatever layout suits it. When you submit, androidskills.dev:
         </p>
         <ul>
-          <li>looks only inside <code>skills/</code> at the root of the repo;</li>
-          <li>publishes every folder beneath it — at any depth — that contains a <code>SKILL.md</code>;</li>
-          <li>ignores <code>SKILL.md</code> files anywhere else (<code>.github/</code>, <code>.claude/</code>, <code>.agents/</code>, repo root).</li>
+          <li>publishes every folder in the repo — at any depth — that contains a <code>SKILL.md</code>;</li>
+          <li>derives each skill's slug from its folder name;</li>
+          <li>ignores <code>SKILL.md</code> files in dot-directories (<code>.github/</code>, <code>.claude/</code>, <code>.agents/</code>), a bare one at the repo root, and folders whose name isn’t a valid slug.</li>
         </ul>
       </div>
     </div>

--- a/web/src/pages/submissions.astro
+++ b/web/src/pages/submissions.astro
@@ -54,7 +54,7 @@ const totalSubmissions = sorted.reduce((sum, g) => sum + g.items.length, 0);
         <div style="max-width:440px;">
           <EmptyState
             title="No submissions yet"
-            body="Connect a GitHub repo with a top-level skills/ directory to publish your first."
+            body="Connect a GitHub repo that contains one or more SKILL.md files to publish your first."
           >
             <a slot="action" class="btn btn-sm btn-primary" href="/submit">Submit a skill</a>
           </EmptyState>

--- a/web/src/scripts/submit-wizard.ts
+++ b/web/src/scripts/submit-wizard.ts
@@ -68,11 +68,11 @@ function renderStep1() {
   const repos = state.repos.repos || [];
   if (repos.length === 0) {
     container.innerHTML =
-      '<div class="state"><p class="muted">No repositories found. Install the GitHub App and grant access to a repo with a top-level <code>skills/</code> directory.</p></div>';
+      '<div class="state"><p class="muted">No repositories found. Install the GitHub App and grant access to a repo that contains one or more skills (any folder with a <code>SKILL.md</code>).</p></div>';
     return;
   }
   container.innerHTML = `
-    <p class="hint" style="margin-bottom:12px;line-height:1.55;">Pick a repository with one or more skills in a top-level <code style="font-family:var(--mono);font-size:11px;">skills/</code> directory.</p>
+    <p class="hint" style="margin-bottom:12px;line-height:1.55;">Pick a repository that contains one or more skills — any folder with a <code style="font-family:var(--mono);font-size:11px;">SKILL.md</code>.</p>
     <div class="tbl-wrap" style="border:1px solid var(--border);border-radius:var(--r-md);overflow:hidden;">
       <div style="padding:10px 12px;border-bottom:1px solid var(--border);">
         <div class="search search-sm">
@@ -148,7 +148,7 @@ function renderStep2() {
   const skills = state.scan.skills || [];
   if (skills.length === 0) {
     container.innerHTML =
-      '<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>No skill found.</b> A skill is a folder containing a SKILL.md inside a top-level skills/ directory.</div></div>';
+      '<div class="callout" style="background:var(--danger-soft);border-color:transparent;align-items:flex-start;"><svg class="ci" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg><div><b>No skill found.</b> A skill is any folder in the repo that contains a SKILL.md (dot-directories are ignored).</div></div>';
     return;
   }
   const items = skills


### PR DESCRIPTION
Second and final PR of the discovery cleanup, on top of #39 (slug-model redesign). This is the salvageable part of the parked #38, rebased onto the new identity model — its dup-slug flagging is **superseded** by #39's `uniqueSlug` and is intentionally *not* re-added.

## The bug

`Discovery.discover` assigned files using **every** directory that holds a `SKILL.md` (including dirs whose leaf isn't a valid slug), then dropped the invalid-leaf ones from the result. `IngestPipeline` assigns using only the **valid** detected dirs (`detected.map { sourceDir }`). So a nested invalid-leaf subtree was counted separately in the scan preview but folded into its valid ancestor on ingest → `DetectedSkill.fileCount` ≠ files actually mirrored.

Traced: archive `skills/mvi/{SKILL.md, references/guide.md}` + `skills/mvi/Bad_Sub/{SKILL.md, notes.md}` (leaf `Bad_Sub` invalid) → scan reports `mvi.fileCount = 2`, ingest mirrors **4** (absorbing `Bad_Sub`), silently.

## The fix

Split **candidate** dirs (any `SKILL.md`, minus dot-dirs → drives the `NoSkillsDir` signal) from **valid** dirs (leaf is a real slug → the file-assignment set). Discovery now assigns files via valid dirs only — the exact set `IngestPipeline` (and `promote`) mirror from — so `fileCount` is truthful and an invalid-leaf subtree folds into its nearest valid ancestor **consistently** in the preview and on ingest. (A subagent proved `validDirs == detected.map { sourceDir }` exactly — a bijection — so this also fixes `promote` for free.)

## Honest copy

Discovery has been any-depth since #37, but "must live under a top-level `skills/` directory" text lingered — including a self-contradictory `about.astro` (said both "must live under `skills/`" *and* "at any depth"). Corrected across the Kotlin `NoSkillsDir` messages, `about.astro` / `submissions.astro`, the submit wizard (3 strings), and `docs/backend-spec.md` + `docs/architecture.md`.

## Tests

- `DiscoveryTest`: invalid-leaf nested dir folds its files into the valid ancestor (`fileCount == 4`) — fails on pre-fix code (`2`).
- `IngestPipelineTest`: Discovery↔ingest consistency — `DetectedSkill.fileCount` equals mirrored `skill_files` (2→4), locking the two assignment paths so they can't drift.

All CI gates green locally: API spotless + detekt + tests; web format + lint + astro-check + tsc + tests + build. Pre-push adversarial subagent review: **SAFE TO PUSH**.

## Out of scope

Dup-leaf slug flagging / any slug synthesis in Discovery / cross-bundle slug concerns — all resolved or superseded by #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)