### PR TITLE
feat(submit): grant GitHub App repo access inline from the wizard

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/ContributorRoutes.kt
@@ -94,7 +94,16 @@ private suspend fun repos(call: ApplicationCall, gh: GitHubAppClient) {
         )
       }
     }
-  call.respond(ReposResponse(repos.map { it.toDto() }))
+  // The App's install/configure page, so the UI can offer "grant repo access" inline (works even
+  // with zero installations, which is exactly when the user needs it). This is ancillary: a failed
+  // `GET /app` must NOT fail the repo list, so degrade to the generic installations page.
+  val installUrl =
+    try {
+      gh.installUrl()
+    } catch (e: GitHubAppException) {
+      "https://github.com/settings/installations"
+    }
+  call.respond(ReposResponse(repos.map { it.toDto() }, installUrl))
 }
 
 private suspend fun scan(call: ApplicationCall, gh: GitHubAppClient) {
@@ -173,7 +182,7 @@ data class RepoDto(
   val defaultBranch: String?,
 )
 
-@Serializable data class ReposResponse(val repos: List<RepoDto>)
+@Serializable data class ReposResponse(val repos: List<RepoDto>, val installUrl: String)
 
 @Serializable
 data class DetectedSkillDto(

--- a/api/src/main/kotlin/dev/androidskills/github/GitHubAppClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/github/GitHubAppClient.kt
@@ -22,6 +22,12 @@ interface GitHubAppClient {
   /** The App's installations (`GET /app/installations`, App-JWT auth). */
   suspend fun installations(): List<Installation>
 
+  /**
+   * The App's install/configure page — where a user grants repo access. Real impls resolve it from
+   * `GET /app` (`html_url`); the default is a fallback for tests and the disabled client.
+   */
+  suspend fun installUrl(): String = "https://github.com/settings/installations"
+
   /** Repos accessible to an installation (`GET /installation/repositories`). */
   suspend fun listRepos(installationId: Long): List<RepoRef>
 

--- a/api/src/main/kotlin/dev/androidskills/github/RealGitHubAppClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/github/RealGitHubAppClient.kt
@@ -97,6 +97,26 @@ class RealGitHubAppClient(
     }
   }
 
+  // The App's html_url is static for the app's lifetime; resolve once, then cache. A benign race
+  // just re-fetches the same value.
+  private var cachedInstallUrl: String? = null
+
+  override suspend fun installUrl(): String {
+    cachedInstallUrl?.let {
+      return it
+    }
+    val jwt = AppJwt.build(appId, privateKeyPem)
+    val resp: AppResponse = ghCall {
+      http
+        .get("$githubApiBase/app") {
+          bearerAuth(jwt)
+          header("Accept", "application/vnd.github+json")
+        }
+        .body()
+    }
+    return "${resp.htmlUrl.trimEnd('/')}/installations/new".also { cachedInstallUrl = it }
+  }
+
   override suspend fun listRepos(installationId: Long): List<RepoRef> {
     val token = installToken(installationId)
     val resp: ReposResponse = ghCall {
@@ -250,6 +270,8 @@ private data class TokenResponse(
   val token: String,
   @SerialName("expires_at") val expiresAt: String,
 )
+
+@Serializable private data class AppResponse(@SerialName("html_url") val htmlUrl: String)
 
 @Serializable private data class InstallationDto(val id: Long, val account: AccountDto)
 

--- a/api/src/main/resources/openapi.yaml
+++ b/api/src/main/resources/openapi.yaml
@@ -1298,11 +1298,15 @@ components:
       type: object
       required:
       - repos
+      - installUrl
       properties:
         repos:
           type: array
           items:
             $ref: '#/components/schemas/RepoDto'
+        installUrl:
+          type: string
+          description: GitHub App install/configure page, for granting repo access inline.
     DetectedFieldError:
       type: object
       required:

--- a/api/src/test/kotlin/dev/androidskills/api/ContributorRoutesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/ContributorRoutesTest.kt
@@ -137,6 +137,7 @@ class ContributorRoutesTest {
       val body = res.bodyAsText()
       assertTrue(body.contains("alice/toolkit"), body)
       assertTrue(!body.contains("other/secret"), "personal-only filter (Q3); body=$body")
+      assertTrue(body.contains("\"installUrl\""), "response carries the install URL; body=$body")
     }
 
   @Test

--- a/api/src/test/kotlin/dev/androidskills/github/RealGitHubAppClientTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/github/RealGitHubAppClientTest.kt
@@ -151,6 +151,12 @@ class RealGitHubAppClientTest {
   }
 
   @Test
+  fun `installUrl resolves the app html_url and appends the install path`() = runBlocking {
+    val (gh, _) = newClient(body = """{"html_url":"https://github.com/apps/my-app"}""")
+    assertEquals("https://github.com/apps/my-app/installations/new", gh.installUrl())
+  }
+
+  @Test
   fun `listRepos parses repository list`() = runBlocking {
     // The client needs an installation token first — mock a token endpoint response,
     // then the repos endpoint. MockEngine handles both in order via request matching.

--- a/web/src/lib/api-types.ts
+++ b/web/src/lib/api-types.ts
@@ -1558,6 +1558,8 @@ export interface components {
     };
     ReposResponse: {
       repos: components['schemas']['RepoDto'][];
+      /** @description GitHub App install/configure page, for granting repo access inline. */
+      installUrl: string;
     };
     DetectedFieldError: {
       field: string;

--- a/web/src/pages/settings.astro
+++ b/web/src/pages/settings.astro
@@ -28,6 +28,10 @@ try {
   repos = null;
   reposError = e instanceof Error ? e.message : 'GitHub App unavailable';
 }
+
+// The App's install/configure page (env-correct, from the API when the App is reachable); falls
+// back to the user's installations page when the App is disabled / the repos call failed.
+const installUrl = repos?.installUrl ?? 'https://github.com/settings/installations';
 ---
 
 <BaseLayout title="Settings" description="Manage your account, preferences, and GitHub access.">
@@ -161,7 +165,7 @@ try {
                     <div>Repository access is controlled on GitHub, not here. We can only read repositories you've granted.</div>
                   </div>
                   <div class="row" style="gap:10px;flex-wrap:wrap;margin-top:14px;">
-                    <a class="btn btn-sm btn-primary" href="https://github.com/settings/installations" target="_blank" rel="noopener">Configure access on GitHub</a>
+                    <a class="btn btn-sm btn-primary" href={installUrl} target="_blank" rel="noopener">Configure access on GitHub</a>
                   </div>
                 </div>
               ) : (
@@ -170,7 +174,7 @@ try {
                   <div>
                     <b>GitHub App not connected.</b> {reposError || 'Install the androidskills GitHub App on your account to import skills from repositories.'}
                     <div class="row" style="gap:10px;margin-top:10px;">
-                      <a class="btn btn-sm btn-primary" href="https://github.com/apps/androidskills" target="_blank" rel="noopener">Install on GitHub</a>
+                      <a class="btn btn-sm btn-primary" href={installUrl} target="_blank" rel="noopener">Install on GitHub</a>
                     </div>
                   </div>
                 </div>

--- a/web/src/scripts/submit-wizard.ts
+++ b/web/src/scripts/submit-wizard.ts
@@ -9,6 +9,7 @@ interface Repo {
 }
 interface ReposResponse {
   repos: Repo[];
+  installUrl: string;
 }
 interface DetectedSkill {
   slug: string;
@@ -66,9 +67,15 @@ function renderStep1() {
     return;
   }
   const repos = state.repos.repos || [];
+  const installUrl = esc(state.repos.installUrl);
   if (repos.length === 0) {
-    container.innerHTML =
-      '<div class="state"><p class="muted">No repositories found. Install the GitHub App and grant access to a repo that contains one or more skills (any folder with a <code>SKILL.md</code>).</p></div>';
+    // No granted repos: GitHub only exposes repos you've installed the App on, so the action is to
+    // grant access. GitHub bounces back here (the App's Setup URL) and the list auto-refreshes.
+    container.innerHTML = `
+      <div class="state" style="text-align:left;">
+        <p class="muted" style="margin-bottom:14px;line-height:1.55;">No repositories yet. Grant the GitHub App access to the repos you want to submit from — anything with a <code style="font-family:var(--mono);font-size:11px;">SKILL.md</code>. You'll come right back here.</p>
+        <a class="btn btn-primary" href="${installUrl}">Grant repository access on GitHub →</a>
+      </div>`;
     return;
   }
   container.innerHTML = `
@@ -82,7 +89,10 @@ function renderStep1() {
       </div>
       <div id="repoList"></div>
     </div>
-    <div id="repoStatus" style="margin-top:10px;"></div>
+    <div class="row" style="justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap;margin-top:10px;">
+      <span id="repoStatus"></span>
+      <a class="hint" href="${installUrl}" style="color:var(--accent-text);">Don't see your repo? Add another →</a>
+    </div>
   `;
   renderRepoList();
 }
@@ -364,12 +374,25 @@ if (vsteps) {
   // Render the wizard immediately so step 1 is visible with a loading state; otherwise a failed
   // (or slow) repo fetch leaves the step hidden and the page looks blank. Then load + re-render,
   // and surface any error into the now-visible step.
+  const loadAndRender = () =>
+    loadRepos()
+      .then(render)
+      .catch((e) => {
+        // Keep an already-loaded list on a transient refetch failure (e.g. on tab refocus) rather
+        // than replacing it with an error; only surface the error when we have nothing to show.
+        if (state.repos) return;
+        const el = document.getElementById('step1content');
+        if (el)
+          el.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;"><b>Failed to load repositories:</b> ${esc(e.message)}</div>`;
+      });
   render();
-  loadRepos()
-    .then(render)
-    .catch((e) => {
-      const el = document.getElementById('step1content');
-      if (el)
-        el.innerHTML = `<div class="callout" style="background:var(--danger-soft);border-color:transparent;"><b>Failed to load repositories:</b> ${esc(e.message)}</div>`;
-    });
+  loadAndRender();
+
+  // When the user returns to this tab after granting repo access on GitHub (the App's Setup URL
+  // bounces them back, or they switch tabs), refresh the repo list so the new repo appears without
+  // a manual reload. Only while still on the repo-picker step.
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && state.step === 1)
+      loadAndRender();
+  });
 }


### PR DESCRIPTION
Granting the App repo access was a separate detour — an "Install on GitHub" button buried in Settings, **hardcoded to the prod app slug** (`github.com/apps/androidskills`), so on staging it pointed at the wrong app. This makes it inline in the submit wizard, and env-correct.

## What
- **api** — `GitHubAppClient.installUrl()` resolves the App's install/configure page from `GET /app` (`html_url` + `/installations/new`), cached. `/api/me/repos` now returns `installUrl`. It's **ancillary**: a `GET /app` failure degrades to a generic installations URL and **never fails the repo list** (a strict-review catch — the primary data shouldn't 502 over a secondary URL). `ReposResponse.installUrl`; openapi + regenerated `api-types.ts`. Interface default keeps the ~6 test fakes untouched.
- **web (wizard)** — the repo step's **empty state** shows a primary *"Grant repository access on GitHub"* button; the **populated state** adds a *"Don't see your repo? Add another →"* link — both to `installUrl`. On **tab refocus** (GitHub's Setup URL bounces back after you grant access) the repo list **auto-refreshes**, and a transient refetch failure keeps the current list instead of clobbering it with an error.
- **web (settings)** — uses the API `installUrl` for both the "Configure access" and "Install" links, killing the hardcoded wrong-slug link.

## Why it's shaped this way
GitHub only exposes repos you've **granted** to the installation (our OAuth scope is `read:user` — there's no "list all my repos"), so "grant access → they appear" is as inline as the model allows. You've set the App's **Setup URL** to the submit page, so the round-trip lands users back on the wizard.

## Tests / gates
API build + tests (`installUrl` unit test; repos route asserts the field) + detekt; web format/lint/astro-check/tsc/build — all green. Pre-push adversarial review returned NEEDS FIXES on 3 items (installUrl failure 502ing the list; refocus clobber; settings dead-code/wrong fallback) — **all fixed** in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)