### PR TITLE
feat(worker): add persistence and error helpers

### DIFF
--- a/api-rs/Cargo.lock
+++ b/api-rs/Cargo.lock
@@ -3,11 +3,22 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "androidskills-api-worker"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
+ "uuid",
  "worker",
 ]
 
@@ -41,6 +52,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,10 +73,18 @@ version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
+ "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
+ "windows-link",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "displaydoc"
@@ -67,6 +96,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "form_urlencoded"
@@ -138,6 +173,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +208,30 @@ checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -284,10 +355,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchit"
@@ -376,6 +459,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +530,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "slab"
@@ -547,6 +642,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +738,71 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "worker"

--- a/api-rs/Cargo.toml
+++ b/api-rs/Cargo.toml
@@ -8,11 +8,13 @@ rust-version = "1.88"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+chrono = { version = "=0.4.45", default-features = false, features = ["clock", "std"] }
 serde = { version = "=1.0.219", features = ["derive"] }
+serde_json = "=1.0.143"
+uuid = { version = "=1.18.1", features = ["v4", "js"] }
 worker = { version = "=0.8.3", features = ["d1", "queue"] }
 
 [dev-dependencies]
-serde_json = "=1.0.143"
 
 [profile.release]
 lto = true

--- a/api-rs/src/error.rs
+++ b/api-rs/src/error.rs
@@ -1,0 +1,113 @@
+//! Stable HTTP error envelope shared by every Worker route.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use worker::{Response, Result};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ErrorBody {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<BTreeMap<String, String>>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ErrorResponse {
+    pub error: ErrorBody,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiError {
+    status: u16,
+    body: ErrorBody,
+}
+
+impl ApiError {
+    pub fn new(status: u16, code: impl Into<String>, message: impl Into<String>) -> Self {
+        assert!(
+            (400..=599).contains(&status),
+            "API errors must use an HTTP error status"
+        );
+        Self {
+            status,
+            body: ErrorBody {
+                code: code.into(),
+                message: message.into(),
+                fields: None,
+            },
+        }
+    }
+
+    pub fn validation(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        fields: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            status: 422,
+            body: ErrorBody {
+                code: code.into(),
+                message: message.into(),
+                fields: Some(fields),
+            },
+        }
+    }
+
+    pub fn not_found() -> Self {
+        Self::new(404, "not_found", "Not found")
+    }
+    pub fn unauthorized() -> Self {
+        Self::new(401, "unauthorized", "Authentication required")
+    }
+    pub fn forbidden() -> Self {
+        Self::new(403, "forbidden", "Forbidden")
+    }
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::new(400, "bad_request", message)
+    }
+    pub fn conflict(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(409, code, message)
+    }
+    pub fn internal() -> Self {
+        Self::new(500, "internal", "Internal server error")
+    }
+
+    pub fn status(&self) -> u16 {
+        self.status
+    }
+    pub fn response(&self) -> Result<Response> {
+        Response::from_json(&ErrorResponse {
+            error: self.body.clone(),
+        })
+        .map(|response| response.with_status(self.status))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ApiError;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn preserves_the_openapi_error_envelope() {
+        let error = ApiError::validation(
+            "validation_failed",
+            "Validation failed",
+            BTreeMap::from([("slug".into(), "required".into())]),
+        );
+        assert_eq!(error.status(), 422);
+        let encoded = serde_json::to_value(error.body).unwrap();
+        assert_eq!(encoded["code"], "validation_failed");
+        assert_eq!(encoded["fields"]["slug"], "required");
+    }
+
+    #[test]
+    fn standard_errors_have_stable_codes() {
+        assert_eq!(ApiError::not_found().status(), 404);
+        assert_eq!(ApiError::unauthorized().status(), 401);
+        assert_eq!(ApiError::forbidden().status(), 403);
+        assert_eq!(ApiError::internal().status(), 500);
+    }
+}

--- a/api-rs/src/ids.rs
+++ b/api-rs/src/ids.rs
@@ -1,0 +1,33 @@
+//! UUIDv4 identifiers for the D1 TEXT primary-key contract.
+
+use uuid::Uuid;
+
+/// Creates a canonical, hyphenated UUIDv4 string suitable for every 36-character D1 ID column.
+pub fn new_id() -> String {
+    Uuid::new_v4().hyphenated().to_string()
+}
+
+/// Accepts only canonical UUIDv4 strings, preventing non-canonical identities from entering D1.
+pub fn is_canonical_v4(value: &str) -> bool {
+    Uuid::parse_str(value)
+        .is_ok_and(|uuid| uuid.get_version_num() == 4 && uuid.hyphenated().to_string() == value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_canonical_v4, new_id};
+
+    #[test]
+    fn generates_canonical_v4_ids() {
+        let id = new_id();
+        assert_eq!(id.len(), 36);
+        assert!(is_canonical_v4(&id));
+    }
+
+    #[test]
+    fn rejects_other_uuid_versions_and_spellings() {
+        assert!(!is_canonical_v4("6ba7b810-9dad-11d1-80b4-00c04fd430c8"));
+        assert!(!is_canonical_v4("550E8400-E29B-41D4-A716-446655440000"));
+        assert!(!is_canonical_v4("not-a-uuid"));
+    }
+}

--- a/api-rs/src/json_column.rs
+++ b/api-rs/src/json_column.rs
@@ -1,0 +1,98 @@
+//! Typed encoding for JSON stored in D1 TEXT columns.
+
+use serde::{de::DeserializeOwned, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsonColumnError {
+    Encode(String),
+    Decode(String),
+}
+
+impl core::fmt::Display for JsonColumnError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Encode(error) => write!(formatter, "could not encode JSON column: {error}"),
+            Self::Decode(error) => write!(formatter, "could not decode JSON column: {error}"),
+        }
+    }
+}
+
+pub fn encode<T: Serialize>(value: &T) -> Result<String, JsonColumnError> {
+    let mut value =
+        serde_json::to_value(value).map_err(|error| JsonColumnError::Encode(error.to_string()))?;
+    omit_object_nulls(&mut value);
+    serde_json::to_string(&value).map_err(|error| JsonColumnError::Encode(error.to_string()))
+}
+
+pub fn decode<T: DeserializeOwned>(value: &str) -> Result<T, JsonColumnError> {
+    serde_json::from_str(value).map_err(|error| JsonColumnError::Decode(error.to_string()))
+}
+
+fn omit_object_nulls(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(object) => {
+            object.retain(|_, value| !value.is_null());
+            for value in object.values_mut() {
+                omit_object_nulls(value);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                omit_object_nulls(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode, encode, JsonColumnError};
+    use serde::Serialize;
+
+    #[test]
+    fn round_trips_json_columns() {
+        let encoded = encode(&vec!["android", "kotlin"]).unwrap();
+        assert_eq!(encoded, r#"["android","kotlin"]"#);
+        assert_eq!(
+            decode::<Vec<String>>(&encoded).unwrap(),
+            ["android", "kotlin"]
+        );
+    }
+
+    #[test]
+    fn surfaces_corrupt_json() {
+        assert!(matches!(
+            decode::<Vec<String>>("{"),
+            Err(JsonColumnError::Decode(_))
+        ));
+    }
+
+    #[derive(Serialize)]
+    struct KotlinCompatiblePayload {
+        present: Option<&'static str>,
+        absent: Option<&'static str>,
+        nested: NestedPayload,
+        array: Vec<Option<&'static str>>,
+    }
+
+    #[derive(Serialize)]
+    struct NestedPayload {
+        absent: Option<&'static str>,
+    }
+
+    #[test]
+    fn omits_object_nulls_like_kotlins_shared_json_encoder() {
+        let encoded = encode(&KotlinCompatiblePayload {
+            present: Some("value"),
+            absent: None,
+            nested: NestedPayload { absent: None },
+            array: vec![Some("value"), None],
+        })
+        .unwrap();
+        assert_eq!(
+            encoded,
+            r#"{"array":["value",null],"nested":{},"present":"value"}"#
+        );
+    }
+}

--- a/api-rs/src/lib.rs
+++ b/api-rs/src/lib.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 pub mod domain;
+pub mod error;
+pub mod ids;
+pub mod json_column;
 pub mod repositories;
+pub mod time;
 use worker::{
     event, Context, Env, MessageBatch, Method, Request, Response, Result, ScheduleContext,
     ScheduledEvent,

--- a/api-rs/src/time.rs
+++ b/api-rs/src/time.rs
@@ -14,12 +14,16 @@ pub fn format_iso(value: DateTime<Utc>) -> Timestamp {
     value.to_rfc3339_opts(SecondsFormat::Nanos, true)
 }
 
-/// Parses only canonical UTC timestamps accepted by the D1 persistence layer.
+/// Parses UTC RFC3339 timestamps from both existing Kotlin fixtures and new fixed-width D1 rows.
+/// Persistence writers must still use [format_iso] so new D1 TEXT values remain sortable.
 pub fn parse_iso(value: &str) -> Option<DateTime<Utc>> {
+    if value.ends_with("-00:00") {
+        return None;
+    }
     DateTime::parse_from_rfc3339(value)
         .ok()
+        .filter(|timestamp| timestamp.offset().local_minus_utc() == 0)
         .map(|timestamp| timestamp.with_timezone(&Utc))
-        .filter(|timestamp| format_iso(*timestamp) == value)
 }
 
 #[cfg(test)]
@@ -37,10 +41,11 @@ mod tests {
     }
 
     #[test]
-    fn rejects_noncanonical_timestamp_spellings() {
-        assert!(parse_iso("2026-07-23T12:34:56Z").is_none());
-        assert!(parse_iso("2026-07-23T12:34:56.000Z").is_none());
+    fn accepts_existing_kotlin_utc_spellings_and_rejects_non_utc_values() {
+        assert!(parse_iso("2026-07-23T12:34:56Z").is_some());
+        assert!(parse_iso("2026-07-23T12:34:56.000Z").is_some());
         assert!(parse_iso("2026-07-23T14:34:56+02:00").is_none());
+        assert!(parse_iso("2026-07-23T12:34:56-00:00").is_none());
         assert!(parse_iso("not-a-timestamp").is_none());
         assert!(parse_iso(&now_iso()).is_some());
     }

--- a/api-rs/src/time.rs
+++ b/api-rs/src/time.rs
@@ -1,0 +1,54 @@
+//! Canonical UTC timestamps for lexically sortable D1 TEXT columns.
+
+use chrono::{DateTime, SecondsFormat, Utc};
+
+pub type Timestamp = String;
+
+/// Returns a fixed-width UTC ISO-8601 value. Fixed nanosecond precision keeps D1 TEXT timestamps
+/// lexically sortable for expiry, scheduling, and index ordering.
+pub fn now_iso() -> Timestamp {
+    format_iso(Utc::now())
+}
+
+pub fn format_iso(value: DateTime<Utc>) -> Timestamp {
+    value.to_rfc3339_opts(SecondsFormat::Nanos, true)
+}
+
+/// Parses only canonical UTC timestamps accepted by the D1 persistence layer.
+pub fn parse_iso(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .filter(|timestamp| format_iso(*timestamp) == value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_iso, now_iso, parse_iso};
+    use chrono::{TimeZone, Timelike, Utc};
+
+    #[test]
+    fn formats_canonical_utc_precision() {
+        let timestamp = Utc.with_ymd_and_hms(2026, 7, 23, 12, 34, 56).unwrap();
+        assert_eq!(format_iso(timestamp), "2026-07-23T12:34:56.000000000Z");
+        assert!(parse_iso("2026-07-23T12:34:56.000000000Z").is_some());
+        assert!(parse_iso("2026-07-23T12:34:56.123000000Z").is_some());
+        assert!(parse_iso("2026-07-23T12:34:56.123456789Z").is_some());
+    }
+
+    #[test]
+    fn rejects_noncanonical_timestamp_spellings() {
+        assert!(parse_iso("2026-07-23T12:34:56Z").is_none());
+        assert!(parse_iso("2026-07-23T12:34:56.000Z").is_none());
+        assert!(parse_iso("2026-07-23T14:34:56+02:00").is_none());
+        assert!(parse_iso("not-a-timestamp").is_none());
+        assert!(parse_iso(&now_iso()).is_some());
+    }
+
+    #[test]
+    fn fixed_width_timestamps_sort_in_chronological_order() {
+        let exact_second = Utc.with_ymd_and_hms(2026, 7, 23, 12, 34, 56).unwrap();
+        let next_nanosecond = exact_second.with_nanosecond(1).unwrap();
+        assert!(format_iso(exact_second) < format_iso(next_nanosecond));
+    }
+}

--- a/api-rs/tests/contract/openapi.json
+++ b/api-rs/tests/contract/openapi.json
@@ -5,6 +5,6 @@
     "status": 200,
     "contentType": "application/yaml",
     "bodyIncludes": ["openapi: 3.0.3", "/api/health:"],
-    "bodySha256": "7df038919f2eac7e950b9b63a93a662723fddb359fd43128ffa699a3c76170d7"
+    "bodySha256": "d15d82c5c94885af22c1e07878a1be1a41871487226d80b6521a36732f0d574b"
   }
 }

--- a/api/src/main/resources/openapi.yaml
+++ b/api/src/main/resources/openapi.yaml
@@ -1238,7 +1238,7 @@ components:
           type: string
         message:
           type: string
-        details:
+        fields:
           type: object
           additionalProperties:
             type: string

--- a/web/src/lib/api-types.ts
+++ b/web/src/lib/api-types.ts
@@ -1533,7 +1533,7 @@ export interface components {
     ErrorBody: {
       code: string;
       message: string;
-      details?: {
+      fields?: {
         [key: string]: string;
       } | null;
     };


### PR DESCRIPTION
## What changed

Adds Phase 1 Worker helpers for canonical UUIDv4 IDs, fixed-width UTC D1 timestamps, Kotlin-compatible JSON TEXT columns, and the stable API error envelope. Reconciles public OpenAPI and generated public types with the existing ields validation envelope.

## Why

These shared primitives make subsequent route and repository work consistent, testable, and safe for D1 ordering.

## Validation

- cargo fmt --check
- cargo test --locked --lib (16 tests)
- cargo check --locked --target wasm32-unknown-unknown
- cargo clippy --locked --target wasm32-unknown-unknown -- -D warnings
- Public TypeScript formatting and type check
- Isolated Sol-high plan alignment and adversarial reviews: clean