### PR TITLE
feat: advisory security notes on the public skill page

### DIFF
--- a/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/AdminQueueQueries.kt
@@ -295,6 +295,12 @@ object AdminQueueQueries {
                 ?.get(Categories.id)
             }
 
+          // Advisory (fyi) notes surface on the public skill page; hard flags never reach a
+          // published skill, so only the advisory notes are carried over.
+          val advisoryNotes =
+            review?.securityFindings?.filter { it.severity == "fyi" }?.map { it.message }
+              ?: emptyList()
+
           Skills.update({ Skills.id eq skillId }) {
             it[Skills.status] = "published"
             it[Skills.verified] = true
@@ -305,6 +311,8 @@ object AdminQueueQueries {
               ?.let(::sanitizeTags)
               ?.takeIf { it.isNotEmpty() }
               ?.let { clean -> it[Skills.tags] = appJson.encodeToString(clean) }
+            it[Skills.security] =
+              advisoryNotes.takeIf { it.isNotEmpty() }?.let(appJson::encodeToString)
             it[Skills.updatedAt] = now
           }
           Submissions.update({ Submissions.id eq submissionId }) {

--- a/api/src/main/kotlin/dev/androidskills/api/Models.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/Models.kt
@@ -77,6 +77,8 @@ data class SkillDetail(
   val readmeMd: String? = null,
   val fileCount: Int,
   val totalSize: Long,
+  /** Advisory review notes (risks inherent to the skill's purpose), shown to users. */
+  val securityNotes: List<String> = emptyList(),
   val createdAt: String,
   val updatedAt: String,
 )

--- a/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
+++ b/api/src/main/kotlin/dev/androidskills/api/PublicQueries.kt
@@ -170,6 +170,10 @@ object PublicQueries {
       readmeMd = row[Skills.readmeMd],
       fileCount = count,
       totalSize = totalSize,
+      securityNotes =
+        row[Skills.security]?.let {
+          runCatching { appJson.decodeFromString<List<String>>(it) }.getOrDefault(emptyList())
+        } ?: emptyList(),
       createdAt = card.createdAt,
       updatedAt = card.updatedAt,
     )

--- a/api/src/main/kotlin/dev/androidskills/db/Migrations.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/Migrations.kt
@@ -40,6 +40,10 @@ object Migrations {
         migrateV4()
         writeVersion(4)
       }
+      if (version < 5) {
+        migrateV5()
+        writeVersion(5)
+      }
     }
 
   /** v1: the full initial schema (spec §4) + default category taxonomy. */
@@ -112,6 +116,11 @@ object Migrations {
     exec(
       "CREATE UNIQUE INDEX IF NOT EXISTS uq_skills_bundle_sourcedir ON skills(bundle_id, source_dir)"
     )
+  }
+
+  /** v5: `skills.security` — advisory (fyi) review notes surfaced on the public skill page. */
+  private fun Transaction.migrateV5() {
+    addColumnIfNotExists("skills", "security", "TEXT")
   }
 
   private fun Transaction.addColumnIfNotExists(table: String, column: String, type: String) {

--- a/api/src/main/kotlin/dev/androidskills/db/Tables.kt
+++ b/api/src/main/kotlin/dev/androidskills/db/Tables.kt
@@ -99,6 +99,7 @@ object Skills : Table("skills") {
   val featured = bool("featured").default(false)
   val installs = integer("installs").default(0)
   val readmeMd = text("readme_md").nullable()
+  val security = text("security").nullable() // JSON array of advisory (fyi) review notes
   val createdAt = text("created_at")
   val updatedAt = text("updated_at")
 

--- a/api/src/main/kotlin/dev/androidskills/ingest/SubmissionPayload.kt
+++ b/api/src/main/kotlin/dev/androidskills/ingest/SubmissionPayload.kt
@@ -45,6 +45,8 @@ data class StagedPayload(
 data class ReviewOutputPayload(
   val category: String,
   val tagsProposed: List<String> = emptyList(),
+  // Moderator-only tag-change annotations — shown in the admin queue, never published.
+  val tagNotes: List<String> = emptyList(),
   val securityPassed: Boolean,
   @Serializable(with = SecurityFindingsSerializer::class)
   val securityFindings: List<SecurityFinding> = emptyList(),
@@ -55,6 +57,7 @@ data class ReviewOutputPayload(
       ReviewOutputPayload(
         category = result.category,
         tagsProposed = result.tagsProposed,
+        tagNotes = result.tagNotes,
         // Authoritative pass/fail, fail-closed: a review passes only when every finding is
         // explicitly advisory ("fyi", inherent to the skill's declared purpose). Anything else —
         // "flag", or an unrecognised severity — fails it.

--- a/api/src/main/kotlin/dev/androidskills/llm/LlmClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/llm/LlmClient.kt
@@ -24,8 +24,12 @@ data class SkillManifest(
  *   submitter per §3.3).
  * @param tagsProposed The tags the LLM proposes for discovery — proposing good tags is the
  *   reviewer's job, so this is populated even when the submitter gave none.
+ * @param tagNotes Moderator-only notes about tag changes vs. an existing published skill's tags
+ *   (add/drop rationale). Kept separate from [security] so they are never shown publicly — they are
+ *   review annotations, not security observations.
  * @param security Automated security findings, each with a [SecurityFinding.severity]. Only
- *   `"flag"` findings fail a review; `"fyi"` findings are advisory context for the admin queue.
+ *   `"flag"` findings fail a review; `"fyi"` findings are advisory context (and the only ones
+ *   surfaced to users on the public skill page).
  * @param lintScore 0..100; recorded on the submission for the admin queue.
  */
 @Serializable
@@ -34,6 +38,7 @@ data class ReviewResult(
   val tagsProposed: List<String> = emptyList(),
   val security: SecurityResult,
   val lintScore: Int,
+  val tagNotes: List<String> = emptyList(),
 )
 
 /**

--- a/api/src/main/kotlin/dev/androidskills/llm/OpenAiLlmClient.kt
+++ b/api/src/main/kotlin/dev/androidskills/llm/OpenAiLlmClient.kt
@@ -131,7 +131,7 @@ class OpenAiLlmClient(
         ChatMessage(
           "system",
           "Respond with ONLY a JSON object matching this schema, no markdown: " +
-            "{\"category\":\"string\",\"tagsProposed\":[\"string\"]," +
+            "{\"category\":\"string\",\"tagsProposed\":[\"string\"],\"tagNotes\":[\"string\"]," +
             "\"security\":{\"passed\":bool,\"findings\":[{\"severity\":\"flag|fyi\"," +
             "\"message\":\"string\"}]},\"lintScore\":int}",
         )
@@ -209,19 +209,20 @@ class OpenAiLlmClient(
         "2. tagsProposed: propose 3–6 short, lowercase, topical tags that aid discovery. Proposing " +
         "good tags is your job — do this even when the submitter provided none, and never treat " +
         "absent or empty tags as a problem. If the input includes existingTags, this skill is " +
-        "already published: keep those tags unless a change is clearly warranted, and for every tag " +
-        "you add or drop, add an fyi security finding describing the change so the moderator can " +
-        "confirm it.\n" +
-        "3. security.findings: identify genuine risks (prompt injection, data exfiltration, unsafe " +
-        "code execution, cross-skill modification, over-broad scope). Judge each risk RELATIVE TO " +
-        "THE SKILL'S STATED PURPOSE. If a behavior is inherent to and openly part of what the skill " +
-        "sets out to do, mark it severity \"fyi\" (advisory only), NOT \"flag\". Reserve severity " +
-        "\"flag\" for risks that are unexpected, avoidable, hidden, or exceed the stated purpose " +
-        "(e.g. covert exfiltration unrelated to the skill's function, obfuscation, silent privilege " +
-        "escalation). Absent tags are never a security finding.\n" +
-        "4. security.passed: true when there are no \"flag\" findings — fyi findings never fail a " +
+        "already published: keep those tags unless a change is clearly warranted.\n" +
+        "3. tagNotes: when existingTags is present, add one short moderator note for every tag you " +
+        "add or drop (e.g. \"added 'compose'\", \"dropped 'ui'\"), so the moderator can confirm the " +
+        "change. These are review annotations for the moderator only — never security findings.\n" +
+        "4. security.findings: identify genuine risks (prompt injection, data exfiltration, unsafe " +
+        "code execution, cross-skill modification, over-broad scope) — nothing about tags belongs " +
+        "here. Judge each risk RELATIVE TO THE SKILL'S STATED PURPOSE. If a behavior is inherent to " +
+        "and openly part of what the skill sets out to do, mark it severity \"fyi\" (advisory, shown " +
+        "to users), NOT \"flag\". Reserve severity \"flag\" for risks that are unexpected, avoidable, " +
+        "hidden, or exceed the stated purpose (e.g. covert exfiltration unrelated to the skill's " +
+        "function, obfuscation, silent privilege escalation). Absent tags are never a finding.\n" +
+        "5. security.passed: true when there are no \"flag\" findings — fyi findings never fail a " +
         "review.\n" +
-        "5. lintScore: 0–100 quality score for the metadata."
+        "6. lintScore: 0–100 quality score for the metadata."
 
     private val reviewSchema = buildJsonObject {
       put("type", "object")
@@ -232,6 +233,13 @@ class OpenAiLlmClient(
           put("category", buildJsonObject { put("type", "string") })
           put(
             "tagsProposed",
+            buildJsonObject {
+              put("type", "array")
+              put("items", buildJsonObject { put("type", "string") })
+            },
+          )
+          put(
+            "tagNotes",
             buildJsonObject {
               put("type", "array")
               put("items", buildJsonObject { put("type", "string") })
@@ -304,6 +312,7 @@ class OpenAiLlmClient(
         buildJsonArray {
           add(JsonPrimitive("category"))
           add(JsonPrimitive("tagsProposed"))
+          add(JsonPrimitive("tagNotes"))
           add(JsonPrimitive("security"))
           add(JsonPrimitive("lintScore"))
         },

--- a/api/src/main/resources/openapi.yaml
+++ b/api/src/main/resources/openapi.yaml
@@ -846,6 +846,7 @@ components:
         - readmeMd
         - fileCount
         - totalSize
+        - securityNotes
         properties:
           readmeMd:
             type: string
@@ -855,6 +856,11 @@ components:
           totalSize:
             type: integer
             format: int64
+          securityNotes:
+            type: array
+            description: Advisory review notes (risks inherent to the skill's purpose).
+            items:
+              type: string
     FacetCount:
       type: object
       required:

--- a/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
@@ -57,7 +57,7 @@ class MigrationTest {
   }
 
   @Test
-  fun `schema_meta version is 4 after migration`() {
+  fun `schema_meta version is 5 after migration`() {
     Database.init(TestSupport.newConfig(dir))
     transaction {
       val v =
@@ -65,7 +65,21 @@ class MigrationTest {
           rs.next()
           rs.getString(1).toInt()
         }
-      assertEquals(4, v)
+      assertEquals(5, v)
+    }
+  }
+
+  @Test
+  fun `v5 adds the skills security column`() {
+    Database.init(TestSupport.newConfig(dir))
+    transaction {
+      val cols =
+        exec("PRAGMA table_info(skills)") { rs ->
+          val out = mutableListOf<String>()
+          while (rs.next()) out += rs.getString(2)
+          out
+        } ?: emptyList()
+      assertTrue("security column missing") { "security" in cols }
     }
   }
 
@@ -175,7 +189,7 @@ class MigrationTest {
           rs.next()
           rs.getString(1).toInt()
         }
-      assertEquals(4, v)
+      assertEquals(5, v)
     }
   }
 

--- a/api/src/test/kotlin/dev/androidskills/api/AdminQueueDecisionTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminQueueDecisionTest.kt
@@ -299,6 +299,7 @@ class AdminQueueDecisionTest {
           ReviewOutputPayload(
             category = "kotlin-language",
             tagsProposed = listOf("android"),
+            tagNotes = listOf("dropped 'ui' — moderator-only, must not be published"),
             securityPassed = true,
             securityFindings =
               listOf(

--- a/api/src/test/kotlin/dev/androidskills/api/AdminQueueDecisionTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/AdminQueueDecisionTest.kt
@@ -17,6 +17,7 @@ import dev.androidskills.github.RepoRef
 import dev.androidskills.ingest.ReviewOutputPayload
 import dev.androidskills.ingest.StagedPayload
 import dev.androidskills.ingest.SubmissionPayload
+import dev.androidskills.llm.SecurityFinding
 import dev.androidskills.storage.LocalFsStore
 import dev.androidskills.util.appJson
 import dev.androidskills.util.newId
@@ -274,6 +275,57 @@ class AdminQueueDecisionTest {
       assertEquals(
         listOf("android", "kotlin"),
         appJson.decodeFromString<List<String>>(skill[Skills.tags]),
+      )
+    }
+  }
+
+  @Test
+  fun `approve stores only fyi notes as the skill's public security notes`() {
+    val slug = "test-skill"
+    val ref = "abc123"
+    val custom =
+      SubmissionPayload(
+        staged =
+          StagedPayload(
+            version = "1.0.0",
+            versionSource = "manifest",
+            name = "Old name",
+            description = "Old description",
+            license = "Apache-2.0",
+            tags = listOf("android", "kotlin"),
+            sourceRef = StagedPayload.SourceRef("owner", "repo", ref),
+          ),
+        review =
+          ReviewOutputPayload(
+            category = "kotlin-language",
+            tagsProposed = listOf("android"),
+            securityPassed = true,
+            securityFindings =
+              listOf(
+                SecurityFinding("fyi", "Reads files in your project."),
+                SecurityFinding("flag", "excluded — flags never reach a published skill"),
+              ),
+            lintScore = 80,
+          ),
+      )
+    val s = seed(slug, ref, custom)
+
+    runBlocking {
+      AdminQueueQueries.decision(
+        principal(s.adminId, s.adminHandle),
+        s.submissionId,
+        AdminQueueQueries.DecisionRequest("approve"),
+        store,
+        FakeApp(makeZipball(slug)),
+      )
+    }
+
+    transaction {
+      val security = Skills.selectAll().where { Skills.id eq s.skillId }.single()[Skills.security]
+      // Only the fyi note is carried to the public skill; the flag is dropped.
+      assertEquals(
+        listOf("Reads files in your project."),
+        appJson.decodeFromString<List<String>>(assertNotNull(security)),
       )
     }
   }

--- a/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/api/PublicReadTest.kt
@@ -143,7 +143,19 @@ class PublicReadTest {
     assertEquals("manifest", d.versionSource)
     assertTrue(d.tags.contains("compose"))
     assertTrue(d.fileCount > 0)
+    assertTrue(d.securityNotes.isEmpty(), "no notes by default")
     assertFailsWith<ApiNotFoundException> { PublicQueries.skillDetail("does-not-exist") }
+  }
+
+  @Test
+  fun `detail exposes stored security notes`() {
+    transaction {
+      Skills.update({ Skills.slug eq "jetpack-compose-mvi" }) {
+        it[Skills.security] = """["Runs Gradle tasks in your project."]"""
+      }
+    }
+    val d = PublicQueries.skillDetail("jetpack-compose-mvi")
+    assertEquals(listOf("Runs Gradle tasks in your project."), d.securityNotes)
   }
 
   @Test

--- a/web/src/lib/api-types.ts
+++ b/web/src/lib/api-types.ts
@@ -1401,6 +1401,8 @@ export interface components {
       fileCount: number;
       /** Format: int64 */
       totalSize: number;
+      /** @description Advisory review notes (risks inherent to the skill's purpose). */
+      securityNotes: string[];
     };
     FacetCount: {
       key: string;

--- a/web/src/pages/admin/queue.astro
+++ b/web/src/pages/admin/queue.astro
@@ -27,11 +27,13 @@ type SecurityFinding = { severity?: string; message?: string };
 type ReviewOut = {
   category?: string;
   tagsProposed?: string[];
+  tagNotes?: string[];
   securityPassed?: boolean;
   securityFindings?: SecurityFinding[];
 };
 const review =
   (detail?.payload as unknown as { review?: ReviewOut } | null | undefined)?.review ?? null;
+const tagNotes = review?.tagNotes ?? [];
 // Fail-closed: only an explicit "fyi" is advisory; "flag" or any unrecognised severity is a flag.
 const flags = (review?.securityFindings ?? []).filter((f) => f.severity !== 'fyi');
 const fyis = (review?.securityFindings ?? []).filter((f) => f.severity === 'fyi');
@@ -96,6 +98,14 @@ const proposedTags = (review?.tagsProposed ?? []).join(', ');
                 <span>{review.category ?? '—'}</span>
                 <span class="faint">Tags</span>
                 <input class="input" data-tags-input type="text" value={proposedTags} placeholder="comma-separated tags" aria-label="Tags applied on approve" style="background: var(--surface);" />
+                {tagNotes.length > 0 && (
+                  <>
+                    <span class="faint">Tag notes</span>
+                    <ul class="muted" style="margin: 0; padding-left: 16px; font-size: 12.5px; display: flex; flex-direction: column; gap: 3px;">
+                      {tagNotes.map((n) => <li>{n}</li>)}
+                    </ul>
+                  </>
+                )}
                 <span class="faint">Security</span>
                 <span style={`color: ${review.securityPassed ? 'var(--accent-text)' : 'var(--danger)'}; font-weight: 600;`}>{review.securityPassed ? '✓ Passed' : '✕ Flagged'}</span>
               </div>
@@ -176,6 +186,7 @@ const proposedTags = (review?.tagsProposed ?? []).join(', ');
   type ReviewOut = {
     category?: string;
     tagsProposed?: string[];
+    tagNotes?: string[];
     securityPassed?: boolean;
     securityFindings?: SecurityFinding[];
   };
@@ -258,6 +269,10 @@ const proposedTags = (review?.tagsProposed ?? []).join(', ');
         const flags = findings.filter((f) => f.severity !== 'fyi');
         const fyis = findings.filter((f) => f.severity === 'fyi');
         const proposedTags = (review?.tagsProposed ?? []).join(', ');
+        const tagNotes = review?.tagNotes ?? [];
+        const tagNotesRow = tagNotes.length
+          ? `<span class="faint">Tag notes</span><ul class="muted" style="margin: 0; padding-left: 16px; font-size: 12.5px; display: flex; flex-direction: column; gap: 3px;">${tagNotes.map((n) => `<li>${esc(n)}</li>`).join('')}</ul>`
+          : '';
         const findingList = (items: SecurityFinding[], label: string, danger: boolean) =>
           items.length
             ? `<div style="margin-top: 14px;">
@@ -270,6 +285,7 @@ const proposedTags = (review?.tagsProposed ?? []).join(', ');
               <div class="grid" style="grid-template-columns: 120px 1fr; gap: 10px 14px; font-size: 14px; align-items: center;">
                 <span class="faint">Category</span><span>${esc(review.category ?? '—')}</span>
                 <span class="faint">Tags</span><input class="input" data-tags-input type="text" value="${esc(proposedTags)}" placeholder="comma-separated tags" aria-label="Tags applied on approve" style="background: var(--surface);" />
+                ${tagNotesRow}
                 <span class="faint">Security</span><span style="color: ${review.securityPassed ? 'var(--accent-text)' : 'var(--danger)'}; font-weight: 600;">${review.securityPassed ? '✓ Passed' : '✕ Flagged'}</span>
               </div>
               ${findingList(flags, 'Flagged', true)}

--- a/web/src/pages/skill/[slug].astro
+++ b/web/src/pages/skill/[slug].astro
@@ -148,6 +148,16 @@ const fileTree = files?.tree ?? [];
               ))}
             </div>
           )}
+
+          {skill.securityNotes.length > 0 && (
+            <div class="card" role="region" aria-label="Security review notes">
+              <span class="section-label" style="margin-bottom:6px;">Security review</span>
+              <p class="faint" style="font-size:12px;margin-bottom:10px;">Things to be aware of, inherent to what this skill does.</p>
+              <ul style="margin:0;padding-left:18px;font-size:13px;color:var(--text-dim);display:flex;flex-direction:column;gap:6px;">
+                {skill.securityNotes.map((note) => <li>{note}</li>)}
+              </ul>
+            </div>
+          )}
         </aside>
       </div>
     </div>


### PR DESCRIPTION
PR 2 of 2 on the review pipeline (follows #50).

Surfaces the reviewer's **fyi (advisory)** findings — risks inherent to what a skill openly does — to users, per the 'advisory notes only' choice. Hard `flag` findings never reach a published skill, so only the advisory notes are carried over.

- **Migration v5**: new nullable `skills.security` column (JSON array of advisory notes).
- **On approve**, the review's `fyi` findings are written there (flags excluded).
- `SkillDetail.securityNotes` exposes them; the public skill page renders a **'Security review'** sidebar card when notes exist.

Tests: migration v5 + column present, approve stores only fyi notes, `skillDetail` exposes them. api `build`+`detekt` and web `check`+`build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)