### PR TITLE
feat: add D1 baseline schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - uses: dtolnay/rust-toolchain@1.88.0
         with:
           targets: wasm32-unknown-unknown
@@ -86,6 +89,7 @@ jobs:
           cargo check --locked --target wasm32-unknown-unknown
           cargo clippy --locked --target wasm32-unknown-unknown -- -D warnings
           cargo test --locked --lib
+          python3 tests/schema_test.py
       - name: Build the Wasm Worker
         run: npx wrangler deploy --dry-run
       - name: Start the local Workers runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,10 @@ jobs:
           cargo clippy --locked --target wasm32-unknown-unknown -- -D warnings
           cargo test --locked --lib
           python3 tests/schema_test.py
+      - name: Apply and inspect migrations in the local D1 emulator
+        run: |
+          npx wrangler d1 migrations apply androidskills --local --config wrangler.d1.local.toml
+          node tests/d1_catalogue_test.mjs
       - name: Build the Wasm Worker
         run: npx wrangler deploy --dry-run
       - name: Start the local Workers runtime

--- a/api-rs/migrations/0001_baseline.sql
+++ b/api-rs/migrations/0001_baseline.sql
@@ -1,0 +1,171 @@
+-- Fresh Cloudflare D1 baseline. This deliberately does not import the disposable Ktor SQLite DB.
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  github_id INTEGER NOT NULL UNIQUE,
+  handle TEXT NOT NULL UNIQUE,
+  name TEXT,
+  avatar_url TEXT,
+  role TEXT NOT NULL DEFAULT 'member',
+  status TEXT NOT NULL DEFAULT 'active',
+  settings_json TEXT,
+  deleted_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE categories (
+  id TEXT PRIMARY KEY,
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE bundles (
+  id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  provenance TEXT NOT NULL,
+  owner_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  source_ref TEXT,
+  installation_id INTEGER,
+  synced_at TEXT,
+  created_at TEXT NOT NULL,
+  UNIQUE(kind, provenance)
+);
+
+CREATE TABLE skills (
+  id TEXT PRIMARY KEY,
+  bundle_id TEXT NOT NULL REFERENCES bundles(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL UNIQUE,
+  source_dir TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  license TEXT,
+  tags TEXT NOT NULL DEFAULT '[]',
+  category_id TEXT REFERENCES categories(id) ON DELETE SET NULL,
+  version TEXT NOT NULL,
+  version_source TEXT NOT NULL,
+  token_upfront INTEGER NOT NULL DEFAULT 0,
+  token_ondemand INTEGER NOT NULL DEFAULT 0,
+  token_band TEXT NOT NULL DEFAULT '100s',
+  verified INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'published',
+  featured INTEGER NOT NULL DEFAULT 0,
+  installs INTEGER NOT NULL DEFAULT 0,
+  readme_md TEXT,
+  security TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(bundle_id, source_dir)
+);
+
+CREATE TABLE skill_files (
+  id TEXT PRIMARY KEY,
+  skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+  path TEXT NOT NULL,
+  size INTEGER NOT NULL,
+  is_binary INTEGER NOT NULL DEFAULT 0,
+  r2_key TEXT NOT NULL,
+  UNIQUE(skill_id, path)
+);
+
+CREATE TABLE versions (
+  id TEXT PRIMARY KEY,
+  skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+  version TEXT NOT NULL,
+  source_ref TEXT NOT NULL,
+  r2_zip_key TEXT,
+  created_at TEXT NOT NULL,
+  UNIQUE(skill_id, version)
+);
+
+CREATE TABLE submissions (
+  id TEXT PRIMARY KEY,
+  bundle_id TEXT REFERENCES bundles(id) ON DELETE SET NULL,
+  skill_id TEXT REFERENCES skills(id) ON DELETE SET NULL,
+  submitter_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  state TEXT NOT NULL,
+  lint_score INTEGER,
+  note TEXT,
+  payload TEXT,
+  revision INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE stars (
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY(user_id, skill_id)
+);
+
+CREATE TABLE sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL
+);
+
+CREATE TABLE jobs (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'queued',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  run_after TEXT NOT NULL,
+  last_error TEXT,
+  dedup_key TEXT NOT NULL,
+  dispatched_at TEXT,
+  lease_until TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(type, dedup_key)
+);
+
+CREATE TABLE audit_log (
+  id TEXT PRIMARY KEY,
+  actor_id TEXT NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  action TEXT NOT NULL,
+  target TEXT NOT NULL,
+  meta TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE platform_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE reports (
+  id TEXT PRIMARY KEY,
+  skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+  reporter_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+  reason TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX ix_users_role_status ON users(role, status);
+CREATE INDEX ix_bundles_owner ON bundles(owner_user_id);
+CREATE INDEX ix_skills_bundle ON skills(bundle_id);
+CREATE INDEX ix_skills_category ON skills(category_id);
+CREATE INDEX ix_skills_status_verified ON skills(status, verified);
+CREATE INDEX ix_skills_featured ON skills(featured);
+CREATE INDEX ix_skills_installs ON skills(installs);
+CREATE INDEX ix_skills_updated ON skills(updated_at);
+CREATE INDEX ix_skills_created ON skills(created_at);
+CREATE INDEX ix_skills_name ON skills(name);
+CREATE INDEX ix_skill_files_skill ON skill_files(skill_id);
+CREATE INDEX ix_versions_skill ON versions(skill_id);
+CREATE INDEX ix_versions_created ON versions(created_at);
+CREATE INDEX ix_submissions_submitter ON submissions(submitter_id);
+CREATE INDEX ix_submissions_state ON submissions(state);
+CREATE INDEX ix_submissions_bundle ON submissions(bundle_id);
+CREATE INDEX ix_submissions_skill ON submissions(skill_id);
+CREATE INDEX ix_sessions_user ON sessions(user_id);
+CREATE INDEX ix_sessions_expires ON sessions(expires_at);
+CREATE INDEX ix_jobs_state_runafter ON jobs(state, run_after);
+CREATE INDEX ix_audit_created ON audit_log(created_at);
+CREATE INDEX ix_audit_action ON audit_log(action);
+CREATE INDEX ix_reports_skill ON reports(skill_id);
+CREATE INDEX ix_reports_created ON reports(created_at);

--- a/api-rs/migrations/0002_seed_categories.sql
+++ b/api-rs/migrations/0002_seed_categories.sql
@@ -1,0 +1,15 @@
+INSERT INTO categories(id, slug, name) VALUES
+  ('3c9572b4-3e39-4e0a-a0cb-0a7078522e00', 'jetpack-compose', 'Jetpack Compose'),
+  ('4b9e4761-94e8-48db-9a6b-2f3555f9bcd8', 'kotlin-language', 'Kotlin Language'),
+  ('421ed6d4-ff58-48af-9315-051db7ba3b31', 'architecture', 'Architecture'),
+  ('6028413c-4582-449c-9efb-d876a4fc6a4f', 'testing-qa', 'Testing & QA'),
+  ('5bd6da47-3748-4200-b224-1b4b0924ec80', 'material-design', 'Material Design'),
+  ('1fddf36b-f9c0-4c2c-aa6b-ea02a4b43c01', 'data-persistence', 'Data & Persistence'),
+  ('be867da8-5c59-49b4-9c0b-8b1e2214e326', 'networking', 'Networking'),
+  ('0e303da2-b47f-4a84-9e02-2266633c9441', 'performance', 'Performance'),
+  ('1e7a245d-1e99-4760-9ca8-92cefb3a0e1a', 'accessibility', 'Accessibility'),
+  ('6a36388d-3c1a-44b1-91e4-0c5b5171ff6b', 'build-ci', 'Build & CI'),
+  ('c1f8196c-0e43-4ab3-82b6-d12ca4625d07', 'uncategorized', 'Uncategorized');
+
+INSERT INTO platform_settings(key, value) VALUES
+  ('settings', '{"reviewPolicy":"manual","tokenSoftCap":1000,"llmEnabled":false}');

--- a/api-rs/migrations/0003_add_job_dispatch_indexes.sql
+++ b/api-rs/migrations/0003_add_job_dispatch_indexes.sql
@@ -1,0 +1,3 @@
+-- Forward-only operational indexes. Kept separate because 0001 may already be applied.
+CREATE INDEX IF NOT EXISTS ix_jobs_dispatch_pending ON jobs(run_after) WHERE state = 'queued' AND dispatched_at IS NULL;
+CREATE INDEX IF NOT EXISTS ix_jobs_lease_expired ON jobs(lease_until) WHERE state = 'running' AND lease_until IS NOT NULL;

--- a/api-rs/migrations/README.md
+++ b/api-rs/migrations/README.md
@@ -8,4 +8,10 @@ The approved fresh-database deltas are:
 - `submissions.revision` supports optimistic JSON-payload updates.
 - `jobs.dedup_key`, `dispatched_at`, and `lease_until` support Queue outbox, idempotency, and leases.
 
-`0002_seed_categories.sql` contains deterministic category IDs and the default platform settings. The SQL is checked against SQLite with foreign keys enabled by `tests/schema_test.py`; applying it to a Cloudflare D1 binding remains a provisioning-gated integration check.
+`0002_seed_categories.sql` contains deterministic category IDs and the default platform settings.
+`tests/d1_catalogue_test.mjs` imports the checked-in real catalogue JSON into the local D1 emulator
+with the same persisted values and token heuristic as Kotlin's `RealSeed`; this intentionally stays
+out of the baseline migration so production catalogue population remains an explicit operation.
+CI checks migrations against SQLite with foreign keys enabled and applies them to Wrangler's local
+D1 emulator. The all-zero database ID in `wrangler.d1.local.toml` is local-emulator-only; applying
+to a provisioned Cloudflare D1 binding remains a permissions-gated integration check.

--- a/api-rs/migrations/README.md
+++ b/api-rs/migrations/README.md
@@ -1,0 +1,11 @@
+# D1 migrations
+
+`0001_baseline.sql` defines the fresh D1 schema equivalent to Kotlin schema v5. It intentionally does not contain `schema_meta`: Wrangler owns D1 migration history.
+
+The approved fresh-database deltas are:
+
+- `skills.source_dir` is required, because no legacy SQLite rows are imported.
+- `submissions.revision` supports optimistic JSON-payload updates.
+- `jobs.dedup_key`, `dispatched_at`, and `lease_until` support Queue outbox, idempotency, and leases.
+
+`0002_seed_categories.sql` contains deterministic category IDs and the default platform settings. The SQL is checked against SQLite with foreign keys enabled by `tests/schema_test.py`; applying it to a Cloudflare D1 binding remains a provisioning-gated integration check.

--- a/api-rs/tests/d1_catalogue_test.mjs
+++ b/api-rs/tests/d1_catalogue_test.mjs
@@ -1,0 +1,88 @@
+/** Account-free D1 seed parity check for the checked-in real catalogue fixture. */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "../..");
+const source = readFileSync(join(root, "api/src/main/resources/seed/real-skills.json"), "utf8");
+const data = JSON.parse(source);
+const snapshot = JSON.parse(readFileSync(join(root, "api/src/test/resources/schema-v5-compatibility.json"), "utf8"));
+const categories = new Map(Object.entries(snapshot.categories));
+if (createHash("sha256").update(source).digest("hex") !== snapshot.catalogue.sha256) {
+  throw new Error("Real catalogue fixture changed; refresh the Kotlin-validated compatibility snapshot.");
+}
+const now = "2026-01-01T00:00:00Z";
+const quote = (value) => `'${String(value).replaceAll("'", "''")}'`;
+const inserts = (table, columns, rows) => rows.map((row) =>
+  `INSERT INTO ${table}(${columns}) VALUES (${row.map(quote).join(",")});`
+).join("\n");
+const bytes = (text) => Buffer.byteLength(text, "utf8");
+const tokens = (text) => Math.ceil(bytes(text) / 4);
+const band = (total) => total < 1_000 ? "100s" : total < 10_000 ? "1k" : total < 100_000 ? "10k" : "100k";
+const userId = new Map(data.authors.map((author, index) => [author.handle, `fixture-user-${index}`]));
+const bundleId = new Map(data.bundles.map((bundle, index) => [bundle.provenance, `fixture-bundle-${index}`]));
+
+const sql = [
+  // Re-running the harness against a retained local emulator must produce the same fixture.
+  "DELETE FROM versions WHERE id LIKE 'fixture-%';",
+  "DELETE FROM skill_files WHERE id LIKE 'fixture-%';",
+  "DELETE FROM skills WHERE id LIKE 'fixture-%';",
+  "DELETE FROM bundles WHERE id LIKE 'fixture-%';",
+  "DELETE FROM users WHERE id LIKE 'fixture-%';",
+  inserts("users", "id,github_id,handle,name,avatar_url,role,status,created_at,updated_at", data.authors.map((author, index) => [
+    `fixture-user-${index}`, author.githubId, author.handle, author.name, `https://github.com/${author.handle}.png`, "contributor", "active", now, now,
+  ])),
+  inserts("bundles", "id,kind,provenance,owner_user_id,source_ref,synced_at,created_at", data.bundles.map((bundle, index) => [
+    `fixture-bundle-${index}`, "repo", bundle.provenance, userId.get(bundle.author), bundle.sourceRef, now, now,
+  ])),
+  inserts("skills", "id,bundle_id,slug,source_dir,name,description,license,tags,category_id,version,version_source,token_upfront,token_ondemand,token_band,verified,status,featured,installs,readme_md,created_at,updated_at", data.skills.map((skill, index) => {
+    const upfront = tokens(`${skill.name} ${skill.description}`);
+    const ondemand = tokens(skill.body);
+    return [`fixture-skill-${index}`, bundleId.get(skill.bundle), skill.slug, `skills/${skill.slug}`, skill.name, skill.description, skill.license, JSON.stringify(skill.tags), categories.get(skill.category), skill.version, "git_head", upfront, ondemand, band(upfront + ondemand), 1, "published", skill.featured ? 1 : 0, 0, skill.body, now, now];
+  })),
+  inserts("skill_files", "id,skill_id,path,size,is_binary,r2_key", data.skills.map((skill, index) => [
+    `fixture-file-${index}`, `fixture-skill-${index}`, "SKILL.md", bytes(skill.body), 0, `skills/fixture-skill-${index}/files/SKILL.md`,
+  ])),
+  inserts("versions", "id,skill_id,version,source_ref,r2_zip_key,created_at", data.skills.map((skill, index) => [
+    `fixture-version-${index}`, `fixture-skill-${index}`, skill.version, `git_head:${skill.version}`, `skills/fixture-skill-${index}/versions/${skill.version}.zip`, now,
+  ])),
+].join("\n");
+
+const directory = mkdtempSync(join(tmpdir(), "androidskills-d1-fixture-"));
+const fixture = join(directory, "catalogue.sql");
+const wrangler = join(resolve(import.meta.dirname, ".."), "node_modules/wrangler/bin/wrangler.js");
+const runWrangler = (args, options = {}) => execFileSync(process.execPath, [wrangler, ...args], {
+  cwd: resolve(import.meta.dirname, ".."),
+  ...options,
+});
+const query = (command) => {
+  const output = runWrangler(["d1", "execute", "androidskills", "--local", "--config", "wrangler.d1.local.toml", "--command", command], { encoding: "utf8" });
+  const start = output.indexOf("[\n  {");
+  const end = output.lastIndexOf("\n]") + 2;
+  return JSON.parse(output.slice(start, end))[0].results;
+};
+try {
+  writeFileSync(fixture, sql, "utf8");
+  runWrangler(["d1", "execute", "androidskills", "--local", "--config", "wrangler.d1.local.toml", "--file", fixture], { stdio: "inherit" });
+  const result = query("SELECT (SELECT COUNT(*) FROM users) AS users, (SELECT COUNT(*) FROM bundles) AS bundles, (SELECT COUNT(*) FROM skills) AS skills, (SELECT COUNT(*) FROM skill_files) AS files, (SELECT COUNT(*) FROM versions) AS versions;")[0];
+  const expected = { users: data.authors.length, bundles: data.bundles.length, skills: data.skills.length, files: data.skills.length, versions: data.skills.length };
+  if (JSON.stringify(result) !== JSON.stringify(expected)) throw new Error(`Catalogue parity failed: ${JSON.stringify(result)} != ${JSON.stringify(expected)}`);
+  const d1Tables = query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'd1_%' AND name NOT LIKE '_cf_%' AND name != 'sqlite_sequence' ORDER BY name;").map((row) => row.name);
+  const kotlinTables = Object.keys(snapshot.tables).sort();
+  if (JSON.stringify(d1Tables) !== JSON.stringify(kotlinTables)) throw new Error("D1 table snapshot differs from Kotlin compatibility snapshot.");
+  const d1Indexes = query("SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_autoindex%' ORDER BY name;").map((row) => row.name);
+  for (const index of [...snapshot.indexes, "ix_jobs_dispatch_pending", "ix_jobs_lease_expired"]) {
+    if (!d1Indexes.includes(index)) throw new Error(`D1 index missing: ${index}`);
+  }
+  const skillColumns = query("PRAGMA table_info(skills);").map((row) => row.name);
+  if (!skillColumns.includes("source_dir") || !skillColumns.includes("security")) throw new Error("D1 skill column snapshot is incomplete.");
+  const jobColumns = query("PRAGMA table_info(jobs);").map((row) => row.name);
+  if (!["dedup_key", "dispatched_at", "lease_until"].every((column) => jobColumns.includes(column))) throw new Error("D1 job operational columns are missing.");
+  const skillForeignKeys = query("PRAGMA foreign_key_list(skills);");
+  if (skillForeignKeys.length !== 2) throw new Error("D1 skill foreign-key snapshot differs from Kotlin compatibility snapshot.");
+  console.log(`D1 real catalogue fixture verified (${expected.skills} skills).`);
+} finally {
+  rmSync(directory, { recursive: true, force: true });
+}

--- a/api-rs/tests/schema_test.py
+++ b/api-rs/tests/schema_test.py
@@ -1,0 +1,87 @@
+"""Fresh-schema checks runnable locally and in CI without a Cloudflare account."""
+
+import sqlite3
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS = ROOT / "migrations"
+NOW = "2026-07-21T00:00:00Z"
+
+
+class BaselineSchemaTest(unittest.TestCase):
+    def setUp(self):
+        self.db = sqlite3.connect(":memory:")
+        self.db.execute("PRAGMA foreign_keys = ON")
+        for migration in sorted(MIGRATIONS.glob("*.sql")):
+            self.db.executescript(migration.read_text(encoding="utf-8"))
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_expected_tables_and_seed_are_present(self):
+        tables = {
+            row[0]
+            for row in self.db.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+        self.assertEqual(
+            tables,
+            {
+                "users", "categories", "bundles", "skills", "skill_files", "versions",
+                "submissions", "stars", "sessions", "jobs", "audit_log",
+                "platform_settings", "reports",
+            },
+        )
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM categories").fetchone()[0], 11)
+        self.assertEqual(self.db.execute("SELECT value FROM platform_settings").fetchone()[0],
+                         '{"reviewPolicy":"manual","tokenSoftCap":1000,"llmEnabled":false}')
+
+    def test_d1_operational_deltas_are_explicit(self):
+        columns = {
+            row[1]: row for row in self.db.execute("PRAGMA table_info(skills)")
+        }
+        self.assertEqual(columns["source_dir"][3], 1)  # non-null on a fresh D1 database
+        jobs = {row[1] for row in self.db.execute("PRAGMA table_info(jobs)")}
+        self.assertTrue({"dedup_key", "dispatched_at", "lease_until"} <= jobs)
+        submission = {row[1]: row for row in self.db.execute("PRAGMA table_info(submissions)")}
+        self.assertEqual(submission["revision"][3], 1)
+        self.assertEqual(submission["revision"][4], "0")
+
+    def test_constraints_and_foreign_key_actions(self):
+        self.db.execute("INSERT INTO users VALUES (?, 1, 'owner', NULL, NULL, 'member', 'active', NULL, NULL, ?, ?)",
+                        ("owner", NOW, NOW))
+        self.db.execute("INSERT INTO users VALUES (?, 2, 'reporter', NULL, NULL, 'member', 'active', NULL, NULL, ?, ?)",
+                        ("reporter", NOW, NOW))
+        category_id = self.db.execute("SELECT id FROM categories LIMIT 1").fetchone()[0]
+        self.db.execute("INSERT INTO bundles VALUES ('bundle', 'repo', 'o/r', 'owner', NULL, NULL, NULL, ?)", (NOW,))
+        self.db.execute(
+            "INSERT INTO skills(id,bundle_id,slug,source_dir,name,description,category_id,version,version_source,created_at,updated_at) "
+            "VALUES ('skill','bundle','slug','skills/slug','Name','Description',?,'1.0.0','manifest',?,?)",
+            (category_id, NOW, NOW),
+        )
+        self.db.execute("INSERT INTO skill_files VALUES ('file','skill','SKILL.md',1,0,'skills/skill/SKILL.md')")
+        self.db.execute("INSERT INTO versions VALUES ('version','skill','1.0.0','sha',NULL,?)", (NOW,))
+        self.db.execute("INSERT INTO reports VALUES ('report','skill','reporter','reason',?)", (NOW,))
+        self.db.execute("INSERT INTO submissions(id,bundle_id,skill_id,submitter_id,state,created_at,updated_at) VALUES ('submission','bundle','skill','owner','draft',?,?)", (NOW, NOW))
+        self.db.execute("INSERT INTO jobs(id,type,payload,run_after,dedup_key,created_at,updated_at) VALUES ('job','review','{}',?,'skill:sha',?,?)", (NOW, NOW, NOW))
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.db.execute("INSERT INTO jobs(id,type,payload,run_after,dedup_key,created_at,updated_at) VALUES ('job2','review','{}',?,'skill:sha',?,?)", (NOW, NOW, NOW))
+
+        self.db.execute("DELETE FROM categories WHERE id = ?", (category_id,))
+        self.assertIsNone(self.db.execute("SELECT category_id FROM skills").fetchone()[0])
+        self.db.execute("DELETE FROM users WHERE id = 'reporter'")
+        self.assertIsNone(self.db.execute("SELECT reporter_id FROM reports").fetchone()[0])
+        self.db.execute("DELETE FROM bundles WHERE id = 'bundle'")
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM skills").fetchone()[0], 0)
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM skill_files").fetchone()[0], 0)
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM versions").fetchone()[0], 0)
+        self.assertEqual(self.db.execute("SELECT bundle_id,skill_id FROM submissions").fetchone(), (None, None))
+
+        self.db.execute("INSERT INTO audit_log VALUES ('audit','owner','user.update','user:owner',NULL,?)", (NOW,))
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.db.execute("DELETE FROM users WHERE id = 'owner'")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api-rs/tests/schema_test.py
+++ b/api-rs/tests/schema_test.py
@@ -1,5 +1,6 @@
 """Fresh-schema checks runnable locally and in CI without a Cloudflare account."""
 
+import json
 import sqlite3
 from pathlib import Path
 import unittest
@@ -7,6 +8,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 MIGRATIONS = ROOT / "migrations"
+SNAPSHOT = json.loads((ROOT.parent / "api/src/test/resources/schema-v5-compatibility.json").read_text(encoding="utf-8"))
 NOW = "2026-07-21T00:00:00Z"
 
 
@@ -37,6 +39,22 @@ class BaselineSchemaTest(unittest.TestCase):
         self.assertEqual(self.db.execute("SELECT value FROM platform_settings").fetchone()[0],
                          '{"reviewPolicy":"manual","tokenSoftCap":1000,"llmEnabled":false}')
 
+    def test_kotlin_v5_shared_schema_snapshot(self):
+        # This is the fresh-SQLite parity snapshot. D1-only deltas are checked separately below.
+        expected_columns = {table: list(columns) for table, columns in SNAPSHOT["tables"].items()}
+        expected_columns["submissions"].insert(8, "revision")
+        expected_columns["jobs"][7:7] = ["dedup_key", "dispatched_at", "lease_until"]
+        for table, columns in expected_columns.items():
+            actual = " ".join(row[1] for row in self.db.execute(f"PRAGMA table_info({table})"))
+            self.assertEqual(actual, " ".join(columns), table)
+
+        expected_indexes = set(SNAPSHOT["indexes"]) | {"ix_jobs_dispatch_pending", "ix_jobs_lease_expired"}
+        actual_indexes = {
+            row[0] for row in self.db.execute("SELECT name FROM sqlite_master WHERE type = 'index'")
+            if not row[0].startswith("sqlite_autoindex")
+        }
+        self.assertEqual(actual_indexes, expected_indexes)
+
     def test_d1_operational_deltas_are_explicit(self):
         columns = {
             row[1]: row for row in self.db.execute("PRAGMA table_info(skills)")
@@ -47,6 +65,20 @@ class BaselineSchemaTest(unittest.TestCase):
         submission = {row[1]: row for row in self.db.execute("PRAGMA table_info(submissions)")}
         self.assertEqual(submission["revision"][3], 1)
         self.assertEqual(submission["revision"][4], "0")
+
+    def test_job_operational_indexes_upgrade_from_the_original_baseline(self):
+        db = sqlite3.connect(":memory:")
+        try:
+            for name in ("0001_baseline.sql", "0002_seed_categories.sql"):
+                db.executescript((MIGRATIONS / name).read_text(encoding="utf-8"))
+            before = {row[1] for row in db.execute("PRAGMA index_list(jobs)")}
+            self.assertNotIn("ix_jobs_dispatch_pending", before)
+            self.assertNotIn("ix_jobs_lease_expired", before)
+            db.executescript((MIGRATIONS / "0003_add_job_dispatch_indexes.sql").read_text(encoding="utf-8"))
+            after = {row[1] for row in db.execute("PRAGMA index_list(jobs)")}
+            self.assertTrue({"ix_jobs_dispatch_pending", "ix_jobs_lease_expired"} <= after)
+        finally:
+            db.close()
 
     def test_constraints_and_foreign_key_actions(self):
         self.db.execute("INSERT INTO users VALUES (?, 1, 'owner', NULL, NULL, 'member', 'active', NULL, NULL, ?, ?)",
@@ -68,19 +100,57 @@ class BaselineSchemaTest(unittest.TestCase):
         with self.assertRaises(sqlite3.IntegrityError):
             self.db.execute("INSERT INTO jobs(id,type,payload,run_after,dedup_key,created_at,updated_at) VALUES ('job2','review','{}',?,'skill:sha',?,?)", (NOW, NOW, NOW))
 
+        # Every unique constraint must reject a collision on a clean, representative dataset.
+        collisions = (
+            ("INSERT INTO users VALUES ('user-github', 1, 'new-handle', NULL, NULL, 'member', 'active', NULL, NULL, ?, ?)", (NOW, NOW)),
+            ("INSERT INTO users VALUES ('user-handle', 3, 'owner', NULL, NULL, 'member', 'active', NULL, NULL, ?, ?)", (NOW, NOW)),
+            ("INSERT INTO categories VALUES ('category-copy', 'jetpack-compose', 'Copy')", ()),
+            ("INSERT INTO bundles VALUES ('bundle-copy', 'repo', 'o/r', 'owner', NULL, NULL, NULL, ?)", (NOW,)),
+            ("INSERT INTO skills(id,bundle_id,slug,source_dir,name,description,version,version_source,created_at,updated_at) VALUES ('skill-slug','bundle','slug','other/path','Name','Description','1.0.0','manifest',?,?)", (NOW, NOW)),
+            ("INSERT INTO skills(id,bundle_id,slug,source_dir,name,description,version,version_source,created_at,updated_at) VALUES ('skill-dir','bundle','other-slug','skills/slug','Name','Description','1.0.0','manifest',?,?)", (NOW, NOW)),
+            ("INSERT INTO skill_files VALUES ('file-copy','skill','SKILL.md',1,0,'skills/skill/SKILL.md')", ()),
+            ("INSERT INTO versions VALUES ('version-copy','skill','1.0.0','sha',NULL,?)", (NOW,)),
+        )
+        for sql, params in collisions:
+            with self.subTest(sql=sql), self.assertRaises(sqlite3.IntegrityError):
+                self.db.execute(sql, params)
+        self.db.execute("INSERT INTO stars VALUES ('owner','skill',?)", (NOW,))
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.db.execute("INSERT INTO stars VALUES ('owner','skill',?)", (NOW,))
+
         self.db.execute("DELETE FROM categories WHERE id = ?", (category_id,))
         self.assertIsNone(self.db.execute("SELECT category_id FROM skills").fetchone()[0])
+        self.db.execute("INSERT INTO stars VALUES ('reporter','skill',?)", (NOW,))
         self.db.execute("DELETE FROM users WHERE id = 'reporter'")
         self.assertIsNone(self.db.execute("SELECT reporter_id FROM reports").fetchone()[0])
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM stars WHERE user_id = 'reporter'").fetchone()[0], 0)
         self.db.execute("DELETE FROM bundles WHERE id = 'bundle'")
         self.assertEqual(self.db.execute("SELECT COUNT(*) FROM skills").fetchone()[0], 0)
         self.assertEqual(self.db.execute("SELECT COUNT(*) FROM skill_files").fetchone()[0], 0)
         self.assertEqual(self.db.execute("SELECT COUNT(*) FROM versions").fetchone()[0], 0)
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM reports").fetchone()[0], 0)
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM stars").fetchone()[0], 0)
         self.assertEqual(self.db.execute("SELECT bundle_id,skill_id FROM submissions").fetchone(), (None, None))
 
         self.db.execute("INSERT INTO audit_log VALUES ('audit','owner','user.update','user:owner',NULL,?)", (NOW,))
         with self.assertRaises(sqlite3.IntegrityError):
             self.db.execute("DELETE FROM users WHERE id = 'owner'")
+
+        # Cover the remaining user-owned edges in isolated fixtures.
+        self.db.execute("INSERT INTO users VALUES ('cascade-user', 4, 'cascade-user', NULL, NULL, 'member', 'active', NULL, NULL, ?, ?)", (NOW, NOW))
+        self.db.execute("INSERT INTO bundles VALUES ('cascade-bundle', 'zip', 'upload-1', 'cascade-user', NULL, NULL, NULL, ?)", (NOW,))
+        self.db.execute("DELETE FROM users WHERE id = 'cascade-user'")
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM bundles WHERE id = 'cascade-bundle'").fetchone()[0], 0)
+
+        self.db.execute("INSERT INTO users VALUES ('session-user', 5, 'session-user', NULL, NULL, 'member', 'active', NULL, NULL, ?, ?)", (NOW, NOW))
+        self.db.execute("INSERT INTO sessions VALUES ('session','session-user',?,?)", (NOW, NOW))
+        self.db.execute("DELETE FROM users WHERE id = 'session-user'")
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM sessions WHERE id = 'session'").fetchone()[0], 0)
+
+        self.db.execute("INSERT INTO users VALUES ('submitter-user', 6, 'submitter-user', NULL, NULL, 'member', 'active', NULL, NULL, ?, ?)", (NOW, NOW))
+        self.db.execute("INSERT INTO submissions(id,submitter_id,state,created_at,updated_at) VALUES ('submission-cascade','submitter-user','draft',?,?)", (NOW, NOW))
+        self.db.execute("DELETE FROM users WHERE id = 'submitter-user'")
+        self.assertEqual(self.db.execute("SELECT COUNT(*) FROM submissions WHERE id = 'submission-cascade'").fetchone()[0], 0)
 
 
 if __name__ == "__main__":

--- a/api-rs/wrangler.d1.local.toml
+++ b/api-rs/wrangler.d1.local.toml
@@ -1,0 +1,11 @@
+# CI-only Wrangler configuration for the account-free local D1 emulator. This is not
+# the deploy configuration: the all-zero ID must be replaced only in the authorized
+# Cloudflare provisioning change.
+name = "androidskills-api-d1-local"
+compatibility_date = "2026-07-16"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "androidskills"
+database_id = "00000000-0000-0000-0000-000000000003"
+migrations_dir = "migrations"

--- a/api-rs/wrangler.toml
+++ b/api-rs/wrangler.toml
@@ -6,13 +6,8 @@ workers_dev = true
 [build]
 command = "worker-build --release"
 
-# Resource bindings are intentionally added in the provisioning change. Keeping this
-# starter deployable without account-specific IDs lets CI run entirely locally.
-#
-# [[d1_databases]]
-# binding = "DB"
-# database_name = "androidskills"
-# database_id = "<provisioned-d1-id>"
+# D1 is deliberately configured only after account provisioning. The CI-only local
+# emulator configuration lives in wrangler.d1.local.toml and has no deploy role.
 #
 # [[r2_buckets]]
 # binding = "FILES"

--- a/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
@@ -15,6 +15,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -53,6 +57,38 @@ class MigrationTest {
           "schema_meta",
         )
         .forEach { assertTrue("$it table missing: $tables") { tables.contains(it) } }
+    }
+  }
+
+  @Test
+  fun `fresh SQLite migration matches the shared v5 compatibility snapshot`() {
+    val snapshot =
+      Json.parseToJsonElement(
+          requireNotNull(javaClass.getResourceAsStream("/schema-v5-compatibility.json"))
+            .bufferedReader()
+            .readText()
+        )
+        .jsonObject
+    Database.init(TestSupport.newConfig(dir))
+    transaction {
+      snapshot.getValue("tables").jsonObject.forEach { (table, expected) ->
+        val columns =
+          exec("PRAGMA table_info($table)") { rs ->
+            buildList {
+              while (rs.next()) add(rs.getString("name"))
+            }
+          } ?: emptyList()
+        assertEquals(expected.jsonArray.map { it.jsonPrimitive.content }, columns, table)
+      }
+      val indexes =
+        exec("SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_autoindex%' AND name NOT LIKE 'uq_%'") {
+          rs -> buildSet { while (rs.next()) add(rs.getString(1)) }
+        } ?: emptySet()
+      assertEquals(snapshot.getValue("indexes").jsonArray.map { it.jsonPrimitive.content }.toSet(), indexes)
+      assertEquals(
+        snapshot.getValue("categories").jsonObject.keys,
+        Categories.selectAll().map { it[Categories.slug] }.toSet(),
+      )
     }
   }
 

--- a/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
+++ b/api/src/test/kotlin/dev/androidskills/MigrationTest.kt
@@ -74,17 +74,20 @@ class MigrationTest {
       snapshot.getValue("tables").jsonObject.forEach { (table, expected) ->
         val columns =
           exec("PRAGMA table_info($table)") { rs ->
-            buildList {
-              while (rs.next()) add(rs.getString("name"))
-            }
+            buildList { while (rs.next()) add(rs.getString("name")) }
           } ?: emptyList()
         assertEquals(expected.jsonArray.map { it.jsonPrimitive.content }, columns, table)
       }
       val indexes =
-        exec("SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_autoindex%' AND name NOT LIKE 'uq_%'") {
-          rs -> buildSet { while (rs.next()) add(rs.getString(1)) }
+        exec(
+          "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_autoindex%' AND name NOT LIKE 'uq_%'"
+        ) { rs ->
+          buildSet { while (rs.next()) add(rs.getString(1)) }
         } ?: emptySet()
-      assertEquals(snapshot.getValue("indexes").jsonArray.map { it.jsonPrimitive.content }.toSet(), indexes)
+      assertEquals(
+        snapshot.getValue("indexes").jsonArray.map { it.jsonPrimitive.content }.toSet(),
+        indexes,
+      )
       assertEquals(
         snapshot.getValue("categories").jsonObject.keys,
         Categories.selectAll().map { it[Categories.slug] }.toSet(),

--- a/api/src/test/resources/schema-v5-compatibility.json
+++ b/api/src/test/resources/schema-v5-compatibility.json
@@ -1,0 +1,20 @@
+{
+  "tables": {
+    "users": ["id","github_id","handle","name","avatar_url","role","status","settings_json","deleted_at","created_at","updated_at"],
+    "categories": ["id","slug","name"],
+    "bundles": ["id","kind","provenance","owner_user_id","source_ref","installation_id","synced_at","created_at"],
+    "skills": ["id","bundle_id","slug","source_dir","name","description","license","tags","category_id","version","version_source","token_upfront","token_ondemand","token_band","verified","status","featured","installs","readme_md","security","created_at","updated_at"],
+    "skill_files": ["id","skill_id","path","size","is_binary","r2_key"],
+    "versions": ["id","skill_id","version","source_ref","r2_zip_key","created_at"],
+    "submissions": ["id","bundle_id","skill_id","submitter_id","state","lint_score","note","payload","created_at","updated_at"],
+    "stars": ["user_id","skill_id","created_at"],
+    "sessions": ["id","user_id","created_at","expires_at"],
+    "jobs": ["id","type","payload","state","attempts","run_after","last_error","created_at","updated_at"],
+    "audit_log": ["id","actor_id","action","target","meta","created_at"],
+    "platform_settings": ["key","value"],
+    "reports": ["id","skill_id","reporter_id","reason","created_at"]
+  },
+  "indexes": ["ix_users_role_status","ix_bundles_owner","ix_skills_bundle","ix_skills_category","ix_skills_status_verified","ix_skills_featured","ix_skills_installs","ix_skills_updated","ix_skills_created","ix_skills_name","ix_skill_files_skill","ix_versions_skill","ix_versions_created","ix_submissions_submitter","ix_submissions_state","ix_submissions_bundle","ix_submissions_skill","ix_sessions_user","ix_sessions_expires","ix_jobs_state_runafter","ix_audit_created","ix_audit_action","ix_reports_skill","ix_reports_created"],
+  "categories": {"jetpack-compose":"3c9572b4-3e39-4e0a-a0cb-0a7078522e00","kotlin-language":"4b9e4761-94e8-48db-9a6b-2f3555f9bcd8","architecture":"421ed6d4-ff58-48af-9315-051db7ba3b31","testing-qa":"6028413c-4582-449c-9efb-d876a4fc6a4f","material-design":"5bd6da47-3748-4200-b224-1b4b0924ec80","data-persistence":"1fddf36b-f9c0-4c2c-aa6b-ea02a4b43c01","networking":"be867da8-5c59-49b4-9c0b-8b1e2214e326","performance":"0e303da2-b47f-4a84-9e02-2266633c9441","accessibility":"1e7a245d-1e99-4760-9ca8-92cefb3a0e1a","build-ci":"6a36388d-3c1a-44b1-91e4-0c5b5171ff6b","uncategorized":"c1f8196c-0e43-4ab3-82b6-d12ca4625d07"},
+  "catalogue": {"authors":4,"bundles":6,"skills":121,"sha256":"b807022d942c6633b72a09a0588efdadb2a2c3e89963e3e65407687ccb189b27"}
+}


### PR DESCRIPTION
## What changed
- adds fresh D1 baseline and deterministic category/settings migrations
- codifies source-dir, optimistic-revision, and Queue-outbox schema deltas
- adds local SQLite foreign-key and constraint tests to Rust CI

## Why
Builds the reproducible data foundation for the Cloudflare Worker without importing disposable Ktor SQLite data.

## Validation
- Python D1 baseline schema tests
- cargo fmt --check
- cargo check --locked --target wasm32-unknown-unknown
- isolated Sol high-rigor alignment and adversarial reviews