### PR TITLE
feat(worker): add D1 repository substrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,15 @@ jobs:
         run: |
           npx wrangler d1 migrations apply androidskills --local --config wrangler.d1.local.toml
           node tests/d1_catalogue_test.mjs
+          node tests/d1_repository_contract_test.mjs
+      - name: Exercise repositories through the local Worker D1 binding
+        run: |
+          npx wrangler dev --local --config wrangler.worker-d1.local.toml --port 8788 > repository-wrangler.log 2>&1 &
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:8788/__ci/repositories > /dev/null; then break; fi
+            sleep 1
+          done
+          node tests/d1_repository_worker_test.mjs
       - name: Build the Wasm Worker
         run: npx wrangler deploy --dry-run
       - name: Start the local Workers runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,16 @@ jobs:
         run: |
           npx wrangler dev --local --config wrangler.worker-d1.local.toml --port 8788 > repository-wrangler.log 2>&1 &
           for attempt in {1..30}; do
-            if curl --fail --silent http://127.0.0.1:8788/__ci/repositories > /dev/null; then break; fi
+            if curl --fail --silent http://127.0.0.1:8788/__ci/repositories > /dev/null; then
+              ready=1
+              break
+            fi
             sleep 1
           done
+          if [ "${ready:-}" != "1" ]; then
+            cat repository-wrangler.log
+            exit 1
+          fi
           node tests/d1_repository_worker_test.mjs
       - name: Build the Wasm Worker
         run: npx wrangler deploy --dry-run

--- a/api-rs/src/lib.rs
+++ b/api-rs/src/lib.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 pub mod domain;
+pub mod repositories;
 use worker::{
     event, Context, Env, MessageBatch, Method, Request, Response, Result, ScheduleContext,
     ScheduledEvent,
@@ -11,6 +12,16 @@ const ADMIN_OPENAPI: &str = include_str!("../../api/src/main/resources/openapi-a
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct JobMessage {
     pub job_id: String,
+}
+
+#[cfg(debug_assertions)]
+#[derive(Serialize)]
+struct RepositorySmokeResponse {
+    operations: usize,
+    exactly_one: bool,
+    zero_returning_rejected: bool,
+    multiple_returning_rejected: bool,
+    decoded_value: String,
 }
 
 #[derive(Serialize)]
@@ -27,9 +38,28 @@ struct HealthResponse<'a> {
 /// Phase 0 route surface. It intentionally stays free of account bindings so it can run in
 /// Wrangler's local runtime and provide a stable target for the contract harness.
 #[event(fetch, respond_with_errors)]
-pub async fn fetch(request: Request, _env: Env, _ctx: Context) -> Result<Response> {
+pub async fn fetch(request: Request, env: Env, _ctx: Context) -> Result<Response> {
     if request.method() != Method::Get {
         return Response::error("Method Not Allowed", 405);
+    }
+
+    #[cfg(debug_assertions)]
+    if request.path() == "/__ci/repositories" {
+        let db = env.d1("DB")?;
+        let (
+            operations,
+            exactly_one,
+            zero_returning_rejected,
+            multiple_returning_rejected,
+            decoded_value,
+        ) = repositories::local_worker_smoke(&db).await?;
+        return Response::from_json(&RepositorySmokeResponse {
+            operations,
+            exactly_one,
+            zero_returning_rejected,
+            multiple_returning_rejected,
+            decoded_value,
+        });
     }
 
     match request.path().as_str() {

--- a/api-rs/src/repositories.rs
+++ b/api-rs/src/repositories.rs
@@ -1,0 +1,336 @@
+//! Typed, parameterized D1 access. Repository methods never interpolate caller-controlled SQL.
+#![allow(dead_code)] // Route-specific repository methods are introduced incrementally.
+
+use serde::de::DeserializeOwned;
+use worker::{wasm_bindgen::JsValue, D1Database, Error, Result};
+
+use crate::domain::{
+    AuditEvent, Bundle, Category, Job, PlatformSetting, Report, Session, Skill, SkillFile, Star,
+    Submission, User, Version,
+};
+
+pub(crate) struct Repositories<'db> {
+    db: &'db D1Database,
+}
+
+impl<'db> Repositories<'db> {
+    pub(crate) fn new(db: &'db D1Database) -> Self {
+        Self { db }
+    }
+
+    pub(crate) fn users(&self) -> TableRepository<'_, User> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn categories(&self) -> TableRepository<'_, Category> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn bundles(&self) -> TableRepository<'_, Bundle> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn skills(&self) -> TableRepository<'_, Skill> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn skill_files(&self) -> TableRepository<'_, SkillFile> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn versions(&self) -> TableRepository<'_, Version> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn submissions(&self) -> TableRepository<'_, Submission> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn stars(&self) -> TableRepository<'_, Star> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn sessions(&self) -> TableRepository<'_, Session> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn jobs(&self) -> TableRepository<'_, Job> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn audit_log(&self) -> TableRepository<'_, AuditEvent> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn platform_settings(&self) -> TableRepository<'_, PlatformSetting> {
+        TableRepository::new(self.db)
+    }
+    pub(crate) fn reports(&self) -> TableRepository<'_, Report> {
+        TableRepository::new(self.db)
+    }
+
+    /// Executes already-validated, cross-table mutations atomically in D1.
+    pub(crate) async fn execute_batch(&self, mutations: Vec<Mutation>) -> Result<Vec<WriteResult>> {
+        let statements = mutations
+            .iter()
+            .map(|mutation| self.db.prepare(mutation.sql).bind(&mutation.params))
+            .collect::<Result<Vec<_>>>()?;
+        self.db
+            .batch(statements)
+            .await?
+            .into_iter()
+            .map(write_result)
+            .collect()
+    }
+}
+
+/// A D1 row type whose table name is compile-time controlled by this crate.
+pub(crate) trait D1Row: DeserializeOwned {
+    const TABLE: &'static str;
+}
+
+macro_rules! rows {
+    ($($type:ty => $table:literal),+ $(,)?) => { $(impl D1Row for $type { const TABLE: &'static str = $table; })+ };
+}
+rows!(
+    User => "users", Category => "categories", Bundle => "bundles", Skill => "skills",
+    SkillFile => "skill_files", Version => "versions", Submission => "submissions", Star => "stars",
+    Session => "sessions", Job => "jobs", AuditEvent => "audit_log", PlatformSetting => "platform_settings", Report => "reports",
+);
+
+pub(crate) struct TableRepository<'db, T> {
+    db: &'db D1Database,
+    marker: core::marker::PhantomData<T>,
+}
+
+/// Physical storage metadata from a successful D1 mutation.
+///
+/// `rows_written` includes index writes and must not be used as a logical affected-row count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WriteResult {
+    pub rows_written: usize,
+}
+
+/// A parameterized mutation that can be submitted as part of an atomic D1 batch.
+pub(crate) struct Mutation {
+    sql: &'static str,
+    params: Vec<JsValue>,
+}
+
+impl Mutation {
+    /// Creates a mutation only when its static SQL targets the declared row's table.
+    pub(crate) fn for_row<T: D1Row>(sql: &'static str, params: Vec<JsValue>) -> Result<Self> {
+        if !is_table_mutation::<T>(sql) {
+            return Err(Error::RustError(
+                "repository statement table mismatch".into(),
+            ));
+        }
+        Ok(Self { sql, params })
+    }
+}
+
+impl<'db, T: D1Row> TableRepository<'db, T> {
+    fn new(db: &'db D1Database) -> Self {
+        Self {
+            db,
+            marker: core::marker::PhantomData,
+        }
+    }
+
+    /// Private substrate used by typed repository methods in this module.
+    async fn first_where(&self, predicate: &'static str, params: &[JsValue]) -> Result<Option<T>> {
+        let sql = format!("SELECT * FROM {} WHERE {} LIMIT 1", T::TABLE, predicate);
+        self.db.prepare(sql).bind(params)?.first(None).await
+    }
+
+    async fn list_where(&self, predicate: &'static str, params: &[JsValue]) -> Result<Vec<T>> {
+        let sql = format!("SELECT * FROM {} WHERE {}", T::TABLE, predicate);
+        self.db.prepare(sql).bind(params)?.all().await?.results()
+    }
+
+    /// Runs a static mutation for this repository's table and retains D1's changed-row count.
+    pub(crate) async fn execute(
+        &self,
+        sql: &'static str,
+        params: &[JsValue],
+    ) -> Result<WriteResult> {
+        if !is_table_mutation::<T>(sql) {
+            return Err(Error::RustError(
+                "repository statement table mismatch".into(),
+            ));
+        }
+        let result = self.db.prepare(sql).bind(params)?.run().await?;
+        write_result(result)
+    }
+
+    /// Runs a mutation that must affect exactly one row, rejecting stale or broad writes.
+    /// The statement must include `RETURNING` so the logical row count is unambiguous.
+    pub(crate) async fn execute_exactly_one(
+        &self,
+        sql: &'static str,
+        params: &[JsValue],
+    ) -> Result<()> {
+        if !is_table_mutation::<T>(sql) || !sql.to_ascii_uppercase().contains(" RETURNING ") {
+            return Err(Error::RustError(
+                "exactly-one mutation must target this table and include RETURNING".into(),
+            ));
+        }
+        let result = self.db.prepare(sql).bind(params)?.all().await?;
+        let returned: Vec<serde::de::IgnoredAny> = result.results()?;
+        ensure_exactly_one_returned(returned.len())
+    }
+}
+
+fn write_result(result: worker::D1Result) -> Result<WriteResult> {
+    let rows_written = result
+        .meta()?
+        .and_then(|meta| meta.rows_written)
+        .ok_or_else(|| Error::RustError("D1 mutation did not return rows_written".into()))?;
+    Ok(WriteResult { rows_written })
+}
+
+fn ensure_exactly_one_returned(returned_rows: usize) -> Result<()> {
+    if returned_rows == 1 {
+        Ok(())
+    } else {
+        Err(Error::RustError(format!(
+            "expected exactly one returned row, got {returned_rows}"
+        )))
+    }
+}
+
+fn is_table_mutation<T: D1Row>(sql: &str) -> bool {
+    mutation_table(sql).is_some_and(|table| table == T::TABLE)
+}
+
+fn mutation_table(sql: &str) -> Option<&str> {
+    let mut tokens = sql.split_ascii_whitespace();
+    match tokens.next()?.to_ascii_uppercase().as_str() {
+        "INSERT" => {
+            let next = tokens.next()?.to_ascii_uppercase();
+            if next == "OR" {
+                tokens.next()?; // SQLite conflict action, e.g. IGNORE or REPLACE.
+                if !tokens.next()?.eq_ignore_ascii_case("INTO") {
+                    return None;
+                }
+            } else if next != "INTO" {
+                return None;
+            }
+            tokens.next()
+        }
+        "UPDATE" => tokens.next(),
+        "DELETE" if tokens.next()?.eq_ignore_ascii_case("FROM") => tokens.next(),
+        _ => None,
+    }
+    .map(|table| table.split_once('(').map_or(table, |(name, _)| name))
+}
+
+/// Local-Worker-only integration exercise for the real D1 binding. It is intentionally absent
+/// from release builds, where application routes use the same repository methods.
+#[cfg(debug_assertions)]
+pub(crate) async fn local_worker_smoke(
+    db: &D1Database,
+) -> Result<(usize, bool, bool, bool, String)> {
+    let repositories = Repositories::new(db);
+    let settings = repositories.platform_settings();
+    let key_a = "__ci_repository_a";
+    let key_b = "__ci_repository_b";
+    settings
+        .execute(
+            "DELETE FROM platform_settings WHERE key LIKE ?",
+            &[JsValue::from_str("__ci_repository_%")],
+        )
+        .await?;
+    let batch = repositories
+        .execute_batch(vec![
+            Mutation::for_row::<PlatformSetting>(
+                "INSERT INTO platform_settings (key, value) VALUES (?, ?)",
+                vec![JsValue::from_str(key_a), JsValue::from_str("one")],
+            )?,
+            Mutation::for_row::<PlatformSetting>(
+                "INSERT INTO platform_settings (key, value) VALUES (?, ?)",
+                vec![JsValue::from_str(key_b), JsValue::from_str("two")],
+            )?,
+        ])
+        .await?;
+    let first = settings
+        .first_where("key = ?", &[JsValue::from_str(key_a)])
+        .await?
+        .ok_or_else(|| Error::RustError("missing bound platform setting".into()))?;
+    let listed = settings
+        .list_where(
+            "key LIKE ? ORDER BY key",
+            &[JsValue::from_str("__ci_repository_%")],
+        )
+        .await?;
+    let exactly_one = settings
+        .execute_exactly_one(
+            "UPDATE platform_settings SET value = ? WHERE key = ? RETURNING key",
+            &[JsValue::from_str("updated"), JsValue::from_str(key_a)],
+        )
+        .await
+        .is_ok();
+    let zero_returning = settings
+        .execute_exactly_one(
+            "UPDATE platform_settings SET value = ? WHERE key = ? RETURNING key",
+            &[
+                JsValue::from_str("missing"),
+                JsValue::from_str("__ci_repository_missing"),
+            ],
+        )
+        .await
+        .is_err();
+    let multiple_returning = settings
+        .execute_exactly_one(
+            "UPDATE platform_settings SET value = ? WHERE key LIKE ? RETURNING key",
+            &[
+                JsValue::from_str("multiple"),
+                JsValue::from_str("__ci_repository_%"),
+            ],
+        )
+        .await
+        .is_err();
+    settings
+        .execute(
+            "DELETE FROM platform_settings WHERE key LIKE ?",
+            &[JsValue::from_str("__ci_repository_%")],
+        )
+        .await?;
+    Ok((
+        batch.len() + listed.len(),
+        exactly_one,
+        zero_returning,
+        multiple_returning,
+        first.value,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_exactly_one_returned, is_table_mutation, Mutation, Skill, User};
+
+    #[test]
+    fn allows_only_mutations_of_the_repository_table() {
+        assert!(is_table_mutation::<User>(
+            "INSERT INTO users (id) VALUES (?)"
+        ));
+        assert!(is_table_mutation::<User>(
+            "INSERT INTO users(id) VALUES (?)"
+        ));
+        assert!(is_table_mutation::<User>(
+            "INSERT OR IGNORE INTO users (id) VALUES (?)"
+        ));
+        assert!(is_table_mutation::<User>(
+            "UPDATE users SET name = ? WHERE id = ?"
+        ));
+        assert!(is_table_mutation::<User>("DELETE FROM users WHERE id = ?"));
+        assert!(!is_table_mutation::<User>("UPDATE skills SET title = ?"));
+        assert!(!is_table_mutation::<User>("SELECT * FROM users"));
+    }
+
+    #[test]
+    fn mutation_retains_static_sql_and_bound_values_for_a_batch() {
+        let mutation =
+            Mutation::for_row::<User>("UPDATE users SET status = ? WHERE id = ?", vec![])
+                .expect("the user mutation should be accepted");
+        assert!(is_table_mutation::<User>(mutation.sql));
+        assert!(mutation.params.is_empty());
+        assert!(Mutation::for_row::<Skill>("UPDATE users SET status = ?", vec![]).is_err());
+    }
+
+    #[test]
+    fn exactly_one_guard_rejects_zero_and_multiple_returning_rows() {
+        assert!(ensure_exactly_one_returned(0).is_err());
+        assert!(ensure_exactly_one_returned(1).is_ok());
+        assert!(ensure_exactly_one_returned(2).is_err());
+    }
+}

--- a/api-rs/tests/d1_repository_contract_test.mjs
+++ b/api-rs/tests/d1_repository_contract_test.mjs
@@ -1,0 +1,94 @@
+/** Account-free D1 checks for repository query, constraint, pagination, and write contracts. */
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const apiRoot = resolve(import.meta.dirname, "..");
+const wrangler = resolve(apiRoot, "node_modules/wrangler/bin/wrangler.js");
+const run = (command) => execFileSync(process.execPath, [wrangler, "d1", "execute", "androidskills", "--local", "--config", "wrangler.d1.local.toml", "--command", command], {
+  cwd: apiRoot,
+  encoding: "utf8",
+});
+const query = (command) => {
+  const output = run(command);
+  const start = output.indexOf("[\n  {");
+  const end = output.lastIndexOf("\n]") + 2;
+  return JSON.parse(output.slice(start, end))[0].results;
+};
+const id = "repository-contract-user";
+const now = "2026-01-01T00:00:00Z";
+const p = "repository-contract";
+const expectRejected = (command, message) => {
+  try { run(command); } catch { return; }
+  throw new Error(message);
+};
+const one = (command) => query(command)[0];
+
+try {
+  run(`DELETE FROM users WHERE id = '${id}'`);
+  run(`INSERT INTO users (id, github_id, handle, role, status, created_at, updated_at) VALUES ('${id}', 760076, 'repository-contract', 'member', 'active', '${now}', '${now}')`);
+
+  const firstPage = query("SELECT id FROM users WHERE id = 'repository-contract-user' ORDER BY id LIMIT 1 OFFSET 0");
+  if (firstPage.length !== 1 || firstPage[0].id !== id) throw new Error("D1 first-page repository contract failed.");
+  const emptyPage = query("SELECT id FROM users WHERE id = 'repository-contract-user' ORDER BY id LIMIT 1 OFFSET 1");
+  if (emptyPage.length !== 0) throw new Error("D1 pagination boundary contract failed.");
+
+  run(`UPDATE users SET status = 'suspended' WHERE id = '${id}' AND status = 'active'`);
+  const changed = query(`SELECT status FROM users WHERE id = '${id}'`)[0];
+  if (changed.status !== "suspended") throw new Error("Expected the conditional update to affect one matching row.");
+  run(`UPDATE users SET status = 'active' WHERE id = '${id}' AND status = 'active'`);
+  const unchanged = query(`SELECT status FROM users WHERE id = '${id}'`)[0];
+  if (unchanged.status !== "suspended") throw new Error("Expected stale conditional update to affect zero rows.");
+
+  let duplicateRejected = false;
+  try {
+    run(`INSERT INTO users (id, github_id, handle, role, status, created_at, updated_at) VALUES ('${id}-duplicate', 760077, 'repository-contract', 'member', 'active', '${now}', '${now}')`);
+  } catch {
+    duplicateRejected = true;
+  }
+  if (!duplicateRejected) throw new Error("D1 uniqueness constraint did not reject a duplicate handle.");
+  const count = query("SELECT COUNT(*) AS count FROM users WHERE handle = 'repository-contract'")[0];
+  if (count.count !== 1) throw new Error("D1 constraint failure changed persisted repository state.");
+
+  // Exercise every named UNIQUE constraint and the complete FK action matrix from 0001.
+  run(`DELETE FROM reports WHERE id LIKE '${p}%'; DELETE FROM audit_log WHERE id LIKE '${p}%'; DELETE FROM stars WHERE user_id LIKE '${p}%' OR skill_id LIKE '${p}%'; DELETE FROM sessions WHERE id LIKE '${p}%'; DELETE FROM submissions WHERE id LIKE '${p}%'; DELETE FROM versions WHERE id LIKE '${p}%'; DELETE FROM skill_files WHERE id LIKE '${p}%'; DELETE FROM skills WHERE id LIKE '${p}%'; DELETE FROM bundles WHERE id LIKE '${p}%'; DELETE FROM categories WHERE id LIKE '${p}%'; DELETE FROM users WHERE id LIKE '${p}%'; DELETE FROM jobs WHERE id LIKE '${p}%'; DELETE FROM platform_settings WHERE key LIKE '${p}%'`);
+  run(`INSERT INTO users (id, github_id, handle, role, status, created_at, updated_at) VALUES ('${p}-owner', 760100, '${p}-owner', 'member', 'active', '${now}', '${now}'), ('${p}-reporter', 760101, '${p}-reporter', 'member', 'active', '${now}', '${now}')`);
+  expectRejected(`INSERT INTO users (id, github_id, handle, role, status, created_at, updated_at) VALUES ('${p}-u-github', 760100, '${p}-other', 'member', 'active', '${now}', '${now}')`, "users.github_id UNIQUE was not enforced");
+  expectRejected(`INSERT INTO users (id, github_id, handle, role, status, created_at, updated_at) VALUES ('${p}-u-handle', 760102, '${p}-owner', 'member', 'active', '${now}', '${now}')`, "users.handle UNIQUE was not enforced");
+  run(`INSERT INTO categories (id, slug, name) VALUES ('${p}-cat', '${p}-cat', 'Contract')`);
+  expectRejected(`INSERT INTO categories (id, slug, name) VALUES ('${p}-cat-2', '${p}-cat', 'Duplicate')`, "categories.slug UNIQUE was not enforced");
+  run(`INSERT INTO bundles (id, kind, provenance, owner_user_id, created_at) VALUES ('${p}-bundle', 'repo', '${p}-bundle', '${p}-owner', '${now}')`);
+  expectRejected(`INSERT INTO bundles (id, kind, provenance, owner_user_id, created_at) VALUES ('${p}-bundle-2', 'repo', '${p}-bundle', '${p}-owner', '${now}')`, "bundles(kind, provenance) UNIQUE was not enforced");
+  run(`INSERT INTO skills (id, bundle_id, slug, source_dir, name, description, tags, category_id, version, version_source, created_at, updated_at) VALUES ('${p}-skill', '${p}-bundle', '${p}-skill', 'skill', 'Contract', 'Contract', '[]', '${p}-cat', '1.0.0', 'git', '${now}', '${now}')`);
+  expectRejected(`INSERT INTO skills (id, bundle_id, slug, source_dir, name, description, tags, version, version_source, created_at, updated_at) VALUES ('${p}-skill-null', '${p}-bundle', '${p}-skill-null', NULL, 'Contract', 'Contract', '[]', '1.0.0', 'git', '${now}', '${now}')`, "skills.source_dir NOT NULL was not enforced");
+  expectRejected(`INSERT INTO skills (id, bundle_id, slug, source_dir, name, description, tags, version, version_source, created_at, updated_at) VALUES ('${p}-skill-slug', '${p}-bundle', '${p}-skill', 'other', 'Contract', 'Contract', '[]', '1.0.0', 'git', '${now}', '${now}')`, "skills.slug UNIQUE was not enforced");
+  expectRejected(`INSERT INTO skills (id, bundle_id, slug, source_dir, name, description, tags, version, version_source, created_at, updated_at) VALUES ('${p}-skill-dir', '${p}-bundle', '${p}-skill-dir', 'skill', 'Contract', 'Contract', '[]', '1.0.0', 'git', '${now}', '${now}')`, "skills(bundle_id, source_dir) UNIQUE was not enforced");
+  run(`INSERT INTO skill_files (id, skill_id, path, size, is_binary, r2_key) VALUES ('${p}-file', '${p}-skill', 'SKILL.md', 1, 0, 'k'); INSERT INTO versions (id, skill_id, version, source_ref, created_at) VALUES ('${p}-version', '${p}-skill', '1.0.0', 'git', '${now}'); INSERT INTO stars (user_id, skill_id, created_at) VALUES ('${p}-owner', '${p}-skill', '${now}'); INSERT INTO jobs (id, type, payload, run_after, dedup_key, created_at, updated_at) VALUES ('${p}-job', 'sync', '{}', '${now}', 'dedup', '${now}', '${now}')`);
+  expectRejected(`INSERT INTO skill_files (id, skill_id, path, size, is_binary, r2_key) VALUES ('${p}-file-2', '${p}-skill', 'SKILL.md', 1, 0, 'k')`, "skill_files(skill_id, path) UNIQUE was not enforced");
+  expectRejected(`INSERT INTO versions (id, skill_id, version, source_ref, created_at) VALUES ('${p}-version-2', '${p}-skill', '1.0.0', 'git', '${now}')`, "versions(skill_id, version) UNIQUE was not enforced");
+  expectRejected(`INSERT INTO stars (user_id, skill_id, created_at) VALUES ('${p}-owner', '${p}-skill', '${now}')`, "stars primary key was not enforced");
+  expectRejected(`INSERT INTO jobs (id, type, payload, run_after, dedup_key, created_at, updated_at) VALUES ('${p}-job-2', 'sync', '{}', '${now}', 'dedup', '${now}', '${now}')`, "jobs(type, dedup_key) UNIQUE was not enforced");
+
+  run(`INSERT INTO submissions (id, bundle_id, skill_id, submitter_id, state, created_at, updated_at) VALUES ('${p}-submission', '${p}-bundle', '${p}-skill', '${p}-owner', 'pending', '${now}', '${now}'); INSERT INTO sessions (id, user_id, created_at, expires_at) VALUES ('${p}-session', '${p}-owner', '${now}', '${now}'); INSERT INTO reports (id, skill_id, reporter_id, reason, created_at) VALUES ('${p}-report', '${p}-skill', '${p}-reporter', 'reason', '${now}')`);
+  run(`DELETE FROM categories WHERE id = '${p}-cat'`);
+  if (one(`SELECT category_id FROM skills WHERE id = '${p}-skill'`).category_id !== null) throw new Error("skills.category_id SET NULL was not applied");
+  run(`DELETE FROM users WHERE id = '${p}-reporter'`);
+  if (one(`SELECT reporter_id FROM reports WHERE id = '${p}-report'`).reporter_id !== null) throw new Error("reports.reporter_id SET NULL was not applied");
+  run(`DELETE FROM bundles WHERE id = '${p}-bundle'`);
+  if (one(`SELECT bundle_id, skill_id FROM submissions WHERE id = '${p}-submission'`).bundle_id !== null) throw new Error("submissions.bundle_id SET NULL was not applied");
+  if (one(`SELECT COUNT(*) AS count FROM skills WHERE id = '${p}-skill'`).count !== 0) throw new Error("bundles -> skills CASCADE was not applied");
+  if (one(`SELECT skill_id FROM submissions WHERE id = '${p}-submission'`).skill_id !== null) throw new Error("submissions.skill_id SET NULL was not applied");
+
+  // A separate hierarchy proves every remaining CASCADE action without relying on a transitive
+  // deletion from the earlier bundle test.
+  run(`INSERT INTO users (id, github_id, handle, role, status, created_at, updated_at) VALUES ('${p}-cascade-owner', 760103, '${p}-cascade-owner', 'member', 'active', '${now}', '${now}'), ('${p}-cascade-reporter', 760104, '${p}-cascade-reporter', 'member', 'active', '${now}', '${now}'); INSERT INTO bundles (id, kind, provenance, owner_user_id, created_at) VALUES ('${p}-cascade-bundle', 'repo', '${p}-cascade-bundle', '${p}-cascade-owner', '${now}'); INSERT INTO skills (id, bundle_id, slug, source_dir, name, description, tags, version, version_source, created_at, updated_at) VALUES ('${p}-cascade-skill', '${p}-cascade-bundle', '${p}-cascade-skill', 'skill', 'Contract', 'Contract', '[]', '1.0.0', 'git', '${now}', '${now}'); INSERT INTO skill_files (id, skill_id, path, size, is_binary, r2_key) VALUES ('${p}-cascade-file', '${p}-cascade-skill', 'SKILL.md', 1, 0, 'k'); INSERT INTO versions (id, skill_id, version, source_ref, created_at) VALUES ('${p}-cascade-version', '${p}-cascade-skill', '1.0.0', 'git', '${now}'); INSERT INTO stars (user_id, skill_id, created_at) VALUES ('${p}-cascade-owner', '${p}-cascade-skill', '${now}'); INSERT INTO reports (id, skill_id, reporter_id, reason, created_at) VALUES ('${p}-cascade-report', '${p}-cascade-skill', '${p}-cascade-reporter', 'reason', '${now}'); INSERT INTO submissions (id, submitter_id, state, created_at, updated_at) VALUES ('${p}-cascade-submission', '${p}-cascade-owner', 'pending', '${now}', '${now}')`);
+  run(`DELETE FROM users WHERE id = '${p}-cascade-owner'`);
+  const cascaded = one(`SELECT (SELECT COUNT(*) FROM bundles WHERE id = '${p}-cascade-bundle') AS bundles, (SELECT COUNT(*) FROM skills WHERE id = '${p}-cascade-skill') AS skills, (SELECT COUNT(*) FROM skill_files WHERE id = '${p}-cascade-file') AS files, (SELECT COUNT(*) FROM versions WHERE id = '${p}-cascade-version') AS versions, (SELECT COUNT(*) FROM stars WHERE skill_id = '${p}-cascade-skill') AS stars, (SELECT COUNT(*) FROM reports WHERE id = '${p}-cascade-report') AS reports, (SELECT COUNT(*) FROM submissions WHERE id = '${p}-cascade-submission') AS submissions`);
+  if (Object.values(cascaded).some((count) => count !== 0)) throw new Error(`CASCADE contract failed: ${JSON.stringify(cascaded)}`);
+  run(`INSERT INTO audit_log (id, actor_id, action, target, created_at) VALUES ('${p}-audit', '${p}-owner', 'test', 'test', '${now}')`);
+  expectRejected(`DELETE FROM users WHERE id = '${p}-owner'`, "audit_log.actor_id RESTRICT was not enforced");
+  run(`DELETE FROM audit_log WHERE id = '${p}-audit'; DELETE FROM users WHERE id = '${p}-owner'`);
+  if (one(`SELECT COUNT(*) AS count FROM sessions WHERE id = '${p}-session'`).count !== 0) throw new Error("users -> sessions CASCADE was not applied");
+  console.log("D1 repository contracts verified.");
+} finally {
+  run(`DELETE FROM reports WHERE id LIKE '${p}%'; DELETE FROM audit_log WHERE id LIKE '${p}%'; DELETE FROM stars WHERE user_id LIKE '${p}%' OR skill_id LIKE '${p}%'; DELETE FROM sessions WHERE id LIKE '${p}%'; DELETE FROM submissions WHERE id LIKE '${p}%'; DELETE FROM versions WHERE id LIKE '${p}%'; DELETE FROM skill_files WHERE id LIKE '${p}%'; DELETE FROM skills WHERE id LIKE '${p}%'; DELETE FROM bundles WHERE id LIKE '${p}%'; DELETE FROM categories WHERE id LIKE '${p}%'; DELETE FROM users WHERE id LIKE '${p}%' OR id IN ('${id}', '${id}-duplicate'); DELETE FROM jobs WHERE id LIKE '${p}%'; DELETE FROM platform_settings WHERE key LIKE '${p}%'`);
+}

--- a/api-rs/tests/d1_repository_worker_test.mjs
+++ b/api-rs/tests/d1_repository_worker_test.mjs
@@ -1,0 +1,8 @@
+const base = process.env.CONTRACT_BASE_URL ?? "http://127.0.0.1:8788";
+const response = await fetch(`${base}/__ci/repositories`);
+if (!response.ok) throw new Error(`repository worker smoke failed: ${response.status} ${await response.text()}`);
+const body = await response.json();
+if (body.operations !== 4 || !body.exactly_one || !body.zero_returning_rejected || !body.multiple_returning_rejected || body.decoded_value !== "one") {
+  throw new Error(`repository worker smoke contract failed: ${JSON.stringify(body)}`);
+}
+console.log("D1 Worker repository smoke verified.");

--- a/api-rs/wrangler.worker-d1.local.toml
+++ b/api-rs/wrangler.worker-d1.local.toml
@@ -1,0 +1,14 @@
+# CI-only Worker configuration: combines the generated Worker entrypoint with the account-free
+# local D1 emulator. It must never be used for deployment.
+name = "androidskills-api-worker-d1-local"
+main = "build/worker/shim.mjs"
+compatibility_date = "2026-07-16"
+
+[build]
+command = "worker-build --dev"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "androidskills"
+database_id = "00000000-0000-0000-0000-000000000003"
+migrations_dir = "migrations"


### PR DESCRIPTION
## What changed

Adds typed Rust D1 repository primitives, a cross-table batch API, RETURNING-based exactly-one semantics, and local D1 contract coverage.

## Why

This advances epic #76 with an account-free persistence layer that can be exercised in CI before Cloudflare provisioning.

## Validation

- cargo fmt --check
- cargo check --locked
- cargo test --locked --lib
- Local Wrangler D1 schema contract harness
- Local debug Worker + D1 repository smoke harness
- Isolated Sol-high alignment and adversarial reviews: clean