### PR TITLE
feat(worker): add remaining public read routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
           node tests/d1_repository_worker_test.mjs
           node tests/d1_public_read_worker_test.mjs
           node tests/d1_skill_read_worker_test.mjs
+          node tests/d1_public_read_remainder_worker_test.mjs
       - name: Build the Wasm Worker
         run: npx wrangler deploy --dry-run
       - name: Start the local Workers runtime

--- a/api-rs/src/error.rs
+++ b/api-rs/src/error.rs
@@ -73,6 +73,9 @@ impl ApiError {
     pub fn internal() -> Self {
         Self::new(500, "internal", "Internal server error")
     }
+    pub fn storage(message: impl Into<String>) -> Self {
+        Self::new(500, "storage_error", message)
+    }
     pub fn service_unavailable() -> Self {
         Self::new(
             503,
@@ -116,6 +119,7 @@ mod tests {
         assert_eq!(ApiError::unauthorized().status(), 401);
         assert_eq!(ApiError::forbidden().status(), 403);
         assert_eq!(ApiError::internal().status(), 500);
+        assert_eq!(ApiError::storage("File bytes missing").status(), 500);
         assert_eq!(ApiError::service_unavailable().status(), 503);
     }
 }

--- a/api-rs/src/lib.rs
+++ b/api-rs/src/lib.rs
@@ -11,6 +11,8 @@ use worker::{
     ScheduledEvent,
 };
 
+use crate::public_read::SkillPath;
+
 const PUBLIC_OPENAPI: &str = include_str!("../../api/src/main/resources/openapi.yaml");
 const ADMIN_OPENAPI: &str = include_str!("../../api/src/main/resources/openapi-admin.yaml");
 
@@ -67,7 +69,9 @@ pub async fn fetch(request: Request, env: Env, _ctx: Context) -> Result<Response
         });
     }
 
-    match request.path().as_str() {
+    let path = request.path();
+    let url = request.url()?;
+    match path.as_str() {
         "/api/health" => Response::from_json(&HealthResponse {
             ok: true,
             version: env!("CARGO_PKG_VERSION"),
@@ -89,23 +93,206 @@ pub async fn fetch(request: Request, env: Env, _ctx: Context) -> Result<Response
             Err(_) => error::ApiError::service_unavailable().response(),
         },
         "/api/skills" => match env.d1("DB") {
-            Ok(db) => match public_read::SearchParams::from_url(&request.url()?) {
+            Ok(db) => match public_read::SearchParams::from_url(&url) {
                 Ok(params) => Response::from_json(&public_read::search(&db, &params).await?),
                 Err(error) => error.response(),
             },
             Err(_) => error::ApiError::service_unavailable().response(),
         },
-        path if path.starts_with("/api/skills/") => match env.d1("DB") {
-            Ok(db) => match public_read::skill_detail(&db, path.trim_start_matches("/api/skills/"))
-                .await?
-            {
-                Some(skill) => Response::from_json(&skill),
-                None => error::ApiError::not_found().response(),
+        "/api/trends" => match env.d1("DB") {
+            Ok(db) => Response::from_json(&public_read::trends(&db).await?),
+            Err(_) => error::ApiError::service_unavailable().response(),
+        },
+        "/api/timeline" => match env.d1("DB") {
+            Ok(db) => match public_read::page_from_url(&url) {
+                Ok((page, page_size)) => {
+                    Response::from_json(&public_read::timeline(&db, page, page_size).await?)
+                }
+                Err(error) => error.response(),
+            },
+            Err(_) => error::ApiError::service_unavailable().response(),
+        },
+        "/api/bundles" => match env.d1("DB") {
+            Ok(db) => match public_read::page_from_url(&url) {
+                Ok((page, page_size)) => {
+                    Response::from_json(&public_read::bundles(&db, page, page_size).await?)
+                }
+                Err(error) => error.response(),
+            },
+            Err(_) => error::ApiError::service_unavailable().response(),
+        },
+        path if path.starts_with("/api/skills/") => match SkillPath::parse(path) {
+            Some(route) => skill_route(route, &url, &env).await,
+            None => Response::error("Not Found", 404),
+        },
+        path if path.starts_with("/api/bundles/") => match env.d1("DB") {
+            Ok(db) => match single_segment(path, "/api/bundles/") {
+                Some(id) => match public_read::bundle_detail(&db, id).await? {
+                    Some(bundle) => Response::from_json(&bundle),
+                    None => error::ApiError::not_found().response(),
+                },
+                None => Response::error("Not Found", 404),
+            },
+            Err(_) => error::ApiError::service_unavailable().response(),
+        },
+        path if path.starts_with("/api/authors/") => match env.d1("DB") {
+            Ok(db) => match single_segment(path, "/api/authors/") {
+                Some(handle) => match public_read::author(&db, handle).await? {
+                    Some(author) => Response::from_json(&author),
+                    None => error::ApiError::not_found().response(),
+                },
+                None => Response::error("Not Found", 404),
             },
             Err(_) => error::ApiError::service_unavailable().response(),
         },
         _ => Response::error("Not Found", 404),
     }
+}
+
+async fn skill_route(route: SkillPath<'_>, url: &worker::Url, env: &Env) -> Result<Response> {
+    let db = match env.d1("DB") {
+        Ok(db) => db,
+        Err(_) => return error::ApiError::service_unavailable().response(),
+    };
+    match route {
+        SkillPath::Detail(slug) => match public_read::skill_detail(&db, slug).await? {
+            Some(skill) => Response::from_json(&skill),
+            None => error::ApiError::not_found().response(),
+        },
+        SkillPath::Files(slug) => match public_read::file_tree(&db, slug).await? {
+            Some(tree) => Response::from_json(&tree),
+            None => error::ApiError::not_found().response(),
+        },
+        SkillPath::File { slug, path } => file_content_route(&db, env, url, slug, path).await,
+        SkillPath::Versions(slug) => match public_read::versions(&db, slug).await? {
+            Some(versions) => Response::from_json(&versions),
+            None => error::ApiError::not_found().response(),
+        },
+        SkillPath::Download(slug) => download_route(&db, env, url, slug).await,
+    }
+}
+
+async fn file_content_route(
+    db: &worker::D1Database,
+    env: &Env,
+    url: &worker::Url,
+    slug: &str,
+    path: &str,
+) -> Result<Response> {
+    let Some(meta) = public_read::file_content_meta(db, slug, path).await? else {
+        return error::ApiError::not_found().response();
+    };
+    let raw = public_read::is_raw_preview(url);
+    if meta.download_only {
+        return Response::from_json(&public_read::file_content_json(meta, None));
+    }
+    let Some(bucket) = files_bucket(env) else {
+        return error::ApiError::service_unavailable().response();
+    };
+    let missing = || {
+        error::ApiError::storage(format!(
+            "File bytes missing for '{}/{}' (key={})",
+            meta.slug, meta.path, meta.r2_key
+        ))
+    };
+    let Some(object) = bucket.get(&meta.r2_key).execute().await? else {
+        return missing().response();
+    };
+    let Some(body) = object.body() else {
+        return missing().response();
+    };
+    let bytes = body.bytes().await?;
+    if bytes.len() as i64 > public_read::PREVIEW_LIMIT {
+        return Response::from_json(&public_read::file_content_json(
+            public_read::FileContentMeta {
+                download_only: true,
+                ..meta
+            },
+            None,
+        ));
+    }
+    let content = match String::from_utf8(bytes) {
+        Ok(content) => content,
+        Err(_) => {
+            return error::ApiError::storage(format!(
+                "File bytes missing for '{}/{}' (key={})",
+                meta.slug, meta.path, meta.r2_key
+            ))
+            .response()
+        }
+    };
+    if raw {
+        let headers = content_type("text/plain; charset=utf-8");
+        headers
+            .set("X-Content-Type-Options", "nosniff")
+            .expect("valid nosniff header");
+        return Response::ok(content).map(|response| response.with_headers(headers));
+    }
+    Response::from_json(&public_read::file_content_json(meta, Some(content)))
+}
+
+async fn download_route(
+    db: &worker::D1Database,
+    env: &Env,
+    url: &worker::Url,
+    slug: &str,
+) -> Result<Response> {
+    let version = public_read::query_value(url, "version");
+    let Some(target) = public_read::download_target(
+        db,
+        slug,
+        version.as_deref().filter(|value| !value.is_empty()),
+    )
+    .await?
+    else {
+        return error::ApiError::not_found().response();
+    };
+    let Some(filename) = public_read::download_filename(&target.slug, &target.version) else {
+        return error::ApiError::internal().response();
+    };
+    let Some(bucket) = files_bucket(env) else {
+        return error::ApiError::service_unavailable().response();
+    };
+    let Some(key) = target.r2_zip_key.as_deref() else {
+        return missing_archive(&target).response();
+    };
+    let Some(object) = bucket.get(key).execute().await? else {
+        return missing_archive(&target).response();
+    };
+    let Some(body) = object.body() else {
+        return missing_archive(&target).response();
+    };
+    public_read::increment_installs(db, &target.skill_id).await?;
+    let headers = content_type("application/zip");
+    headers
+        .set(
+            "content-disposition",
+            &format!("attachment; filename=\"{filename}\""),
+        )
+        .expect("valid content disposition");
+    Ok(Response::from_body(body.response_body()?)?.with_headers(headers))
+}
+
+fn missing_archive(target: &public_read::DownloadTarget) -> error::ApiError {
+    if target.is_current {
+        error::ApiError::storage(format!(
+            "File bytes missing for '{}' version '{}' (key={})",
+            target.slug,
+            target.version,
+            target.r2_zip_key.as_deref().unwrap_or("none")
+        ))
+    } else {
+        error::ApiError::not_found()
+    }
+}
+
+fn files_bucket(env: &Env) -> Option<worker::Bucket> {
+    env.bucket("FILES").ok()
+}
+
+fn single_segment<'a>(path: &'a str, prefix: &str) -> Option<&'a str> {
+    path.strip_prefix(prefix)
+        .filter(|rest| !rest.is_empty() && !rest.contains('/'))
 }
 
 /// Queue plumbing is present from the first Worker build. The job ledger and consumer logic are

--- a/api-rs/src/public_read.rs
+++ b/api-rs/src/public_read.rs
@@ -8,7 +8,10 @@ use std::collections::{BTreeMap, HashMap};
 use serde::{Deserialize, Serialize};
 use worker::{wasm_bindgen::JsValue, D1Database, Error, Result};
 
-use crate::{domain::PageRequest, error::ApiError};
+use crate::{
+    domain::{PageError, PageRequest},
+    error::ApiError,
+};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -599,12 +602,846 @@ struct TokenRow {
     token_ondemand: i64,
 }
 
+pub(crate) const PREVIEW_LIMIT: i64 = 256 * 1024;
+const MAX_TAG_FACETS: usize = 20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillPath<'a> {
+    Detail(&'a str),
+    Files(&'a str),
+    File { slug: &'a str, path: &'a str },
+    Versions(&'a str),
+    Download(&'a str),
+}
+
+impl<'a> SkillPath<'a> {
+    pub fn parse(path: &'a str) -> Option<Self> {
+        let rest = path.strip_prefix("/api/skills/")?;
+        if rest.is_empty() {
+            return None;
+        }
+        let parsed = match rest.split_once('/') {
+            None => Self::Detail(rest),
+            Some((slug, "files")) => Self::Files(slug),
+            Some((slug, rest)) if rest.starts_with("files/") => Self::File {
+                slug,
+                path: &rest["files/".len()..],
+            },
+            Some((slug, "versions")) => Self::Versions(slug),
+            Some((slug, "download")) => Self::Download(slug),
+            _ => return None,
+        };
+        let slug = match parsed {
+            Self::Detail(slug)
+            | Self::Files(slug)
+            | Self::File { slug, .. }
+            | Self::Versions(slug)
+            | Self::Download(slug) => slug,
+        };
+        (!slug.is_empty()).then_some(parsed)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FileEntry {
+    pub path: String,
+    pub name: String,
+    pub dir: String,
+    pub size: i64,
+    pub is_binary: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TreeNode {
+    pub name: String,
+    pub path: String,
+    #[serde(rename = "type")]
+    pub node_type: String,
+    pub size: i64,
+    pub is_binary: bool,
+    pub children: Option<Vec<TreeNode>>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FileTreeResponse {
+    pub slug: String,
+    pub files: Vec<FileEntry>,
+    pub tree: Vec<TreeNode>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FileContentResponse {
+    pub slug: String,
+    pub path: String,
+    pub size: i64,
+    pub is_binary: bool,
+    pub content: Option<String>,
+    pub download_only: bool,
+    pub download_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VersionEntry {
+    pub version: String,
+    pub source_ref: String,
+    pub created_at: String,
+    pub current: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct VersionsResponse {
+    pub slug: String,
+    pub current: String,
+    pub versions: Vec<VersionEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrendsResponse {
+    pub categories: Vec<FacetCount>,
+    pub tags: Vec<FacetCount>,
+    pub token_mix: Vec<FacetCount>,
+    pub security_pass_rate: Option<f64>,
+    pub submission_funnel: BTreeMap<String, i64>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelineEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub at: String,
+    pub slug: String,
+    pub name: String,
+    pub version: Option<String>,
+    pub author_handle: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelinePage {
+    pub items: Vec<TimelineEvent>,
+    pub page: u32,
+    pub page_size: u32,
+    pub total: i64,
+    pub total_pages: i64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleSummary {
+    pub id: String,
+    pub kind: String,
+    pub provenance: String,
+    pub owner: AuthorRef,
+    pub source_ref: Option<String>,
+    pub skill_count: i64,
+    pub synced_at: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BundlePage {
+    pub items: Vec<BundleSummary>,
+    pub page: u32,
+    pub page_size: u32,
+    pub total: i64,
+    pub total_pages: i64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleDetail {
+    pub id: String,
+    pub kind: String,
+    pub provenance: String,
+    pub owner: AuthorRef,
+    pub source_ref: Option<String>,
+    pub synced_at: Option<String>,
+    pub created_at: String,
+    pub skills: Vec<SkillCard>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorProfile {
+    pub handle: String,
+    pub name: Option<String>,
+    pub avatar_url: Option<String>,
+    pub skill_count: i64,
+    pub total_installs: i64,
+    pub skills: Vec<SkillCard>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileContentMeta {
+    pub slug: String,
+    pub path: String,
+    pub size: i64,
+    pub is_binary: bool,
+    pub r2_key: String,
+    pub download_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DownloadTarget {
+    pub skill_id: String,
+    pub slug: String,
+    pub version: String,
+    pub r2_zip_key: Option<String>,
+    pub is_current: bool,
+}
+
+#[derive(Deserialize)]
+struct PublishedSkillRow {
+    id: String,
+    slug: String,
+    version: String,
+}
+
+#[derive(Deserialize)]
+struct FileMetaRow {
+    path: String,
+    size: i64,
+    is_binary: i64,
+    r2_key: String,
+}
+
+#[derive(Deserialize)]
+struct VersionRow {
+    version: String,
+    source_ref: String,
+    created_at: String,
+}
+
+#[derive(Deserialize)]
+struct DownloadVersionRow {
+    version: String,
+    r2_zip_key: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct FunnelRow {
+    state: String,
+    count: i64,
+}
+
+#[derive(Deserialize)]
+struct TimelineRow {
+    event_type: String,
+    at: String,
+    slug: String,
+    name: String,
+    version: Option<String>,
+    author_handle: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct BundleListRow {
+    id: String,
+    kind: String,
+    provenance: String,
+    source_ref: Option<String>,
+    synced_at: Option<String>,
+    created_at: String,
+    skill_count: i64,
+    author_handle: String,
+    author_name: Option<String>,
+    author_avatar_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct BundleHeadRow {
+    id: String,
+    kind: String,
+    provenance: String,
+    source_ref: Option<String>,
+    synced_at: Option<String>,
+    created_at: String,
+    author_handle: String,
+    author_name: Option<String>,
+    author_avatar_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AuthorHeadRow {
+    handle: String,
+    name: Option<String>,
+    avatar_url: Option<String>,
+}
+
+pub fn page_from_url(url: &worker::Url) -> std::result::Result<(u32, u32), ApiError> {
+    let pairs = url.query_pairs().into_owned().collect::<Vec<_>>();
+    let one = |key: &str| {
+        pairs
+            .iter()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value.as_str())
+    };
+    Ok((
+        parse_page_strict(one("page"))?,
+        parse_page_size_strict(one("pageSize"))?,
+    ))
+}
+
+pub fn query_value(url: &worker::Url, key: &str) -> Option<String> {
+    url.query_pairs()
+        .find(|(name, _)| name == key)
+        .map(|(_, value)| value.into_owned())
+}
+
+pub fn is_raw_preview(url: &worker::Url) -> bool {
+    query_value(url, "raw").as_deref() == Some("1")
+}
+
+fn parse_page_strict(raw: Option<&str>) -> std::result::Result<u32, ApiError> {
+    match raw {
+        None => Ok(1),
+        Some(value) => {
+            let parsed = value
+                .parse::<u32>()
+                .map_err(|_| page_error("page", "must be a positive integer", PageError::Page))?;
+            PageRequest {
+                page: parsed,
+                page_size: PageRequest::DEFAULT_PAGE_SIZE,
+            }
+            .validate()
+            .map_err(|error| match error {
+                PageError::Page if parsed == 0 => page_error("page", "must be >= 1", error),
+                PageError::Page => page_error(
+                    "page",
+                    &format!(
+                        "must be <= {} (deep pagination is not supported)",
+                        PageRequest::MAX_PAGE
+                    ),
+                    error,
+                ),
+                PageError::PageSize => page_error(
+                    "pageSize",
+                    &format!("must be 1..{}", PageRequest::MAX_PAGE_SIZE),
+                    error,
+                ),
+            })?;
+            Ok(parsed)
+        }
+    }
+}
+
+fn parse_page_size_strict(raw: Option<&str>) -> std::result::Result<u32, ApiError> {
+    match raw {
+        None => Ok(PageRequest::DEFAULT_PAGE_SIZE),
+        Some(value) => {
+            let parsed = value
+                .parse::<u32>()
+                .map_err(|_| page_error("pageSize", "must be an integer", PageError::PageSize))?;
+            PageRequest {
+                page: 1,
+                page_size: parsed,
+            }
+            .validate()
+            .map_err(|_| {
+                page_error(
+                    "pageSize",
+                    &format!("must be 1..{}", PageRequest::MAX_PAGE_SIZE),
+                    PageError::PageSize,
+                )
+            })?;
+            Ok(parsed)
+        }
+    }
+}
+
+fn page_error(field: &str, message: &str, _kind: PageError) -> ApiError {
+    ApiError::validation(
+        "validation_failed",
+        format!("Invalid '{field}'"),
+        BTreeMap::from([(field.into(), message.into())]),
+    )
+}
+
+fn total_pages(total: i64, page_size: u32) -> i64 {
+    if page_size == 0 {
+        0
+    } else {
+        (total + i64::from(page_size) - 1) / i64::from(page_size)
+    }
+}
+
+async fn published_skill(db: &D1Database, slug: &str) -> Result<Option<PublishedSkillRow>> {
+    db.prepare("SELECT id, slug, version FROM skills WHERE slug = ? AND status = 'published'")
+        .bind(&[JsValue::from_str(slug)])?
+        .first(None)
+        .await
+}
+
+pub async fn file_tree(db: &D1Database, slug: &str) -> Result<Option<FileTreeResponse>> {
+    let Some(skill) = published_skill(db, slug).await? else {
+        return Ok(None);
+    };
+    let rows: Vec<FileMetaRow> = db
+        .prepare(
+            "SELECT path, size, is_binary, r2_key FROM skill_files WHERE skill_id = ? ORDER BY path",
+        )
+        .bind(&[JsValue::from_str(&skill.id)])?
+        .all()
+        .await?
+        .results()?;
+    let files = rows
+        .into_iter()
+        .map(|row| {
+            let (dir, name) = row
+                .path
+                .rsplit_once('/')
+                .map(|(dir, name)| (dir.to_owned(), name.to_owned()))
+                .unwrap_or_else(|| (String::new(), row.path.clone()));
+            FileEntry {
+                path: row.path,
+                name,
+                dir,
+                size: row.size,
+                is_binary: row.is_binary == 1,
+            }
+        })
+        .collect::<Vec<_>>();
+    let tree = build_tree(&files);
+    Ok(Some(FileTreeResponse {
+        slug: skill.slug,
+        files,
+        tree,
+    }))
+}
+
+pub async fn file_content_meta(
+    db: &D1Database,
+    slug: &str,
+    path: &str,
+) -> Result<Option<FileContentMeta>> {
+    let Some(skill) = published_skill(db, slug).await? else {
+        return Ok(None);
+    };
+    let row: Option<FileMetaRow> = db
+        .prepare(
+            "SELECT path, size, is_binary, r2_key FROM skill_files WHERE skill_id = ? AND path = ?",
+        )
+        .bind(&[JsValue::from_str(&skill.id), JsValue::from_str(path)])?
+        .first(None)
+        .await?;
+    Ok(row.map(|row| {
+        let is_binary = row.is_binary == 1;
+        FileContentMeta {
+            slug: skill.slug,
+            path: row.path,
+            size: row.size,
+            is_binary,
+            r2_key: row.r2_key,
+            download_only: is_binary || row.size > PREVIEW_LIMIT,
+        }
+    }))
+}
+
+pub fn file_content_json(meta: FileContentMeta, content: Option<String>) -> FileContentResponse {
+    FileContentResponse {
+        slug: meta.slug,
+        path: meta.path,
+        size: meta.size,
+        is_binary: meta.is_binary,
+        content,
+        download_only: meta.download_only,
+        download_url: None,
+    }
+}
+
+pub async fn versions(db: &D1Database, slug: &str) -> Result<Option<VersionsResponse>> {
+    let Some(skill) = published_skill(db, slug).await? else {
+        return Ok(None);
+    };
+    let rows: Vec<VersionRow> = db
+        .prepare(
+            "SELECT version, source_ref, created_at FROM versions WHERE skill_id = ? ORDER BY created_at DESC",
+        )
+        .bind(&[JsValue::from_str(&skill.id)])?
+        .all()
+        .await?
+        .results()?;
+    Ok(Some(VersionsResponse {
+        slug: skill.slug,
+        current: skill.version.clone(),
+        versions: rows
+            .into_iter()
+            .map(|row| VersionEntry {
+                current: row.version == skill.version,
+                version: row.version,
+                source_ref: row.source_ref,
+                created_at: row.created_at,
+            })
+            .collect(),
+    }))
+}
+
+pub async fn download_target(
+    db: &D1Database,
+    slug: &str,
+    version: Option<&str>,
+) -> Result<Option<DownloadTarget>> {
+    let Some(skill) = published_skill(db, slug).await? else {
+        return Ok(None);
+    };
+    let requested = version.unwrap_or(&skill.version);
+    let row: Option<DownloadVersionRow> = db
+        .prepare("SELECT version, r2_zip_key FROM versions WHERE skill_id = ? AND version = ?")
+        .bind(&[JsValue::from_str(&skill.id), JsValue::from_str(requested)])?
+        .first(None)
+        .await?;
+    Ok(row.map(|row| DownloadTarget {
+        skill_id: skill.id,
+        slug: skill.slug,
+        is_current: row.version == skill.version,
+        version: row.version,
+        r2_zip_key: row.r2_zip_key,
+    }))
+}
+
+pub fn download_filename(slug: &str, version: &str) -> Option<String> {
+    let filename = format!("{slug}-{version}.zip");
+    filename
+        .bytes()
+        .all(|byte| byte >= 0x20 && byte != b'"' && byte != b'\\')
+        .then_some(filename)
+}
+
+pub async fn increment_installs(db: &D1Database, skill_id: &str) -> Result<()> {
+    db.prepare("UPDATE skills SET installs = installs + 1 WHERE id = ?")
+        .bind(&[JsValue::from_str(skill_id)])?
+        .run()
+        .await?;
+    Ok(())
+}
+
+pub async fn trends(db: &D1Database) -> Result<TrendsResponse> {
+    let category_rows: Vec<FacetRow> = db
+        .prepare(
+            "SELECT COALESCE(c.slug, 'uncategorized') AS key, COALESCE(c.name, 'Uncategorized') AS label, COUNT(*) AS count \
+             FROM skills s LEFT JOIN categories c ON c.id = s.category_id \
+             WHERE s.status = 'published' GROUP BY s.category_id ORDER BY count DESC, key ASC",
+        )
+        .all()
+        .await?
+        .results()?;
+    let tag_rows: Vec<TagRow> = db
+        .prepare("SELECT tags FROM skills WHERE status = 'published'")
+        .all()
+        .await?
+        .results()?;
+    let mut tag_counts = HashMap::<String, i64>::new();
+    for row in tag_rows {
+        for tag in serde_json::from_str::<Vec<String>>(&row.tags).unwrap_or_default() {
+            *tag_counts.entry(tag).or_default() += 1;
+        }
+    }
+    let mut tags = tag_counts
+        .into_iter()
+        .map(|(key, count)| FacetCount {
+            key,
+            label: None,
+            count,
+        })
+        .collect::<Vec<_>>();
+    tags.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.key.cmp(&right.key))
+    });
+    tags.truncate(MAX_TAG_FACETS);
+    let band_rows: Vec<FacetRow> = db
+        .prepare(
+            "SELECT token_band AS key, token_band AS label, COUNT(*) AS count \
+             FROM skills WHERE status = 'published' GROUP BY token_band",
+        )
+        .all()
+        .await?
+        .results()?;
+    let band_counts = band_rows
+        .into_iter()
+        .map(|row| (row.key, row.count))
+        .collect::<HashMap<_, _>>();
+    let funnel_rows: Vec<FunnelRow> = db
+        .prepare("SELECT state, COUNT(*) AS count FROM submissions GROUP BY state")
+        .all()
+        .await?
+        .results()?;
+    Ok(TrendsResponse {
+        categories: category_rows
+            .into_iter()
+            .map(|row| FacetCount {
+                key: row.key,
+                label: Some(row.label),
+                count: row.count,
+            })
+            .collect(),
+        tags,
+        token_mix: ["100s", "1k", "10k", "100k"]
+            .into_iter()
+            .map(|key| FacetCount {
+                key: key.into(),
+                label: None,
+                count: band_counts.get(key).copied().unwrap_or(0),
+            })
+            .collect(),
+        security_pass_rate: None,
+        submission_funnel: funnel_rows
+            .into_iter()
+            .map(|row| (row.state, row.count))
+            .collect(),
+    })
+}
+
+pub async fn timeline(db: &D1Database, page: u32, page_size: u32) -> Result<TimelinePage> {
+    let total: Option<CountRow> = db
+        .prepare(
+            "SELECT (SELECT COUNT(*) FROM skills WHERE status = 'published') \
+                    + (SELECT COUNT(*) FROM versions v INNER JOIN skills s ON s.id = v.skill_id WHERE s.status = 'published') \
+                    AS count",
+        )
+        .first(None)
+        .await?;
+    let total = total.map_or(0, |row| row.count);
+    let rows: Vec<TimelineRow> = db
+        .prepare(
+            "SELECT event_type, at, slug, name, version, author_handle FROM ( \
+                SELECT 'publish' AS event_type, s.created_at AS at, s.slug, s.name, s.version, u.handle AS author_handle \
+                FROM skills s INNER JOIN bundles b ON b.id = s.bundle_id INNER JOIN users u ON u.id = b.owner_user_id \
+                WHERE s.status = 'published' \
+                UNION ALL \
+                SELECT 'version' AS event_type, v.created_at AS at, s.slug, s.name, v.version, u.handle AS author_handle \
+                FROM versions v INNER JOIN skills s ON s.id = v.skill_id \
+                INNER JOIN bundles b ON b.id = s.bundle_id INNER JOIN users u ON u.id = b.owner_user_id \
+                WHERE s.status = 'published' \
+             ) AS events ORDER BY at DESC, event_type ASC, slug ASC LIMIT ? OFFSET ?",
+        )
+        .bind(&[
+            JsValue::from_f64(page_size.into()),
+            JsValue::from_f64(((page - 1) * page_size).into()),
+        ])?
+        .all()
+        .await?
+        .results()?;
+    Ok(TimelinePage {
+        items: rows
+            .into_iter()
+            .map(|row| TimelineEvent {
+                event_type: row.event_type,
+                at: row.at,
+                slug: row.slug,
+                name: row.name,
+                version: row.version,
+                author_handle: row.author_handle,
+            })
+            .collect(),
+        page,
+        page_size,
+        total,
+        total_pages: total_pages(total, page_size),
+    })
+}
+
+pub async fn bundles(db: &D1Database, page: u32, page_size: u32) -> Result<BundlePage> {
+    let total: Option<CountRow> = db
+        .prepare("SELECT COUNT(DISTINCT bundle_id) AS count FROM skills WHERE status = 'published'")
+        .first(None)
+        .await?;
+    let total = total.map_or(0, |row| row.count);
+    let rows: Vec<BundleListRow> = db
+        .prepare(
+            "SELECT b.id, b.kind, b.provenance, b.source_ref, b.synced_at, b.created_at, COUNT(s.id) AS skill_count, \
+                    u.handle AS author_handle, u.name AS author_name, u.avatar_url AS author_avatar_url \
+             FROM bundles b INNER JOIN users u ON u.id = b.owner_user_id \
+             INNER JOIN skills s ON s.bundle_id = b.id AND s.status = 'published' \
+             GROUP BY b.id ORDER BY b.created_at DESC, b.id DESC LIMIT ? OFFSET ?",
+        )
+        .bind(&[
+            JsValue::from_f64(page_size.into()),
+            JsValue::from_f64(((page - 1) * page_size).into()),
+        ])?
+        .all()
+        .await?
+        .results()?;
+    Ok(BundlePage {
+        items: rows
+            .into_iter()
+            .map(|row| BundleSummary {
+                id: row.id,
+                kind: row.kind,
+                provenance: row.provenance,
+                owner: AuthorRef {
+                    handle: row.author_handle,
+                    name: row.author_name,
+                    avatar_url: row.author_avatar_url,
+                },
+                source_ref: row.source_ref,
+                skill_count: row.skill_count,
+                synced_at: row.synced_at,
+                created_at: row.created_at,
+            })
+            .collect(),
+        page,
+        page_size,
+        total,
+        total_pages: total_pages(total, page_size),
+    })
+}
+
+pub async fn bundle_detail(db: &D1Database, id: &str) -> Result<Option<BundleDetail>> {
+    let head: Option<BundleHeadRow> = db
+        .prepare(
+            "SELECT b.id, b.kind, b.provenance, b.source_ref, b.synced_at, b.created_at, \
+                    u.handle AS author_handle, u.name AS author_name, u.avatar_url AS author_avatar_url \
+             FROM bundles b INNER JOIN users u ON u.id = b.owner_user_id WHERE b.id = ?",
+        )
+        .bind(&[JsValue::from_str(id)])?
+        .first(None)
+        .await?;
+    let Some(head) = head else {
+        return Ok(None);
+    };
+    let rows: Vec<CardRow> = db
+        .prepare(format!(
+            "{CARD_SELECT} WHERE s.bundle_id = ? AND s.status = 'published' ORDER BY s.updated_at DESC"
+        ))
+        .bind(&[JsValue::from_str(id)])?
+        .all()
+        .await?
+        .results()?;
+    if rows.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(BundleDetail {
+        id: head.id,
+        kind: head.kind,
+        provenance: head.provenance,
+        owner: AuthorRef {
+            handle: head.author_handle,
+            name: head.author_name,
+            avatar_url: head.author_avatar_url,
+        },
+        source_ref: head.source_ref,
+        synced_at: head.synced_at,
+        created_at: head.created_at,
+        skills: rows.into_iter().map(card).collect(),
+    }))
+}
+
+pub async fn author(db: &D1Database, handle: &str) -> Result<Option<AuthorProfile>> {
+    let head: Option<AuthorHeadRow> = db
+        .prepare("SELECT handle, name, avatar_url FROM users WHERE handle = ?")
+        .bind(&[JsValue::from_str(handle)])?
+        .first(None)
+        .await?;
+    let Some(head) = head else {
+        return Ok(None);
+    };
+    let rows: Vec<CardRow> = db
+        .prepare(format!(
+            "{CARD_SELECT} WHERE u.handle = ? AND s.status = 'published' ORDER BY s.installs DESC"
+        ))
+        .bind(&[JsValue::from_str(handle)])?
+        .all()
+        .await?
+        .results()?;
+    if rows.is_empty() {
+        return Ok(None);
+    }
+    let total_installs = rows.iter().map(|row| row.installs).sum();
+    Ok(Some(AuthorProfile {
+        handle: head.handle,
+        name: head.name,
+        avatar_url: head.avatar_url,
+        skill_count: rows.len() as i64,
+        total_installs,
+        skills: rows.into_iter().map(card).collect(),
+    }))
+}
+
+fn build_tree(files: &[FileEntry]) -> Vec<TreeNode> {
+    #[derive(Default)]
+    struct MutableNode {
+        name: String,
+        path: String,
+        node_type: String,
+        size: i64,
+        is_binary: bool,
+        kids: Vec<MutableNode>,
+    }
+    fn insert(node: &mut MutableNode, parts: &[&str], file: &FileEntry) {
+        let Some((part, rest)) = parts.split_first() else {
+            return;
+        };
+        let is_leaf = rest.is_empty();
+        let full_path = if node.path.is_empty() {
+            (*part).to_owned()
+        } else {
+            format!("{}/{}", node.path, part)
+        };
+        if let Some(index) = node.kids.iter().position(|kid| kid.name == *part) {
+            if is_leaf {
+                node.kids[index].size = file.size;
+                node.kids[index].is_binary = file.is_binary;
+            } else {
+                insert(&mut node.kids[index], rest, file);
+            }
+            return;
+        }
+        let mut child = MutableNode {
+            name: (*part).to_owned(),
+            path: full_path,
+            node_type: if is_leaf { "file" } else { "dir" }.into(),
+            size: if is_leaf { file.size } else { 0 },
+            is_binary: is_leaf && file.is_binary,
+            kids: Vec::new(),
+        };
+        if !is_leaf {
+            insert(&mut child, rest, file);
+        }
+        node.kids.push(child);
+    }
+    let mut root = MutableNode {
+        node_type: "dir".into(),
+        ..MutableNode::default()
+    };
+    for file in files {
+        let parts = file.path.split('/').collect::<Vec<_>>();
+        insert(&mut root, &parts, file);
+    }
+    fn freeze(node: MutableNode) -> TreeNode {
+        TreeNode {
+            name: node.name,
+            path: node.path,
+            node_type: node.node_type,
+            size: node.size,
+            is_binary: node.is_binary,
+            children: if node.kids.is_empty() {
+                None
+            } else {
+                Some(node.kids.into_iter().map(freeze).collect())
+            },
+        }
+    }
+    root.kids.into_iter().map(freeze).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        AuthorRef, BundleRef, CategoryWithCount, SearchParams, SkillCard, SkillDetail,
-        StatsResponse,
+        build_tree, download_filename, page_from_url, AuthorRef, BundleRef, CategoryWithCount,
+        FileContentResponse, FileEntry, SearchParams, SkillCard, SkillDetail, SkillPath,
+        StatsResponse, TreeNode, TrendsResponse,
     };
+    use std::collections::BTreeMap;
 
     #[test]
     fn public_payloads_keep_the_openapi_camel_case_shape() {
@@ -713,5 +1550,145 @@ mod tests {
                 && DETAIL_SELECT.contains("skill_files")
                 && DETAIL_SELECT.contains("file_count")
         );
+    }
+
+    #[test]
+    fn skill_subroutes_do_not_collapse_into_detail_slugs() {
+        assert_eq!(
+            SkillPath::parse("/api/skills/jetpack-compose-mvi"),
+            Some(SkillPath::Detail("jetpack-compose-mvi"))
+        );
+        assert_eq!(
+            SkillPath::parse("/api/skills/jetpack-compose-mvi/files"),
+            Some(SkillPath::Files("jetpack-compose-mvi"))
+        );
+        assert_eq!(
+            SkillPath::parse("/api/skills/jetpack-compose-mvi/files/references/intent.md"),
+            Some(SkillPath::File {
+                slug: "jetpack-compose-mvi",
+                path: "references/intent.md",
+            })
+        );
+        assert_eq!(
+            SkillPath::parse("/api/skills/jetpack-compose-mvi/versions"),
+            Some(SkillPath::Versions("jetpack-compose-mvi"))
+        );
+        assert_eq!(
+            SkillPath::parse("/api/skills/jetpack-compose-mvi/download"),
+            Some(SkillPath::Download("jetpack-compose-mvi"))
+        );
+        assert_eq!(
+            SkillPath::parse("/api/skills/jetpack-compose-mvi/report"),
+            None
+        );
+        assert_eq!(SkillPath::parse("/api/skills/"), None);
+        assert_eq!(SkillPath::parse("/api/skills"), None);
+    }
+
+    #[test]
+    fn page_parser_matches_ktor_strict_messages() {
+        let ok = page_from_url(
+            &worker::Url::parse("https://example.test/api/timeline?page=2&pageSize=20").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(ok, (2, 20));
+        assert_eq!(
+            page_from_url(&worker::Url::parse("https://example.test/api/timeline").unwrap())
+                .unwrap(),
+            (1, 24)
+        );
+        assert!(page_from_url(
+            &worker::Url::parse("https://example.test/api/timeline?page=0").unwrap()
+        )
+        .is_err());
+        assert!(page_from_url(
+            &worker::Url::parse("https://example.test/api/timeline?page=10001").unwrap()
+        )
+        .is_err());
+        assert!(page_from_url(
+            &worker::Url::parse("https://example.test/api/timeline?pageSize=abc").unwrap()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn file_tree_preserves_nested_paths_and_required_null_children() {
+        let tree = build_tree(&[
+            FileEntry {
+                path: "references/intent.md".into(),
+                name: "intent.md".into(),
+                dir: "references".into(),
+                size: 12,
+                is_binary: false,
+            },
+            FileEntry {
+                path: "SKILL.md".into(),
+                name: "SKILL.md".into(),
+                dir: String::new(),
+                size: 4,
+                is_binary: false,
+            },
+        ]);
+        assert_eq!(tree[0].path, "references");
+        assert_eq!(tree[0].node_type, "dir");
+        assert_eq!(
+            tree[0].children.as_ref().unwrap()[0].path,
+            "references/intent.md"
+        );
+        assert!(tree[1].children.is_none());
+        let encoded = serde_json::to_value(&tree[1]).unwrap();
+        assert!(encoded.get("children").unwrap().is_null());
+        assert_eq!(encoded["isBinary"], false);
+    }
+
+    #[test]
+    fn file_content_and_trends_keep_required_nullable_fields() {
+        let encoded = serde_json::to_value(FileContentResponse {
+            slug: "slug".into(),
+            path: "SKILL.md".into(),
+            size: 1,
+            is_binary: false,
+            content: None,
+            download_only: true,
+            download_url: None,
+        })
+        .unwrap();
+        assert!(encoded.get("content").unwrap().is_null());
+        assert!(encoded.get("downloadUrl").unwrap().is_null());
+        let trends = serde_json::to_value(TrendsResponse {
+            categories: vec![],
+            tags: vec![],
+            token_mix: vec![],
+            security_pass_rate: None,
+            submission_funnel: BTreeMap::new(),
+        })
+        .unwrap();
+        assert!(trends.get("securityPassRate").unwrap().is_null());
+        assert_eq!(trends["submissionFunnel"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn download_filenames_reject_header_injection() {
+        assert_eq!(
+            download_filename("jetpack-compose-mvi", "1.4.2").as_deref(),
+            Some("jetpack-compose-mvi-1.4.2.zip")
+        );
+        assert!(download_filename("bad\r\nslug", "1.0.0").is_none());
+        assert!(download_filename("slug", "1\".zip").is_none());
+    }
+
+    #[test]
+    fn tree_node_type_is_not_a_rust_keyword_field() {
+        let encoded = serde_json::to_value(TreeNode {
+            name: "SKILL.md".into(),
+            path: "SKILL.md".into(),
+            node_type: "file".into(),
+            size: 1,
+            is_binary: false,
+            children: None,
+        })
+        .unwrap();
+        assert_eq!(encoded["type"], "file");
+        assert!(encoded.get("node_type").is_none());
     }
 }

--- a/api-rs/tests/d1_public_read_remainder_worker_test.mjs
+++ b/api-rs/tests/d1_public_read_remainder_worker_test.mjs
@@ -1,0 +1,150 @@
+/** Remaining public-read routes against the real local Worker and catalogue D1 fixture. */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const base = process.env.CONTRACT_BASE_URL ?? "http://127.0.0.1:8788";
+const root = resolve(import.meta.dirname, "../..");
+const catalogue = JSON.parse(
+  readFileSync(
+    resolve(root, "api/src/main/resources/seed/real-skills.json"),
+    "utf8",
+  ),
+);
+const wrangler = resolve(
+  import.meta.dirname,
+  "../node_modules/wrangler/bin/wrangler.js",
+);
+const mutateD1 = (command) =>
+  execFileSync(
+    process.execPath,
+    [
+      wrangler,
+      "d1",
+      "execute",
+      "androidskills",
+      "--local",
+      "--config",
+      "wrangler.d1.local.toml",
+      "--command",
+      command,
+    ],
+    { cwd: resolve(import.meta.dirname, ".."), stdio: "pipe" },
+  );
+
+const json = async (path, status = 200) => {
+  const response = await fetch(`${base}${path}`);
+  assert.equal(response.status, status, `${path} -> ${response.status}`);
+  assert.match(response.headers.get("content-type") ?? "", /application\/json/);
+  return response.json();
+};
+
+const known = catalogue.skills[0];
+const skill = await json(`/api/skills/${known.slug}`);
+const authorHandle = skill.author.handle;
+const knownBundleId = skill.bundle.id;
+
+const tree = await json(`/api/skills/${known.slug}/files`);
+assert.equal(tree.slug, known.slug);
+assert.ok(tree.files.some((file) => file.path === "SKILL.md" && file.isBinary === false));
+assert.ok(tree.tree.some((node) => node.path === "SKILL.md" && node.type === "file" && node.children === null));
+
+const versions = await json(`/api/skills/${known.slug}/versions`);
+assert.equal(versions.slug, known.slug);
+assert.equal(versions.current, known.version);
+assert.ok(versions.versions.some((entry) => entry.version === known.version && entry.current));
+
+const trends = await json("/api/trends");
+assert.equal(trends.tokenMix.length, 4);
+assert.equal(
+  trends.tokenMix.reduce((sum, band) => sum + band.count, 0),
+  catalogue.skills.length,
+);
+assert.equal(trends.securityPassRate, null);
+assert.deepEqual(trends.submissionFunnel, {});
+assert.ok(trends.categories.every((facet) => facet.count > 0));
+
+const timeline = await json("/api/timeline?page=1&pageSize=20");
+assert.equal(timeline.page, 1);
+assert.equal(timeline.pageSize, 20);
+assert.equal(timeline.total, catalogue.skills.length * 2);
+assert.equal(timeline.items.length, 20);
+assert.ok(timeline.items.some((item) => item.type === "publish"));
+assert.ok(timeline.items.every((item) => item.slug && item.at && item.name));
+
+const invalidPage = await json("/api/timeline?page=0", 422);
+assert.equal(invalidPage.error.code, "validation_failed");
+
+const bundles = await json("/api/bundles?page=1&pageSize=60");
+assert.equal(bundles.total, catalogue.bundles.length);
+assert.ok(bundles.items.every((bundle) => bundle.skillCount >= 1 && bundle.owner.handle));
+const firstBundle = bundles.items[0];
+const bundle = await json(`/api/bundles/${firstBundle.id}`);
+assert.equal(bundle.id, firstBundle.id);
+assert.ok(bundle.skills.length >= 1);
+assert.ok(bundle.skills.every((skill) => skill.status === "published"));
+
+const profile = await json(`/api/authors/${authorHandle}`);
+assert.equal(profile.handle, authorHandle);
+assert.ok(profile.skillCount >= 1);
+assert.ok(profile.skills.every((card) => card.author.handle === authorHandle));
+
+assert.equal((await json("/api/skills/does-not-exist/files", 404)).error.code, "not_found");
+assert.equal((await json("/api/skills/does-not-exist/versions", 404)).error.code, "not_found");
+assert.equal((await json(`/api/skills/${known.slug}/files/missing.md`, 404)).error.code, "not_found");
+assert.equal((await json("/api/bundles/nope", 404)).error.code, "not_found");
+assert.equal((await json("/api/authors/nobody", 404)).error.code, "not_found");
+assert.equal((await json(`/api/skills/${known.slug}/download?version=not-a-version`, 404)).error.code, "not_found");
+const missingBundleZip = await fetch(`${base}/api/bundles/${firstBundle.id}/download`);
+assert.equal(missingBundleZip.status, 404);
+
+const preview = await fetch(`${base}/api/skills/${known.slug}/files/SKILL.md`);
+assert.equal(preview.status, 503);
+assert.equal((await preview.json()).error.code, "service_unavailable");
+const download = await fetch(`${base}/api/skills/${known.slug}/download`);
+assert.equal(download.status, 503);
+assert.equal((await download.json()).error.code, "service_unavailable");
+
+mutateD1(
+  "INSERT INTO skill_files (id, skill_id, path, size, is_binary, r2_key) VALUES ('fixture-bin-test', 'fixture-skill-0', 'scripts/tool.bin', 12, 1, 'skills/fixture-skill-0/files/scripts/tool.bin')",
+);
+try {
+  const binary = await json(`/api/skills/${known.slug}/files/scripts/tool.bin`);
+  assert.equal(binary.downloadOnly, true);
+  assert.equal(binary.content, null);
+  assert.equal(binary.downloadUrl, null);
+  assert.equal(binary.isBinary, true);
+  const updatedTree = await json(`/api/skills/${known.slug}/files`);
+  assert.ok(updatedTree.files.some((file) => file.path === "scripts/tool.bin" && file.isBinary));
+} finally {
+  mutateD1("DELETE FROM skill_files WHERE id = 'fixture-bin-test'");
+}
+
+mutateD1("UPDATE skills SET status = 'unlisted' WHERE id = 'fixture-skill-0'");
+try {
+  assert.equal((await json(`/api/skills/${known.slug}`, 404)).error.code, "not_found");
+  assert.equal((await json(`/api/skills/${known.slug}/files`, 404)).error.code, "not_found");
+  assert.equal((await json(`/api/skills/${known.slug}/versions`, 404)).error.code, "not_found");
+  assert.equal((await json(`/api/skills/${known.slug}/files/SKILL.md`, 404)).error.code, "not_found");
+  assert.equal((await json(`/api/skills/${known.slug}/download`, 404)).error.code, "not_found");
+  const hiddenTrends = await json("/api/trends");
+  assert.equal(
+    hiddenTrends.tokenMix.reduce((sum, band) => sum + band.count, 0),
+    catalogue.skills.length - 1,
+  );
+  const hiddenTimeline = await json("/api/timeline?pageSize=60");
+  assert.equal(hiddenTimeline.total, catalogue.skills.length * 2 - 2);
+  const hiddenBundles = await json("/api/bundles?pageSize=60");
+  const ownerBundle = hiddenBundles.items.find((item) => item.id === knownBundleId);
+  if (ownerBundle) {
+    const detail = await json(`/api/bundles/${ownerBundle.id}`);
+    assert.ok(detail.skills.every((card) => card.slug !== known.slug));
+  } else {
+    assert.equal((await json(`/api/bundles/${knownBundleId}`, 404)).error.code, "not_found");
+  }
+} finally {
+  mutateD1("UPDATE skills SET status = 'published' WHERE id = 'fixture-skill-0'");
+}
+
+console.log("D1 Worker remaining public-read routes verified.");

--- a/api-rs/tests/unconfigured_public_read_worker_test.mjs
+++ b/api-rs/tests/unconfigured_public_read_worker_test.mjs
@@ -3,7 +3,19 @@ import assert from "node:assert/strict";
 
 const base = process.env.CONTRACT_BASE_URL ?? "http://127.0.0.1:8787";
 
-for (const path of ["/api/stats", "/api/categories"]) {
+for (const path of [
+  "/api/stats",
+  "/api/categories",
+  "/api/skills",
+  "/api/skills/example/files",
+  "/api/skills/example/versions",
+  "/api/skills/example/download",
+  "/api/trends",
+  "/api/timeline",
+  "/api/bundles",
+  "/api/bundles/example",
+  "/api/authors/example",
+]) {
   const response = await fetch(`${base}${path}`);
   assert.equal(response.status, 503, path);
   assert.match(response.headers.get("content-type") ?? "", /application\/json/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues epic #52 / issue #53 after PR #74. This slice ports the rest of the **unauthenticated public GET** surface that Astro already calls and that #74 left as 404.

- `GET /api/skills/{slug}/files` — file tree + nested `tree` (D1 only)
- `GET /api/skills/{slug}/files/{path}` — JSON content or `raw=1` `text/plain; nosniff` preview
- `GET /api/skills/{slug}/versions`
- `GET /api/skills/{slug}/download` — current version (not newest `created_at`); streams the stored R2 zip when `FILES` is bound
- `GET /api/trends`, `/api/timeline`, `/api/bundles`, `/api/bundles/{id}`, `/api/authors/{handle}`

**Not in this slice (intentionally):**
- `POST /api/skills/{slug}/report` — public but not a GET
- `/api/bundles/{id}/download` — Astro links it; Ktor/OpenAPI do not serve it
- OAuth, GitHub App, ingest, admin, Astro-as-Worker
- Fallback zip-from-`skill_files` when the current archive object is missing (Ktor unit-test path; no shared contract fixture requires it)

## Security / visibility

- Every skill-scoped route resolves a **published** row first. Unlisted/flagged skills 404 on files, content, versions, and download — same as detail.
- Bundles with zero published skills 404; bundle detail omits unpublished skills.
- Authors with zero published skills 404.
- Trends/timeline aggregates are published-only. The submission funnel matches Ktor (all submission rows).
- Raw file preview is always `text/plain` + `X-Content-Type-Options: nosniff`.
- Download filenames reject CR/LF/quote injection.
- `FILES` unbound + bytes required → **503** (not a fake 404). Historical version with no archive object → **404**. Missing current archive object when R2 is bound → **500 `storage_error`**.
- Installs increment only after the R2 object body is in hand.

## Kotlin behavior covered

- `PublicReadTest.file tree and content work for a known file` (tree + unpublished isolation)
- `PublicReadTest.file content marks oversized as download-only` (binary/large metadata without R2)
- `PublicReadTest.versions list current flag`
- `PublicReadTest.historical version with missing archive is 404` (unknown version row)
- `PublicReadTest.default download selects skills version not newest created_at`
- `PublicReadTest.bundles list and detail` / `bundles only expose published skills`
- `PublicReadTest.author profile` / `author with no public skills is hidden`
- `PublicReadTest.timeline and trends return shaped data`
- `PublicReadTest.unlisted skills are not publicly reachable`
- `PublicReadTest.parsePageStrict rejects deep pagination`
- `PublicRoutesSecurityTest.rawHtmlPreviewIsServedAsTextPlainWithNoSniff` (header contract; bytes need R2)
- `PublicRoutesHttpTest.downloadStreamsZipWithAttachmentHeader` (headers + R2 stream when `FILES` is bound)

## Validation

- `cargo fmt --check`
- `cargo test --locked --lib` (26 tests)
- `cargo check --locked --target wasm32-unknown-unknown`
- `cargo clippy --locked --target wasm32-unknown-unknown -- -D warnings`
- Local D1 catalogue Worker: `d1_public_read_worker_test`, `d1_skill_read_worker_test`, `d1_public_read_remainder_worker_test`
- Unconfigured Worker (no D1/R2): shared contract fixtures + 503 on every new public-read path

Ktor/Astro staging stays private. Prod Pages coming-soon stays. This PR is not merged by this agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15fa054b-a58e-4653-b7fa-ee2018897510?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15fa054b-a58e-4653-b7fa-ee2018897510&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

