### PR TITLE
feat(worker): add public D1 read routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
             exit 1
           fi
           node tests/d1_repository_worker_test.mjs
+          node tests/d1_public_read_worker_test.mjs
       - name: Build the Wasm Worker
         run: npx wrangler deploy --dry-run
       - name: Start the local Workers runtime
@@ -122,7 +123,9 @@ jobs:
           cat wrangler.log
           exit 1
       - name: Run black-box contract fixtures against the Worker
-        run: CONTRACT_BASE_URL=http://127.0.0.1:8787 node tests/contract/run.mjs
+        run: |
+          CONTRACT_BASE_URL=http://127.0.0.1:8787 node tests/contract/run.mjs
+          CONTRACT_BASE_URL=http://127.0.0.1:8787 node tests/unconfigured_public_read_worker_test.mjs
 
   ktor-contract:
     runs-on: ubuntu-latest

--- a/api-rs/src/error.rs
+++ b/api-rs/src/error.rs
@@ -73,6 +73,13 @@ impl ApiError {
     pub fn internal() -> Self {
         Self::new(500, "internal", "Internal server error")
     }
+    pub fn service_unavailable() -> Self {
+        Self::new(
+            503,
+            "service_unavailable",
+            "Service temporarily unavailable",
+        )
+    }
 
     pub fn status(&self) -> u16 {
         self.status
@@ -109,5 +116,6 @@ mod tests {
         assert_eq!(ApiError::unauthorized().status(), 401);
         assert_eq!(ApiError::forbidden().status(), 403);
         assert_eq!(ApiError::internal().status(), 500);
+        assert_eq!(ApiError::service_unavailable().status(), 503);
     }
 }

--- a/api-rs/src/lib.rs
+++ b/api-rs/src/lib.rs
@@ -3,6 +3,7 @@ pub mod domain;
 pub mod error;
 pub mod ids;
 pub mod json_column;
+pub mod public_read;
 pub mod repositories;
 pub mod time;
 use worker::{
@@ -79,6 +80,14 @@ pub async fn fetch(request: Request, env: Env, _ctx: Context) -> Result<Response
             .map(|response| response.with_headers(content_type("application/yaml"))),
         "/api/openapi-admin.yaml" => Response::ok(ADMIN_OPENAPI)
             .map(|response| response.with_headers(content_type("application/yaml"))),
+        "/api/stats" => match env.d1("DB") {
+            Ok(db) => Response::from_json(&public_read::stats(&db).await?),
+            Err(_) => error::ApiError::service_unavailable().response(),
+        },
+        "/api/categories" => match env.d1("DB") {
+            Ok(db) => Response::from_json(&public_read::categories(&db).await?),
+            Err(_) => error::ApiError::service_unavailable().response(),
+        },
         _ => Response::error("Not Found", 404),
     }
 }

--- a/api-rs/src/public_read.rs
+++ b/api-rs/src/public_read.rs
@@ -1,0 +1,91 @@
+//! Public D1-backed read models and queries.
+//!
+//! These endpoints intentionally use aggregate SQL rather than loading skills into the Worker:
+//! D1 remains responsible for filtering public rows and computing counts.
+
+use serde::{Deserialize, Serialize};
+use worker::{D1Database, Error, Result};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StatsResponse {
+    pub indexed: i64,
+    pub contributors: i64,
+    pub last_updated: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct CategoryWithCount {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct StatsRow {
+    indexed: i64,
+    contributors: i64,
+    last_updated: Option<String>,
+}
+
+/// Matches Ktor's public `stats()` query: only published skills influence every aggregate.
+pub async fn stats(db: &D1Database) -> Result<StatsResponse> {
+    let row: Option<StatsRow> = db
+        .prepare(
+            "SELECT COUNT(*) AS indexed, \
+                    COUNT(DISTINCT bundles.owner_user_id) AS contributors, \
+                    MAX(skills.updated_at) AS last_updated \
+             FROM skills \
+             INNER JOIN bundles ON bundles.id = skills.bundle_id \
+             WHERE skills.status = 'published'",
+        )
+        .first(None)
+        .await?;
+    let row = row.ok_or_else(|| Error::RustError("stats aggregate returned no row".into()))?;
+    Ok(StatsResponse {
+        indexed: row.indexed,
+        contributors: row.contributors,
+        last_updated: row.last_updated,
+    })
+}
+
+/// Returns every seeded category, including categories which currently have no public skills.
+pub async fn categories(db: &D1Database) -> Result<Vec<CategoryWithCount>> {
+    db.prepare(
+        "SELECT categories.id, categories.slug, categories.name, COUNT(skills.id) AS count \
+         FROM categories \
+         LEFT JOIN skills ON skills.category_id = categories.id AND skills.status = 'published' \
+         GROUP BY categories.id, categories.slug, categories.name \
+         ORDER BY categories.name",
+    )
+    .all()
+    .await?
+    .results()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CategoryWithCount, StatsResponse};
+
+    #[test]
+    fn public_payloads_keep_the_openapi_camel_case_shape() {
+        let stats = serde_json::to_value(StatsResponse {
+            indexed: 6,
+            contributors: 2,
+            last_updated: Some("2026-01-01T00:00:00Z".into()),
+        })
+        .unwrap();
+        assert_eq!(stats["lastUpdated"], "2026-01-01T00:00:00Z");
+        assert!(stats.get("last_updated").is_none());
+
+        let category = serde_json::to_value(CategoryWithCount {
+            id: "category".into(),
+            slug: "testing-qa".into(),
+            name: "Testing & QA".into(),
+            count: 1,
+        })
+        .unwrap();
+        assert_eq!(category["count"], 1);
+    }
+}

--- a/api-rs/tests/d1_public_read_worker_test.mjs
+++ b/api-rs/tests/d1_public_read_worker_test.mjs
@@ -1,0 +1,109 @@
+/** Public read routes exercised against the real local Worker and seeded D1 catalogue. */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const base = process.env.CONTRACT_BASE_URL ?? "http://127.0.0.1:8788";
+const root = resolve(import.meta.dirname, "../..");
+const catalogue = JSON.parse(
+  readFileSync(
+    resolve(root, "api/src/main/resources/seed/real-skills.json"),
+    "utf8",
+  ),
+);
+const categorySnapshot = JSON.parse(
+  readFileSync(
+    resolve(root, "api/src/test/resources/schema-v5-compatibility.json"),
+    "utf8",
+  ),
+);
+const categoryCounts = new Map();
+for (const skill of catalogue.skills)
+  categoryCounts.set(
+    skill.category,
+    (categoryCounts.get(skill.category) ?? 0) + 1,
+  );
+const contributorCount = new Set(
+  catalogue.bundles.map((bundle) => bundle.author),
+).size;
+const wrangler = resolve(
+  import.meta.dirname,
+  "../node_modules/wrangler/bin/wrangler.js",
+);
+const mutateD1 = (command) =>
+  execFileSync(
+    process.execPath,
+    [
+      wrangler,
+      "d1",
+      "execute",
+      "androidskills",
+      "--local",
+      "--config",
+      "wrangler.d1.local.toml",
+      "--command",
+      command,
+    ],
+    { cwd: resolve(import.meta.dirname, ".."), stdio: "pipe" },
+  );
+
+const stats = await fetch(`${base}/api/stats`);
+assert.equal(stats.status, 200);
+assert.match(stats.headers.get("content-type") ?? "", /application\/json/);
+assert.deepEqual(await stats.json(), {
+  indexed: catalogue.skills.length,
+  contributors: contributorCount,
+  lastUpdated: "2026-01-01T00:00:00Z",
+});
+
+const categories = await fetch(`${base}/api/categories`);
+assert.equal(categories.status, 200);
+const body = await categories.json();
+assert.equal(body.length, Object.keys(categorySnapshot.categories).length);
+assert.deepEqual(
+  body.map((category) => category.name),
+  [...body.map((category) => category.name)].sort(),
+);
+assert.equal(
+  body.reduce((sum, category) => sum + category.count, 0),
+  catalogue.skills.length,
+);
+assert.deepEqual(
+  body.find((category) => category.slug === "jetpack-compose"),
+  {
+    id: "3c9572b4-3e39-4e0a-a0cb-0a7078522e00",
+    slug: "jetpack-compose",
+    name: "Jetpack Compose",
+    count: categoryCounts.get("jetpack-compose") ?? 0,
+  },
+);
+assert.equal(
+  body.find((category) => category.slug === "uncategorized")?.count,
+  categoryCounts.get("uncategorized") ?? 0,
+);
+
+// The seed starts entirely published, so explicitly change one row to prove both aggregates do
+// not leak an unlisted skill. The fixture is restored for subsequent local runs.
+const hidden = catalogue.skills[0];
+mutateD1("UPDATE skills SET status = 'unlisted' WHERE id = 'fixture-skill-0'");
+try {
+  const hiddenStats = await fetch(`${base}/api/stats`);
+  assert.equal((await hiddenStats.json()).indexed, catalogue.skills.length - 1);
+  const hiddenCategories = await fetch(`${base}/api/categories`);
+  const hiddenBody = await hiddenCategories.json();
+  assert.equal(
+    hiddenBody.reduce((sum, category) => sum + category.count, 0),
+    catalogue.skills.length - 1,
+  );
+  assert.equal(
+    hiddenBody.find((category) => category.slug === hidden.category)?.count,
+    (categoryCounts.get(hidden.category) ?? 0) - 1,
+  );
+} finally {
+  mutateD1(
+    "UPDATE skills SET status = 'published' WHERE id = 'fixture-skill-0'",
+  );
+}
+
+console.log("D1 Worker public-read routes verified.");

--- a/api-rs/tests/unconfigured_public_read_worker_test.mjs
+++ b/api-rs/tests/unconfigured_public_read_worker_test.mjs
@@ -1,0 +1,18 @@
+/** Public D1 reads must fail safely until the production binding is provisioned. */
+import assert from "node:assert/strict";
+
+const base = process.env.CONTRACT_BASE_URL ?? "http://127.0.0.1:8787";
+
+for (const path of ["/api/stats", "/api/categories"]) {
+  const response = await fetch(`${base}${path}`);
+  assert.equal(response.status, 503, path);
+  assert.match(response.headers.get("content-type") ?? "", /application\/json/);
+  assert.deepEqual(await response.json(), {
+    error: {
+      code: "service_unavailable",
+      message: "Service temporarily unavailable",
+    },
+  });
+}
+
+console.log("Unconfigured public-read routes fail safely.");


### PR DESCRIPTION
## Summary

- Add Worker `GET /api/stats` and `GET /api/categories` backed by D1 aggregate queries.
- Preserve the Kotlin/OpenAPI payloads, camel-case names, seeded empty categories, and published-only visibility.
- Add account-free local Worker/D1 smoke coverage using the real 121-skill catalogue, including an unlisted-row exclusion check.
- Return the stable `503 service_unavailable` envelope for these routes until the production D1 binding is provisioned in the Cloudflare-authorized slice.

## Kotlin behavior covered

- `PublicReadTest.stats reflect seeded data`
- `PublicReadTest.stats lastUpdated ignores non-public skills`
- `PublicReadTest.categories list counts published skills`
- `PublicRoutesHttpTest.skillsListDetailCategoriesAndErrorEnvelope` (categories route wiring)

## Validation

- `cargo fmt --check`
- `cargo test --locked --lib` (17 tests)
- `cargo check --locked --target wasm32-unknown-unknown`
- `cargo clippy --locked --all-targets -- -D warnings`
- Local D1 migration/catalogue harness and live bound Worker smoke
- Live ordinary Worker smoke for the intentional unconfigured-binding `503` contract
- Prettier and whitespace checks

## Review gates

Two isolated Sol-high reviews found and then verified fixes for binding-safe behavior and public-only aggregate coverage. Fresh alignment and adversarial re-reviews are clean.
