### PR TITLE
fix(github): parse /app/installations as an array; fix OAuth callback UOE + blank wizard

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/auth/AuthRoutes.kt
@@ -58,42 +58,35 @@ fun Route.authRoutes(config: AppConfig, oauth: OAuthClient) {
         val code = call.request.queryParameters["code"]
         val stateParam = call.request.queryParameters["state"]
         val stateCookie = call.request.cookies[stateCookieName(auth)]
-        try {
-          // CSRF: the state echoed by GitHub must match the cookie we set on start.
-          if (code.isNullOrBlank() || stateParam.isNullOrBlank() || stateCookie.isNullOrBlank()) {
-            throw ApiBadRequestException("Missing OAuth code/state")
-          }
-          if (!constantTimeEquals(stateParam, stateCookie)) {
-            throw ApiBadRequestException("OAuth state mismatch")
-          }
-          val userId =
-            try {
-              val tokens = oauth.exchange(code, redirectUri)
-              val ghUser = oauth.userInfo(tokens.accessToken)
-              UsersRepo.upsertFromGitHub(ghUser, auth.bootstrapAdminGithubId)
-            } catch (e: OAuthException) {
-              // GitHubOAuthClient translates every auth/network failure into
-              // OAuthException, so a bad/expired code, a revoked token, or a
-              // transient GitHub outage is a controlled 400 — never an opaque
-              // 500. (DB/server errors still propagate as genuine 5xx.)
-              logger.warn("GitHub OAuth callback failed: {}", e.message)
-              throw ApiBadRequestException("GitHub sign-in failed. Please try again.")
-            }
-          val session = SessionStore.create(userId, SESSION_MAX_AGE_SECONDS)
-          setSessionCookie(call, session, auth)
-          // Clear the single-use state cookie BEFORE the redirect is committed —
-          // appending Set-Cookie after respondRedirect is engine-dependent and
-          // may be dropped on a real engine (NEW-2). (The finally below covers
-          // the throw paths; success clears here, before responding.)
-          clearStateCookie(call, auth)
-          // Redirect to the site root; the SPA/Astro picks up the session cookie.
-          call.respondRedirect(auth.publicBaseUrl)
-        } finally {
-          // Throws (validation 400, auth-failure 400, or an unexpected 5xx):
-          // StatusPages responds AFTER this, so the Set-Cookie lands. The
-          // success path cleared the cookie itself, above (before its redirect).
-          clearStateCookie(call, auth)
+        // The state cookie is single-use: queue its removal NOW, before any response is
+        // committed, so it lands on both the success redirect and any StatusPages error. Doing it
+        // in a `finally` after `respondRedirect` throws "headers can no longer be set" on a real
+        // engine because the redirect already completed the response (NEW-2).
+        clearStateCookie(call, auth)
+        // CSRF: the state echoed by GitHub must match the cookie we set on start.
+        if (code.isNullOrBlank() || stateParam.isNullOrBlank() || stateCookie.isNullOrBlank()) {
+          throw ApiBadRequestException("Missing OAuth code/state")
         }
+        if (!constantTimeEquals(stateParam, stateCookie)) {
+          throw ApiBadRequestException("OAuth state mismatch")
+        }
+        val userId =
+          try {
+            val tokens = oauth.exchange(code, redirectUri)
+            val ghUser = oauth.userInfo(tokens.accessToken)
+            UsersRepo.upsertFromGitHub(ghUser, auth.bootstrapAdminGithubId)
+          } catch (e: OAuthException) {
+            // GitHubOAuthClient translates every auth/network failure into
+            // OAuthException, so a bad/expired code, a revoked token, or a
+            // transient GitHub outage is a controlled 400 — never an opaque
+            // 500. (DB/server errors still propagate as genuine 5xx.)
+            logger.warn("GitHub OAuth callback failed: {}", e.message)
+            throw ApiBadRequestException("GitHub sign-in failed. Please try again.")
+          }
+        val session = SessionStore.create(userId, SESSION_MAX_AGE_SECONDS)
+        setSessionCookie(call, session, auth)
+        // Redirect to the site root; the SPA/Astro picks up the session cookie.
+        call.respondRedirect(auth.publicBaseUrl)
       }
 
       post("auth/logout") {

--- a/api/src/main/kotlin/dev/androidskills/github/RealGitHubAppClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/github/RealGitHubAppClient.kt
@@ -78,7 +78,8 @@ class RealGitHubAppClient(
 
   override suspend fun installations(): List<Installation> {
     val jwt = AppJwt.build(appId, privateKeyPem)
-    val resp: InstallationsResponse = ghCall {
+    // GitHub's `GET /app/installations` returns a TOP-LEVEL JSON array, not a wrapped object.
+    val resp: List<InstallationDto> = ghCall {
       http
         .get("$githubApiBase/app/installations") {
           bearerAuth(jwt)
@@ -86,7 +87,7 @@ class RealGitHubAppClient(
         }
         .body()
     }
-    return resp.installations.map {
+    return resp.map {
       Installation(
         id = it.id,
         accountId = it.account.id,
@@ -249,9 +250,6 @@ private data class TokenResponse(
   val token: String,
   @SerialName("expires_at") val expiresAt: String,
 )
-
-@Serializable
-private data class InstallationsResponse(val installations: List<InstallationDto> = emptyList())
 
 @Serializable private data class InstallationDto(val id: Long, val account: AccountDto)
 

--- a/api/src/test/kotlin/dev/androidskills/github/RealGitHubAppClientTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/github/RealGitHubAppClientTest.kt
@@ -133,14 +133,21 @@ class RealGitHubAppClientTest {
 
   @Test
   fun `installations parses account info`() = runBlocking {
+    // GitHub's GET /app/installations returns a TOP-LEVEL array, not a wrapped object.
     val (gh, _) =
-      newClient(
-        body = """{"installations":[{"id":1,"account":{"id":42,"login":"alice","type":"User"}}]}"""
-      )
+      newClient(body = """[{"id":1,"account":{"id":42,"login":"alice","type":"User"}}]""")
     val list = gh.installations()
     assertEquals(1, list.size)
     assertEquals(42L, list[0].accountId)
     assertEquals("alice", list[0].accountLogin)
+  }
+
+  @Test
+  fun `installations returns empty for a bare empty array`() = runBlocking {
+    // An app with no installs returns `[]`. Regression: a wrapper-object DTO threw on this,
+    // surfacing as a 502 on /api/me/repos and a blank submit wizard.
+    val (gh, _) = newClient(body = "[]")
+    assertEquals(emptyList(), gh.installations())
   }
 
   @Test

--- a/web/src/scripts/submit-wizard.ts
+++ b/web/src/scripts/submit-wizard.ts
@@ -361,6 +361,10 @@ if (vsteps) {
     if (target.id === 'repoFilter') renderRepoList();
   });
 
+  // Render the wizard immediately so step 1 is visible with a loading state; otherwise a failed
+  // (or slow) repo fetch leaves the step hidden and the page looks blank. Then load + re-render,
+  // and surface any error into the now-visible step.
+  render();
   loadRepos()
     .then(render)
     .catch((e) => {


### PR DESCRIPTION
Three bugs that together broke the GitHub App **submit flow** end-to-end — found while testing it on staging (signed in as an admin, opened *Submit a skill*, got a blank repo picker).

## 1. `installations()` parsed the wrong JSON shape → repo picker always 502'd (the blocker)
`RealGitHubAppClient.installations()` deserialized GitHub's `GET /app/installations` into a **wrapped object** `{"installations":[…]}`, but that endpoint returns a **bare JSON array** `[…]` (verified against live GitHub). So it threw on parse for *every* call → `GitHubAppException` → `/api/me/repos` returned **502** every time. The repo picker has never worked against real GitHub. The unit test passed only because it **mocked the wrong wrapped shape** — so the test enshrined the bug.

Fix: deserialize `List<InstallationDto>` directly; drop the unused `InstallationsResponse` DTO; correct the test mock to a bare array **and** add an empty-array `[]` regression test (the 0-installations case that surfaced this). `listRepos`/`token`/`repo` DTOs are genuinely wrapped and were left alone.

## 2. OAuth callback threw `UnsupportedOperationException` (noisy 500 in logs)
The success path did `respondRedirect()` then a `finally { clearStateCookie() }` — setting a Set-Cookie **after** the response was already completed → "Headers can no longer be set". Login worked despite it, but it logged an unhandled 500. Fix: clear the single-use state cookie **once, early** (queued before any response, lands on both the redirect and any error), and drop the try/finally.

## 3. Submit wizard showed a blank step 1 on a failed repo load
`render()` (which makes the active step's content visible via `.vstep.active`) only ran on `loadRepos()` **success**; the `.catch` wrote an error callout into a still-hidden step → blank page. Fix: `render()` first so loading/error states are visible.

## Tests / gates
API build + new `installations` array/empty-array tests green; all web gates (format/lint/astro-check/tsc/build) green. Pre-push adversarial subagent review: **SAFE TO PUSH** (traced the callback restructure path-by-path; no regressions).

## Known follow-up (pre-existing, out of scope)
`installations()`/`listRepos()` don't paginate — they cap at GitHub's default first page (30). Fine for now; worth a follow-up if anyone installs on >30 accounts/repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)