### PR TITLE
fix(api): starred page fails to load after starring a skill

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
@@ -614,6 +614,21 @@ object PublicQueries {
     return Facets(categoryFacet, tagFacet, sizeFacet)
   }
 
+  /**
+   * Full skill cards for the given published skill [ids], returned in the same order as [ids]
+   * (unknown or non-published IDs are silently dropped). Shares the [buildCards] projection so the
+   * starred library renders cards identical to search results.
+   */
+  fun cardsByIds(ids: List<String>): List<SkillCard> = transaction {
+    if (ids.isEmpty()) return@transaction emptyList()
+    val rows =
+      Skills.selectAll()
+        .where { (Skills.id inList ids) and (Skills.status eq "published") }
+        .toList()
+    val byId = buildCards(rows).associateBy { it.id }
+    ids.mapNotNull { byId[it] }
+  }
+
   private fun buildCards(rows: List<ResultRow>): List<SkillCard> {
     if (rows.isEmpty()) return emptyList()
     val bundles =

--- a/api/src/main/kotlin/dev/androidskills/api/StarsQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/StarsQueries.kt
@@ -1,12 +1,10 @@
 package dev.androidskills.api
 
 import dev.androidskills.auth.Principal
-import dev.androidskills.db.Categories
 import dev.androidskills.db.SkillStatus
 import dev.androidskills.db.Skills
 import dev.androidskills.db.Stars
 import dev.androidskills.util.nowIso
-import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
@@ -17,45 +15,19 @@ import org.jetbrains.exposed.sql.transactions.transaction
 /** Account-synced starred library (spec §9 Contributor). */
 object StarsQueries {
 
-  @Serializable
-  data class StarredSkill(
-    val slug: String,
-    val name: String,
-    val category: String?,
-    val createdAt: String,
-  )
-
-  fun listStars(principal: Principal): List<StarredSkill> = transaction {
-    val stars =
+  /**
+   * The user's starred skills as full [SkillCard]s (spec: `GET /api/me/stars` returns
+   * `SkillCard[]`), newest star first. Unpublished/removed skills are dropped so the library never
+   * renders a broken card.
+   */
+  fun listStars(principal: Principal): List<SkillCard> {
+    val skillIds = transaction {
       Stars.selectAll()
         .where { Stars.userId eq principal.userId }
         .orderBy(Stars.createdAt to SortOrder.DESC)
-        .map { it[Stars.skillId] to it[Stars.createdAt] }
-    val skillIds = stars.map { it.first }
-    val skillsById =
-      if (skillIds.isEmpty()) emptyMap()
-      else {
-        Skills.selectAll()
-          .where { (Skills.id inList skillIds) and (Skills.status eq SkillStatus.published.name) }
-          .associateBy({ it[Skills.id] }, { it })
-      }
-    val categoryIds = skillsById.values.mapNotNull { it[Skills.categoryId] }.distinct()
-    val categoryNames =
-      if (categoryIds.isEmpty()) emptyMap()
-      else {
-        Categories.selectAll()
-          .where { Categories.id inList categoryIds }
-          .associate { it[Categories.id] to it[Categories.name] }
-      }
-    stars.mapNotNull { (skillId, createdAt) ->
-      val skill = skillsById[skillId] ?: return@mapNotNull null
-      StarredSkill(
-        slug = skill[Skills.slug],
-        name = skill[Skills.name],
-        category = skill[Skills.categoryId]?.let { categoryNames[it] },
-        createdAt = createdAt,
-      )
+        .map { it[Stars.skillId] }
     }
+    return PublicQueries.cardsByIds(skillIds)
   }
 
   fun addStar(principal: Principal, slug: String) {

--- a/api/src/test/kotlin/dev/androidskills/api/StarsQueriesTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/StarsQueriesTest.kt
@@ -108,8 +108,11 @@ class StarsQueriesTest {
     val stars = StarsQueries.listStars(principal)
     assertEquals(2, stars.size)
     val bySlug = stars.associateBy { it.slug }
-    assertEquals("UI", bySlug["skill-one"]?.category)
+    assertEquals("UI", bySlug["skill-one"]?.category?.name)
     assertEquals(null, bySlug["skill-two"]?.category)
+    // Full SkillCard projection — the /starred page renders these, so author must be present
+    // (a lean DTO here previously crashed the page on the first star).
+    assertEquals("alice", bySlug["skill-one"]?.author?.handle)
   }
 
   @Test


### PR DESCRIPTION
## The bug
Starring a skill made `/starred` fail to load. With zero stars the page was fine; the first star broke it.

## Root cause
`GET /api/me/stars` is declared to return `SkillCard[]` (OpenAPI + generated TS client), and `starred.astro` renders `<SkillCard>`, which reads `skill.tags.length`, `skill.installs.toLocaleString()`, and `skill.author.name`. But the Kotlin route serialized a **lean `StarredSkill`** (`slug`/`name`/`category`/`createdAt` only), so those fields arrived `undefined` → `TypeError` during SSR → 500. Zero stars never hit the `.map`, hiding the bug.

## Fix (API-only, honors the existing contract)
- `StarsQueries.listStars` now returns real `SkillCard[]` via a shared `PublicQueries.cardsByIds()` that reuses the same `buildCards()` projection as search — full `tags`/`installs`/`author`/`tokenBand`/`verified`.
- Preserves newest-star-first order; drops unpublished/removed skills so the library never renders a broken card.
- No OpenAPI or client-type change needed (the spec already said `SkillCard[]`).
- Test now asserts the full-card shape (`author.handle`), which a lean DTO would fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)