### PR TITLE
fix(web): starred page full-width grid + empty-state copy

### DIFF
--- a/web/src/pages/starred.astro
+++ b/web/src/pages/starred.astro
@@ -18,7 +18,7 @@ try {
 
 <BaseLayout title="Starred skills" description="Your personal library of starred Android skills.">
   <section class="section" style="padding-top:32px;">
-    <div class="wrap" style="max-width:440px;">
+    <div class="wrap">
       <div class="kicker"><span class="tick">//</span> LIBRARY</div>
       <h1 style="font-size:30px;margin-top:8px;">Starred skills</h1>
 

--- a/web/src/pages/starred.astro
+++ b/web/src/pages/starred.astro
@@ -34,7 +34,7 @@ try {
         </div>
       ) : (
         <div style="margin-top:24px;">
-          <EmptyState title="Nothing starred yet" body="Your starred skills are saved on this device.">
+          <EmptyState title="Nothing starred yet" body="Your starred skills are saved to your account.">
             <a slot="action" class="btn btn-primary" href="/search">Browse skills</a>
           </EmptyState>
         </div>


### PR DESCRIPTION
Two small fixes to [starred.astro](web/src/pages/starred.astro):

- **Layout**: the `.wrap` was pinned to `max-width:440px`, which squeezed the skills grid into one narrow centred column. Dropped the override so it matches `search.astro` — the grid now spans the content column and `grid-skills` (`auto-fill, minmax(290px,1fr)`) lays cards out properly.
- **Copy**: the "Nothing starred yet" state said stars are *"saved on this device"*, but they're account-synced (the signed-out state already says *"saved to your account"*). Made the two consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)