### PR TITLE
feat(worker): add public skill read routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
           fi
           node tests/d1_repository_worker_test.mjs
           node tests/d1_public_read_worker_test.mjs
+          node tests/d1_skill_read_worker_test.mjs
       - name: Build the Wasm Worker
         run: npx wrangler deploy --dry-run
       - name: Start the local Workers runtime

--- a/api-rs/src/lib.rs
+++ b/api-rs/src/lib.rs
@@ -88,6 +88,22 @@ pub async fn fetch(request: Request, env: Env, _ctx: Context) -> Result<Response
             Ok(db) => Response::from_json(&public_read::categories(&db).await?),
             Err(_) => error::ApiError::service_unavailable().response(),
         },
+        "/api/skills" => match env.d1("DB") {
+            Ok(db) => match public_read::SearchParams::from_url(&request.url()?) {
+                Ok(params) => Response::from_json(&public_read::search(&db, &params).await?),
+                Err(error) => error.response(),
+            },
+            Err(_) => error::ApiError::service_unavailable().response(),
+        },
+        path if path.starts_with("/api/skills/") => match env.d1("DB") {
+            Ok(db) => match public_read::skill_detail(&db, path.trim_start_matches("/api/skills/"))
+                .await?
+            {
+                Some(skill) => Response::from_json(&skill),
+                None => error::ApiError::not_found().response(),
+            },
+            Err(_) => error::ApiError::service_unavailable().response(),
+        },
         _ => Response::error("Not Found", 404),
     }
 }

--- a/api-rs/src/public_read.rs
+++ b/api-rs/src/public_read.rs
@@ -3,8 +3,12 @@
 //! These endpoints intentionally use aggregate SQL rather than loading skills into the Worker:
 //! D1 remains responsible for filtering public rows and computing counts.
 
+use std::collections::{BTreeMap, HashMap};
+
 use serde::{Deserialize, Serialize};
-use worker::{D1Database, Error, Result};
+use worker::{wasm_bindgen::JsValue, D1Database, Error, Result};
+
+use crate::{domain::PageRequest, error::ApiError};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -20,6 +24,118 @@ pub struct CategoryWithCount {
     pub slug: String,
     pub name: String,
     pub count: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchParams {
+    pub q: Option<String>,
+    pub categories: Vec<String>,
+    pub tags: Vec<String>,
+    pub size: Option<SizeFilter>,
+    pub verified: bool,
+    pub sort: Sort,
+    pub page: u32,
+    pub page_size: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SizeFilter {
+    Small,
+    Medium,
+    Large,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sort {
+    Relevance,
+    Installs,
+    Updated,
+    Tokens,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillSearchPage {
+    pub items: Vec<SkillCard>,
+    pub page: u32,
+    pub page_size: u32,
+    pub total: i64,
+    pub total_pages: i64,
+    pub facets: Facets,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SkillCard {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub description: String,
+    pub license: Option<String>,
+    pub tags: Vec<String>,
+    pub category: Option<CategoryRef>,
+    pub version: String,
+    #[serde(rename = "versionSource")]
+    pub version_source: String,
+    #[serde(rename = "tokenUpfront")]
+    pub token_upfront: i64,
+    #[serde(rename = "tokenOndemand")]
+    pub token_ondemand: i64,
+    #[serde(rename = "tokenBand")]
+    pub token_band: String,
+    pub verified: bool,
+    pub status: String,
+    pub featured: bool,
+    pub installs: i64,
+    pub author: AuthorRef,
+    pub bundle: BundleRef,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CategoryRef {
+    pub slug: String,
+    pub name: String,
+}
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AuthorRef {
+    pub handle: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "avatarUrl", skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
+}
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BundleRef {
+    pub id: String,
+    pub kind: String,
+    pub provenance: String,
+}
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FacetCount {
+    pub key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub count: i64,
+}
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Facets {
+    pub categories: Vec<FacetCount>,
+    pub tags: Vec<FacetCount>,
+    pub sizes: Vec<FacetCount>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillDetail {
+    #[serde(flatten)]
+    pub card: SkillCard,
+    pub readme_md: Option<String>,
+    pub file_count: i64,
+    pub total_size: i64,
+    pub security_notes: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -64,9 +180,424 @@ pub async fn categories(db: &D1Database) -> Result<Vec<CategoryWithCount>> {
     .results()
 }
 
+impl SearchParams {
+    pub fn from_url(url: &worker::Url) -> std::result::Result<Self, ApiError> {
+        let pairs = url.query_pairs().into_owned().collect::<Vec<_>>();
+        let values = |key: &str| {
+            let direct = pairs
+                .iter()
+                .filter(|(name, _)| name == key)
+                .map(|(_, value)| value.clone())
+                .collect::<Vec<_>>();
+            let source = if direct.is_empty() {
+                pairs
+                    .iter()
+                    .filter(|(name, _)| name == &format!("{key}[]"))
+                    .map(|(_, value)| value.clone())
+                    .collect::<Vec<_>>()
+            } else {
+                direct
+            };
+            source
+                .into_iter()
+                .filter(|value| !value.trim().is_empty())
+                .collect()
+        };
+        let one = |key: &str| {
+            pairs
+                .iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value.clone())
+        };
+        let invalid = |field: &str, message: &str| {
+            ApiError::validation(
+                "validation_failed",
+                format!("Invalid '{field}'"),
+                BTreeMap::from([(field.into(), message.into())]),
+            )
+        };
+        let verified = match one("verified")
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            None | Some("true" | "1" | "yes") => true,
+            Some("false" | "0" | "no") => false,
+            _ => return Err(invalid("verified", "must be one of true|false")),
+        };
+        let size = match one("size").as_deref() {
+            None => None,
+            Some("<2k") => Some(SizeFilter::Small),
+            Some("2-5k") => Some(SizeFilter::Medium),
+            Some("5k+") => Some(SizeFilter::Large),
+            _ => return Err(invalid("size", "must be one of <2k|2-5k|5k+")),
+        };
+        let sort = match one("sort").as_deref() {
+            None | Some("relevance") => Sort::Relevance,
+            Some("installs") => Sort::Installs,
+            Some("updated") => Sort::Updated,
+            Some("tokens") => Sort::Tokens,
+            _ => {
+                return Err(invalid(
+                    "sort",
+                    "must be one of relevance|installs|updated|tokens",
+                ))
+            }
+        };
+        let positive = |key: &str, default: u32, max: u32| -> std::result::Result<u32, ApiError> {
+            match one(key) {
+                None => Ok(default),
+                Some(value) => value
+                    .parse::<u32>()
+                    .ok()
+                    .filter(|value| *value > 0 && *value <= max)
+                    .ok_or_else(|| invalid(key, &format!("must be 1..{max}"))),
+            }
+        };
+        let page = positive("page", 1, PageRequest::MAX_PAGE)?;
+        let page_size = positive(
+            "pageSize",
+            PageRequest::DEFAULT_PAGE_SIZE,
+            PageRequest::MAX_PAGE_SIZE,
+        )?;
+        Ok(Self {
+            q: one("q")
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty()),
+            categories: values("cat"),
+            tags: values("tag"),
+            size,
+            verified,
+            sort,
+            page,
+            page_size,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CardRow {
+    id: String,
+    slug: String,
+    name: String,
+    description: String,
+    license: Option<String>,
+    tags: String,
+    version: String,
+    version_source: String,
+    token_upfront: i64,
+    token_ondemand: i64,
+    token_band: String,
+    verified: i64,
+    status: String,
+    featured: i64,
+    installs: i64,
+    created_at: String,
+    updated_at: String,
+    category_slug: Option<String>,
+    category_name: Option<String>,
+    bundle_id: String,
+    bundle_kind: String,
+    bundle_provenance: String,
+    author_handle: String,
+    author_name: Option<String>,
+    author_avatar_url: Option<String>,
+    readme_md: Option<String>,
+    security: Option<String>,
+    file_count: i64,
+    total_size: i64,
+}
+
+const CARD_SELECT: &str = "SELECT s.id, s.slug, s.name, s.description, s.license, s.tags, s.version, s.version_source, s.token_upfront, s.token_ondemand, s.token_band, s.verified, s.status, s.featured, s.installs, s.created_at, s.updated_at, c.slug AS category_slug, c.name AS category_name, b.id AS bundle_id, b.kind AS bundle_kind, b.provenance AS bundle_provenance, u.handle AS author_handle, u.name AS author_name, u.avatar_url AS author_avatar_url, s.readme_md, s.security, COUNT(f.id) AS file_count, COALESCE(SUM(f.size), 0) AS total_size FROM skills s INNER JOIN bundles b ON b.id=s.bundle_id INNER JOIN users u ON u.id=b.owner_user_id LEFT JOIN categories c ON c.id=s.category_id LEFT JOIN skill_files f ON f.skill_id=s.id";
+
+pub async fn search(db: &D1Database, params: &SearchParams) -> Result<SkillSearchPage> {
+    let (where_sql, bindings) = filters(params, false, false, false);
+    let total: Option<CountRow> = db
+        .prepare(format!(
+            "SELECT COUNT(*) AS count FROM skills s WHERE {where_sql}"
+        ))
+        .bind(&bindings)?
+        .first(None)
+        .await?;
+    let total = total.map_or(0, |row| row.count);
+    let order = order_by(params);
+    let mut bindings = bindings;
+    if params.sort == Sort::Relevance && params.q.is_some() {
+        bindings.push(JsValue::from_str(&format!(
+            "%{}%",
+            params.q.as_ref().unwrap().replace(['%', '_'], "")
+        )));
+    }
+    bindings.push(JsValue::from_f64(params.page_size.into()));
+    bindings.push(JsValue::from_f64(
+        ((params.page - 1) * params.page_size).into(),
+    ));
+    let rows: Vec<CardRow> = db
+        .prepare(format!(
+            "{CARD_SELECT} WHERE {where_sql} GROUP BY s.id ORDER BY {order} LIMIT ? OFFSET ?"
+        ))
+        .bind(&bindings)?
+        .all()
+        .await?
+        .results()?;
+    let (categories, tags, sizes) = facets(db, params).await?;
+    Ok(SkillSearchPage {
+        items: rows.into_iter().map(card).collect(),
+        page: params.page,
+        page_size: params.page_size,
+        total,
+        total_pages: (total + i64::from(params.page_size) - 1) / i64::from(params.page_size),
+        facets: Facets {
+            categories,
+            tags,
+            sizes,
+        },
+    })
+}
+
+pub async fn skill_detail(db: &D1Database, slug: &str) -> Result<Option<SkillDetail>> {
+    let rows: Vec<CardRow> = db
+        .prepare(format!(
+            "{CARD_SELECT} WHERE s.slug = ? AND s.status = 'published' GROUP BY s.id"
+        ))
+        .bind(&[JsValue::from_str(slug)])?
+        .all()
+        .await?
+        .results()?;
+    Ok(rows.into_iter().next().map(|row| SkillDetail {
+        readme_md: row.readme_md.clone(),
+        file_count: row.file_count,
+        total_size: row.total_size,
+        security_notes: row
+            .security
+            .as_deref()
+            .and_then(|raw| serde_json::from_str(raw).ok())
+            .unwrap_or_default(),
+        card: card(row),
+    }))
+}
+
+#[derive(Deserialize)]
+struct CountRow {
+    count: i64,
+}
+
+fn card(row: CardRow) -> SkillCard {
+    SkillCard {
+        id: row.id,
+        slug: row.slug,
+        name: row.name,
+        description: row.description,
+        license: row.license,
+        tags: serde_json::from_str(&row.tags).unwrap_or_default(),
+        category: row
+            .category_slug
+            .zip(row.category_name)
+            .map(|(slug, name)| CategoryRef { slug, name }),
+        version: row.version,
+        version_source: row.version_source,
+        token_upfront: row.token_upfront,
+        token_ondemand: row.token_ondemand,
+        token_band: row.token_band,
+        verified: row.verified == 1,
+        status: row.status,
+        featured: row.featured == 1,
+        installs: row.installs,
+        author: AuthorRef {
+            handle: row.author_handle,
+            name: row.author_name,
+            avatar_url: row.author_avatar_url,
+        },
+        bundle: BundleRef {
+            id: row.bundle_id,
+            kind: row.bundle_kind,
+            provenance: row.bundle_provenance,
+        },
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    }
+}
+
+fn filters(
+    params: &SearchParams,
+    exclude_categories: bool,
+    exclude_tags: bool,
+    exclude_size: bool,
+) -> (String, Vec<JsValue>) {
+    let mut clauses = vec!["s.status = 'published'".to_owned()];
+    let mut values = Vec::new();
+    if params.verified {
+        clauses.push("s.verified = 1".into());
+    }
+    if let Some(query) = &params.q {
+        let pattern = format!("%{}%", query.replace(['%', '_'], ""));
+        clauses.push(
+            "(s.tags LIKE ? OR LOWER(s.name) LIKE LOWER(?) OR LOWER(s.description) LIKE LOWER(?))"
+                .into(),
+        );
+        for _ in 0..3 {
+            values.push(JsValue::from_str(&pattern));
+        }
+    }
+    if !exclude_categories && !params.categories.is_empty() {
+        clauses.push(format!(
+            "s.category_id IN (SELECT id FROM categories WHERE slug IN ({}))",
+            placeholders(params.categories.len())
+        ));
+        values.extend(
+            params
+                .categories
+                .iter()
+                .map(|value| JsValue::from_str(value)),
+        );
+    }
+    if !exclude_tags && !params.tags.is_empty() {
+        clauses.push(format!(
+            "({})",
+            params
+                .tags
+                .iter()
+                .map(|_| "s.tags LIKE ?")
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        ));
+        values.extend(
+            params
+                .tags
+                .iter()
+                .map(|tag| JsValue::from_str(&format!("%\"{}\"%", tag.replace(['%', '_'], "")))),
+        );
+    }
+    if !exclude_size {
+        if let Some(size) = params.size {
+            clauses.push(
+                match size {
+                    SizeFilter::Small => "s.token_upfront + s.token_ondemand < 2000",
+                    SizeFilter::Medium => {
+                        "s.token_upfront + s.token_ondemand BETWEEN 2000 AND 5000"
+                    }
+                    SizeFilter::Large => "s.token_upfront + s.token_ondemand > 5000",
+                }
+                .into(),
+            );
+        }
+    }
+    (clauses.join(" AND "), values)
+}
+fn placeholders(count: usize) -> String {
+    std::iter::repeat_n("?", count)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+fn order_by(params: &SearchParams) -> &'static str {
+    match params.sort {
+        Sort::Installs => "s.installs DESC, s.updated_at DESC",
+        Sort::Updated => "s.updated_at DESC",
+        Sort::Tokens => "s.token_upfront + s.token_ondemand ASC, s.name ASC",
+        Sort::Relevance if params.q.is_some() => {
+            "(LOWER(s.name) LIKE LOWER(?)) DESC, s.installs DESC, s.updated_at DESC"
+        }
+        Sort::Relevance => "s.featured DESC, s.installs DESC, s.updated_at DESC",
+    }
+}
+
+async fn facets(
+    db: &D1Database,
+    params: &SearchParams,
+) -> Result<(Vec<FacetCount>, Vec<FacetCount>, Vec<FacetCount>)> {
+    let (category_where, category_bindings) = filters(params, true, false, false);
+    let category_rows: Vec<FacetRow> = db.prepare(format!("SELECT COALESCE(c.slug, 'uncategorized') AS key, COALESCE(c.name, 'Uncategorized') AS label, COUNT(*) AS count FROM skills s LEFT JOIN categories c ON c.id=s.category_id WHERE {category_where} GROUP BY s.category_id ORDER BY count DESC")).bind(&category_bindings)?.all().await?.results()?;
+    let (tag_where, tag_bindings) = filters(params, false, true, false);
+    let tag_rows: Vec<TagRow> = db
+        .prepare(format!("SELECT s.tags FROM skills s WHERE {tag_where}"))
+        .bind(&tag_bindings)?
+        .all()
+        .await?
+        .results()?;
+    let mut tag_counts = HashMap::<String, i64>::new();
+    for row in tag_rows {
+        for tag in serde_json::from_str::<Vec<String>>(&row.tags).unwrap_or_default() {
+            *tag_counts.entry(tag).or_default() += 1;
+        }
+    }
+    let mut tags = tag_counts
+        .into_iter()
+        .map(|(key, count)| FacetCount {
+            key,
+            label: None,
+            count,
+        })
+        .collect::<Vec<_>>();
+    tags.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.key.cmp(&right.key))
+    });
+    tags.truncate(20);
+    let (size_where, size_bindings) = filters(params, false, false, true);
+    let size_rows: Vec<TokenRow> = db
+        .prepare(format!(
+            "SELECT s.token_upfront, s.token_ondemand FROM skills s WHERE {size_where}"
+        ))
+        .bind(&size_bindings)?
+        .all()
+        .await?
+        .results()?;
+    let mut size_counts = [0_i64; 3];
+    for row in size_rows {
+        let total = row.token_upfront + row.token_ondemand;
+        size_counts[if total < 2000 {
+            0
+        } else if total <= 5000 {
+            1
+        } else {
+            2
+        }] += 1;
+    }
+    Ok((
+        category_rows
+            .into_iter()
+            .map(|row| FacetCount {
+                key: row.key,
+                label: Some(row.label),
+                count: row.count,
+            })
+            .collect(),
+        tags,
+        ["<2k", "2-5k", "5k+"]
+            .into_iter()
+            .zip(size_counts)
+            .map(|(key, count)| FacetCount {
+                key: key.into(),
+                label: None,
+                count,
+            })
+            .collect(),
+    ))
+}
+#[derive(Deserialize)]
+struct FacetRow {
+    key: String,
+    label: String,
+    count: i64,
+}
+#[derive(Deserialize)]
+struct TagRow {
+    tags: String,
+}
+#[derive(Deserialize)]
+struct TokenRow {
+    token_upfront: i64,
+    token_ondemand: i64,
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CategoryWithCount, StatsResponse};
+    use super::{
+        AuthorRef, BundleRef, CategoryWithCount, SearchParams, SkillCard, SkillDetail,
+        StatsResponse,
+    };
 
     #[test]
     fn public_payloads_keep_the_openapi_camel_case_shape() {
@@ -87,5 +618,76 @@ mod tests {
         })
         .unwrap();
         assert_eq!(category["count"], 1);
+    }
+
+    #[test]
+    fn search_parser_preserves_the_kotlin_query_contract() {
+        let url = worker::Url::parse("https://example.test/api/skills?cat=build-ci&cat[]=testing-qa&tag=Android&verified=no&size=2-5k&sort=tokens&page=2&pageSize=10&q=compose").unwrap();
+        let params = SearchParams::from_url(&url).unwrap();
+        assert_eq!(params.categories, ["build-ci"]);
+        assert_eq!(params.tags, ["Android"]);
+        assert!(!params.verified);
+        assert_eq!(params.page, 2);
+        assert_eq!(params.page_size, 10);
+        assert_eq!(params.q.as_deref(), Some("compose"));
+        let mixed = SearchParams::from_url(
+            &worker::Url::parse("https://example.test/api/skills?cat=plain&cat[]=bracketed")
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(mixed.categories, ["plain"]);
+        assert!(SearchParams::from_url(
+            &worker::Url::parse("https://example.test/api/skills?verified=maybe").unwrap()
+        )
+        .is_err());
+        assert!(SearchParams::from_url(
+            &worker::Url::parse("https://example.test/api/skills?page=0").unwrap()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn required_nullable_skill_fields_are_encoded_as_null() {
+        let card = SkillCard {
+            id: "id".into(),
+            slug: "slug".into(),
+            name: "name".into(),
+            description: "description".into(),
+            license: None,
+            tags: vec![],
+            category: None,
+            version: "1".into(),
+            version_source: "manifest".into(),
+            token_upfront: 0,
+            token_ondemand: 0,
+            token_band: "100s".into(),
+            verified: true,
+            status: "published".into(),
+            featured: false,
+            installs: 0,
+            author: AuthorRef {
+                handle: "author".into(),
+                name: None,
+                avatar_url: None,
+            },
+            bundle: BundleRef {
+                id: "bundle".into(),
+                kind: "repo".into(),
+                provenance: "repo/name".into(),
+            },
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+        };
+        let encoded = serde_json::to_value(SkillDetail {
+            card,
+            readme_md: None,
+            file_count: 0,
+            total_size: 0,
+            security_notes: vec![],
+        })
+        .unwrap();
+        assert!(encoded.get("license").unwrap().is_null());
+        assert!(encoded.get("category").unwrap().is_null());
+        assert!(encoded.get("readmeMd").unwrap().is_null());
     }
 }

--- a/api-rs/src/public_read.rs
+++ b/api-rs/src/public_read.rs
@@ -302,13 +302,20 @@ struct CardRow {
     author_handle: String,
     author_name: Option<String>,
     author_avatar_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DetailRow {
+    #[serde(flatten)]
+    card: CardRow,
     readme_md: Option<String>,
     security: Option<String>,
     file_count: i64,
     total_size: i64,
 }
 
-const CARD_SELECT: &str = "SELECT s.id, s.slug, s.name, s.description, s.license, s.tags, s.version, s.version_source, s.token_upfront, s.token_ondemand, s.token_band, s.verified, s.status, s.featured, s.installs, s.created_at, s.updated_at, c.slug AS category_slug, c.name AS category_name, b.id AS bundle_id, b.kind AS bundle_kind, b.provenance AS bundle_provenance, u.handle AS author_handle, u.name AS author_name, u.avatar_url AS author_avatar_url, s.readme_md, s.security, COUNT(f.id) AS file_count, COALESCE(SUM(f.size), 0) AS total_size FROM skills s INNER JOIN bundles b ON b.id=s.bundle_id INNER JOIN users u ON u.id=b.owner_user_id LEFT JOIN categories c ON c.id=s.category_id LEFT JOIN skill_files f ON f.skill_id=s.id";
+const CARD_SELECT: &str = "SELECT s.id, s.slug, s.name, s.description, s.license, s.tags, s.version, s.version_source, s.token_upfront, s.token_ondemand, s.token_band, s.verified, s.status, s.featured, s.installs, s.created_at, s.updated_at, c.slug AS category_slug, c.name AS category_name, b.id AS bundle_id, b.kind AS bundle_kind, b.provenance AS bundle_provenance, u.handle AS author_handle, u.name AS author_name, u.avatar_url AS author_avatar_url FROM skills s INNER JOIN bundles b ON b.id=s.bundle_id INNER JOIN users u ON u.id=b.owner_user_id LEFT JOIN categories c ON c.id=s.category_id";
+const DETAIL_SELECT: &str = "SELECT s.id, s.slug, s.name, s.description, s.license, s.tags, s.version, s.version_source, s.token_upfront, s.token_ondemand, s.token_band, s.verified, s.status, s.featured, s.installs, s.created_at, s.updated_at, c.slug AS category_slug, c.name AS category_name, b.id AS bundle_id, b.kind AS bundle_kind, b.provenance AS bundle_provenance, u.handle AS author_handle, u.name AS author_name, u.avatar_url AS author_avatar_url, s.readme_md, s.security, COUNT(f.id) AS file_count, COALESCE(SUM(f.size), 0) AS total_size FROM skills s INNER JOIN bundles b ON b.id=s.bundle_id INNER JOIN users u ON u.id=b.owner_user_id LEFT JOIN categories c ON c.id=s.category_id LEFT JOIN skill_files f ON f.skill_id=s.id";
 
 pub async fn search(db: &D1Database, params: &SearchParams) -> Result<SkillSearchPage> {
     let (where_sql, bindings) = filters(params, false, false, false);
@@ -334,7 +341,7 @@ pub async fn search(db: &D1Database, params: &SearchParams) -> Result<SkillSearc
     ));
     let rows: Vec<CardRow> = db
         .prepare(format!(
-            "{CARD_SELECT} WHERE {where_sql} GROUP BY s.id ORDER BY {order} LIMIT ? OFFSET ?"
+            "{CARD_SELECT} WHERE {where_sql} ORDER BY {order} LIMIT ? OFFSET ?"
         ))
         .bind(&bindings)?
         .all()
@@ -356,16 +363,16 @@ pub async fn search(db: &D1Database, params: &SearchParams) -> Result<SkillSearc
 }
 
 pub async fn skill_detail(db: &D1Database, slug: &str) -> Result<Option<SkillDetail>> {
-    let rows: Vec<CardRow> = db
+    let rows: Vec<DetailRow> = db
         .prepare(format!(
-            "{CARD_SELECT} WHERE s.slug = ? AND s.status = 'published' GROUP BY s.id"
+            "{DETAIL_SELECT} WHERE s.slug = ? AND s.status = 'published' GROUP BY s.id"
         ))
         .bind(&[JsValue::from_str(slug)])?
         .all()
         .await?
         .results()?;
     Ok(rows.into_iter().next().map(|row| SkillDetail {
-        readme_md: row.readme_md.clone(),
+        readme_md: row.readme_md,
         file_count: row.file_count,
         total_size: row.total_size,
         security_notes: row
@@ -373,7 +380,7 @@ pub async fn skill_detail(db: &D1Database, slug: &str) -> Result<Option<SkillDet
             .as_deref()
             .and_then(|raw| serde_json::from_str(raw).ok())
             .unwrap_or_default(),
-        card: card(row),
+        card: card(row.card),
     }))
 }
 
@@ -689,5 +696,22 @@ mod tests {
         assert!(encoded.get("license").unwrap().is_null());
         assert!(encoded.get("category").unwrap().is_null());
         assert!(encoded.get("readmeMd").unwrap().is_null());
+    }
+
+    #[test]
+    fn list_card_select_does_not_over_fetch_detail_columns() {
+        use super::{CARD_SELECT, DETAIL_SELECT};
+        assert!(
+            !CARD_SELECT.contains("readme_md")
+                && !CARD_SELECT.contains("security")
+                && !CARD_SELECT.contains("skill_files")
+                && !CARD_SELECT.contains("file_count")
+        );
+        assert!(
+            DETAIL_SELECT.contains("readme_md")
+                && DETAIL_SELECT.contains("security")
+                && DETAIL_SELECT.contains("skill_files")
+                && DETAIL_SELECT.contains("file_count")
+        );
     }
 }

--- a/api-rs/tests/d1_skill_read_worker_test.mjs
+++ b/api-rs/tests/d1_skill_read_worker_test.mjs
@@ -1,0 +1,66 @@
+/** Search and detail routes exercised against the real local Worker and catalogue D1 fixture. */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const base = process.env.CONTRACT_BASE_URL ?? "http://127.0.0.1:8788";
+const root = resolve(import.meta.dirname, "../..");
+const catalogue = JSON.parse(
+  readFileSync(
+    resolve(root, "api/src/main/resources/seed/real-skills.json"),
+    "utf8",
+  ),
+);
+
+const list = await fetch(
+  `${base}/api/skills?verified=false&pageSize=2&sort=tokens`,
+);
+assert.equal(list.status, 200);
+const page = await list.json();
+assert.equal(page.page, 1);
+assert.equal(page.pageSize, 2);
+assert.equal(page.total, catalogue.skills.length);
+assert.equal(page.items.length, 2);
+assert.ok(
+  page.items[0].tokenUpfront + page.items[0].tokenOndemand <=
+    page.items[1].tokenUpfront + page.items[1].tokenOndemand,
+);
+assert.ok(page.facets.categories.length > 0 && page.facets.tags.length > 0);
+
+const known = catalogue.skills[0];
+const detail = await fetch(`${base}/api/skills/${known.slug}`);
+assert.equal(detail.status, 200);
+const skill = await detail.json();
+assert.equal(skill.slug, known.slug);
+assert.equal(skill.name, known.name);
+assert.deepEqual(skill.tags, known.tags);
+assert.equal(skill.status, "published");
+assert.ok(skill.author.handle && skill.bundle.id && skill.fileCount >= 1);
+
+const filtered = await fetch(
+  `${base}/api/skills?verified=false&cat=${encodeURIComponent(known.category)}&pageSize=60`,
+);
+assert.equal(filtered.status, 200);
+assert.ok(
+  (await filtered.json()).items.every(
+    (item) => item.category?.slug === known.category,
+  ),
+);
+
+const matching = await fetch(
+  `${base}/api/skills?q=${encodeURIComponent(known.name.split(" ")[0])}&verified=false`,
+);
+assert.equal(matching.status, 200);
+assert.ok(
+  (await matching.json()).items.some((item) => item.slug === known.slug),
+);
+
+const invalid = await fetch(`${base}/api/skills?sort=made-up`);
+assert.equal(invalid.status, 422);
+assert.equal((await invalid.json()).error.code, "validation_failed");
+
+const missing = await fetch(`${base}/api/skills/does-not-exist`);
+assert.equal(missing.status, 404);
+assert.equal((await missing.json()).error.code, "not_found");
+
+console.log("D1 Worker search and detail routes verified.");


### PR DESCRIPTION
## Summary

- Add Worker `GET /api/skills` with the Ktor-compatible public search, filters, pagination, sort orders, cards, and facets.
- Add Worker `GET /api/skills/{slug}` with public-only detail, storage aggregates, security notes, and the stable not-found envelope.
- Preserve required nullable OpenAPI fields, including `license`, `category`, and `readmeMd`.
- Split list `CARD_SELECT` from `DETAIL_SELECT` so search no longer left-joins `skill_files` or pulls `readme_md`/`security` that list cards never return.
- Add real local Worker/D1 coverage over the checked-in 121-skill catalogue, including filters, relevance search, invalid parameters, and not-found behavior.

This is the public skill-read slice of epic #52 / issue #53. It does not cut `androidskills.dev` off GitHub Pages and does not promote the Ktor/Astro stack.

## Kotlin behavior covered

- `PublicReadTest.search default verified-only excludes unverified`
- `PublicReadTest.search facets ignore their own dimension`
- `PublicReadTest.search by query matches name`
- `PublicReadTest.search size filter buckets by total tokens`
- `PublicReadTest.search sort by installs orders descending`
- `PublicReadTest.detail returns manifest fields and 404 for unknown`
- `PublicReadTest.detail exposes stored security notes`
- `PublicReadTest.unlisted skills are not publicly reachable`

## Validation

- `cargo fmt --check`
- `cargo test --locked --lib` (20 tests)
- `cargo check --locked --target wasm32-unknown-unknown`
- `cargo clippy --locked --all-targets -- -D warnings`
- Prettier and whitespace checks
- Local D1 catalogue fixture and live Worker search/detail smoke

## Review gates

Initial isolated Sol-high reviews found compatibility differences in mixed query-key precedence, required nullable fields, and validation message text. All were corrected; fresh isolated alignment and adversarial re-reviews are clean.

Bugbot flagged search reusing the detail `CARD_SELECT` (files join + unused README/security columns). That is fixed at the query root: list uses `CARD_SELECT`, detail uses `DETAIL_SELECT`.
